### PR TITLE
force one content provider per install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ dependencies {
 
 Simple example source code can be found in this demo module: [Android Simple Demo][2]
 
+You will need to add this to your Android application build.gradle:
+
+```groovy
+
+android { 
+  defaultConfig {
+       // other things
+       
+       manifestPlaceholders = [downloadAuthority: "${applicationId}"]
+  }
+}
+```
+
 
 ## Links
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -18,6 +18,8 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+
+        manifestPlaceholders = [downloadAuthority: "${applicationId}"]
     }
 
     lintOptions {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,9 +24,12 @@ android {
 
         def projects = rootProject.getProject().getChildProjects()
         projects.each {
-            def authority = it.value.android.defaultConfig.manifestPlaceholders.downloadAuthority
-            if (authority) {
-                buildConfigField "String", "DOWNLOAD_AUTHORITY", "\"${authority}\""
+            def project = it.value
+            if (project.hasProperty('android')) {
+                def authority = project.android.defaultConfig.manifestPlaceholders.downloadAuthority
+                if (authority) {
+                    buildConfigField "String", "DOWNLOAD_AUTHORITY", "\"${authority}\""
+                }
             }
         }
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -21,6 +21,14 @@ android {
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion 22
+
+        def projects = rootProject.getProject().getChildProjects();
+        projects.each {
+            def authority = it.value.android.defaultConfig.manifestPlaceholders.downloadAuthority
+            if(authority) {
+                buildConfigField "String", "DOWNLOAD_AUTHORITY", "\"${authority}\""
+            }
+        }
     }
 
     lintOptions {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -25,7 +25,7 @@ android {
         def projects = rootProject.getProject().getChildProjects();
         projects.each {
             def authority = it.value.android.defaultConfig.manifestPlaceholders.downloadAuthority
-            if(authority) {
+            if (authority) {
                 buildConfigField "String", "DOWNLOAD_AUTHORITY", "\"${authority}\""
             }
         }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,7 +22,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 22
 
-        def projects = rootProject.getProject().getChildProjects();
+        def projects = rootProject.getProject().getChildProjects()
         projects.each {
             def authority = it.value.android.defaultConfig.manifestPlaceholders.downloadAuthority
             if (authority) {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
     <provider
       android:name="com.novoda.downloadmanager.lib.DownloadProvider"
-      android:authorities="downloadsSCUBA"
+      android:authorities="${downloadAuthority}"
       android:exported="false" />
 
     <activity android:name="com.novoda.downloadmanager.lib.SizeLimitActivity" />

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -59,7 +59,7 @@ import java.util.Map;
 public final class DownloadProvider extends ContentProvider {
 
     /**
-     * Added so we can use our own ContentProvider - Matches: Downloads.java
+     * Added so we can use our own ContentProvider
      */
     static final String AUTHORITY = BuildConfig.DOWNLOAD_AUTHORITY;
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -37,6 +37,7 @@ import android.os.Process;
 import android.provider.OpenableColumns;
 import android.text.TextUtils;
 
+import com.novoda.downloadmanager.BuildConfig;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.File;
@@ -60,7 +61,7 @@ public final class DownloadProvider extends ContentProvider {
     /**
      * Added so we can use our own ContentProvider - Matches: Downloads.java
      */
-    public static final String AUTHORITY = "downloadsSCUBA";
+    static final String AUTHORITY = BuildConfig.DOWNLOAD_AUTHORITY;
     /**
      * Database filename
      */

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -75,7 +75,7 @@ public final class DownloadProvider extends ContentProvider {
     /**
      * Name of table in the database
      */
-    private static final String DB_TABLE = AUTHORITY;
+    private static final String DB_TABLE = "DownloadManagerTable";
 
     /**
      * MIME type for the entire download list


### PR DESCRIPTION
Fixes #3 

Now if a client wishes to use Download-Manager they have to declare `manifestPlaceholders = [downloadAuthority: "WATEVER_U_WANT"]` and then this will be used as the name of the content provider authority allowing, multiple apps using this library to be installed at the same time.
