### PR TITLE
Reducing scope of DownloadManager API

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -4,7 +4,7 @@ package com.novoda.downloadmanager.lib;
  * Contains the internal constants that are used in the download manager.
  * As a general rule, modifying these constants should be done with care.
  */
-public class Constants {
+class Constants {
 
     /**
      * The column that used to be used for the HTTP method of the request

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDrmHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDrmHelper.java
@@ -24,7 +24,7 @@ import android.os.Build;
 
 import java.io.File;
 
-public class DownloadDrmHelper {
+class DownloadDrmHelper {
 
     /**
      * The MIME type of special DRM files

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
 /**
  * Stores information about an individual download.
  */
-public class DownloadInfo {
+class DownloadInfo {
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
 
     // TODO: move towards these in-memory objects being sources of truth, and

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -348,10 +348,8 @@ public class DownloadManager {
     /**
      * Makes this object access the download provider through /all_downloads URIs rather than
      * /my_downloads URIs, for clients that have permission to do so.
-     *
-     * @hide
      */
-    public void setAccessAllDownloads(boolean accessAllDownloads) {
+    void setAccessAllDownloads(boolean accessAllDownloads) {
         if (accessAllDownloads) {
             mBaseUri = Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI;
         } else {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -338,9 +338,6 @@ public class DownloadManager {
     private ContentResolver mResolver;
     private Uri mBaseUri = Downloads.Impl.CONTENT_URI;
 
-    /**
-     * @hide
-     */
     public DownloadManager(ContentResolver resolver) {
         mResolver = resolver;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -598,22 +598,6 @@ public class DownloadManager {
     }
 
     /**
-     * {@hide}
-     */
-    public static boolean isActiveNetworkExpensive(Context context) {
-        // TODO: connect to NetworkPolicyManager
-        return false;
-    }
-
-    /**
-     * {@hide}
-     */
-    public static long getActiveNetworkWarningBytes(Context context) {
-        // TODO: connect to NetworkPolicyManager
-        return -1;
-    }
-
-    /**
      * Adds a file to the downloads database system, so it could appear in Downloads App
      * (and thus become eligible for management by the Downloads App).
      * <p/>

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -233,14 +233,6 @@ public class DownloadManager {
     public static final int ERROR_FILE_ALREADY_EXISTS = 1009;
 
     /**
-     * Value of {@link #COLUMN_REASON} when the download has failed because of
-     * {NetworkPolicyManager} controls on the requesting application.
-     *
-     * @hide
-     */
-    public static final int ERROR_BLOCKED = 1010;
-
-    /**
      * Value of {@link #COLUMN_REASON} when the download is paused because some network error
      * occurred and the download manager is waiting before retrying the request.
      */

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -50,7 +50,7 @@ import static com.novoda.downloadmanager.lib.Request.*;
  * states. Collapses similar downloads into a single notification, and builds
  * {@link PendingIntent} that launch towards {DownloadReceiver}.
  */
-public class DownloadNotifier {
+class DownloadNotifier {
 
     private static final int TYPE_ACTIVE = 1;
     private static final int TYPE_WAITING = 2;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadScanner.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadScanner.java
@@ -34,7 +34,7 @@ import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
 /**
  * Manages asynchronous scanning of completed downloads.
  */
-public class DownloadScanner implements MediaScannerConnectionClient {
+class DownloadScanner implements MediaScannerConnectionClient {
     private static final long SCAN_TIMEOUT = MINUTE_IN_MILLIS;
 
     private final Context mContext;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -58,7 +58,7 @@ import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
  * Any database updates important enough to initiate tasks should always be
  * delivered through {Context#startService(Intent)}.
  */
-class DownloadService extends Service {
+public class DownloadService extends Service {
     // TODO: migrate WakeLock from individual DownloadThreads out into
     // DownloadReceiver to protect our entire workflow.
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -58,7 +58,7 @@ import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
  * Any database updates important enough to initiate tasks should always be
  * delivered through {Context#startService(Intent)}.
  */
-public class DownloadService extends Service {
+class DownloadService extends Service {
     // TODO: migrate WakeLock from individual DownloadThreads out into
     // DownloadReceiver to protect our entire workflow.
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -52,7 +52,7 @@ import static java.net.HttpURLConnection.*;
  * Task which executes a given {@link DownloadInfo}: making network requests,
  * persisting data to disk, and updating {@link DownloadProvider}.
  */
-public class DownloadThread implements Runnable {
+class DownloadThread implements Runnable {
 
     private static final String TAG = "DownloadManager-DownloadThread";
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -26,7 +26,7 @@ import android.provider.BaseColumns;
  *
  * @pending
  */
-public final class Downloads {
+final class Downloads {
     private Downloads() {
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -713,9 +713,6 @@ final class Downloads {
         @Deprecated
         public static final int STATUS_BLOCKED = 498;
 
-        /**
-         * {@hide}
-         */
         public static String statusToString(int status) {
             switch (status) {
                 case STATUS_PENDING:

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -700,17 +700,6 @@ final class Downloads {
          */
         public static final int STATUS_TOO_MANY_REDIRECTS = 497;
 
-        /**
-         * This download has failed because requesting application has been
-         * blocked by {NetworkPolicyManager}.
-         *
-         * @hide
-         * @deprecated since behavior now uses
-         * {@link #STATUS_WAITING_FOR_NETWORK}
-         */
-        @Deprecated
-        public static final int STATUS_BLOCKED = 498;
-
         public static String statusToString(int status) {
             switch (status) {
                 case STATUS_PENDING:
@@ -759,8 +748,6 @@ final class Downloads {
                     return "HTTP_EXCEPTION";
                 case STATUS_TOO_MANY_REDIRECTS:
                     return "TOO_MANY_REDIRECTS";
-                case STATUS_BLOCKED:
-                    return "BLOCKED";
                 default:
                     return Integer.toString(status);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -36,10 +36,8 @@ final class Downloads {
      * Exposes constants used to interact with the download manager's
      * content provider.
      * The constants URI ... STATUS are the names of columns in the downloads table.
-     *
-     * @hide
      */
-    public static final class Impl implements BaseColumns {
+    static final class Impl implements BaseColumns {
 
         private Impl() {
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 /**
  * Some helper functions for the download manager
  */
-public class Helpers {
+class Helpers {
     public static Random sRandom = new Random(SystemClock.uptimeMillis());
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NetworkMeter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NetworkMeter.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager.lib;
 import android.net.ConnectivityManager;
 import android.os.Build;
 
-public interface NetworkMeter {
+interface NetworkMeter {
     boolean isActiveNetworkMetered();
 
     public static class Factory {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OpenHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OpenHelper.java
@@ -28,7 +28,7 @@ import static android.app.DownloadManager.*;
 import static com.novoda.downloadmanager.lib.Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI;
 import static com.novoda.downloadmanager.lib.Downloads.Impl.RequestHeaders;
 
-public class OpenHelper {
+class OpenHelper {
     /**
      * Build an {@link Intent} to view the download at current {@link Cursor}
      * position, handling subtleties around installing packages.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -66,7 +66,6 @@ public class Query {
      *              the system's Downloads UI; if false (the default), this query will include
      *              both visible and invisible downloads.
      * @return this object
-     * @hide
      */
     public Query setOnlyIncludeVisibleInDownloadsUi(boolean value) {
         mOnlyIncludeVisibleInDownloadsUi = value;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -13,17 +13,13 @@ import java.util.List;
 public class Query {
     /**
      * Constant for use with {@link #orderBy}
-     *
-     * @hide
      */
-    public static final int ORDER_ASCENDING = 1;
+    static final int ORDER_ASCENDING = 1;
 
     /**
      * Constant for use with {@link #orderBy}
-     *
-     * @hide
      */
-    public static final int ORDER_DESCENDING = 2;
+    static final int ORDER_DESCENDING = 2;
 
     private long[] mIds = null;
     private Integer mStatusFlags = null;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -85,9 +85,8 @@ public class Query {
      *                  supported.
      * @param direction either {@link #ORDER_ASCENDING} or {@link #ORDER_DESCENDING}
      * @return this object
-     * @hide
      */
-    public Query orderBy(String column, int direction) {
+    Query orderBy(String column, int direction) {
         if (direction != ORDER_ASCENDING && direction != ORDER_DESCENDING) {
             throw new IllegalArgumentException("Invalid direction: " + direction);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -48,7 +48,6 @@ public class Request {
     private boolean mMeteredAllowed = true;
     private boolean mIsVisibleInDownloadsUi = true;
     private boolean mScannable = false;
-    private boolean mUseSystemCache = false;
     private String extraField;
     private String bigPictureUrl;
     /**
@@ -130,24 +129,6 @@ public class Request {
      */
     public Request setDestinationUri(Uri uri) {
         mDestinationUri = uri;
-        return this;
-    }
-
-    /**
-     * Set the local destination for the downloaded file to the system cache dir (/cache).
-     * This is only available to System apps with the permission
-     * { android.Manifest.permission#ACCESS_CACHE_FILESYSTEM}.
-     * <p/>
-     * The downloaded file is not scanned by MediaScanner.
-     * But it can be made scannable by calling {@link #allowScanningByMediaScanner()}.
-     * <p/>
-     * Files downloaded to /cache may be deleted by the system at any time to reclaim space.
-     *
-     * @return this object
-     * @hide
-     */
-    public Request setDestinationToSystemCache() {
-        mUseSystemCache = true;
         return this;
     }
 
@@ -445,7 +426,7 @@ public class Request {
             values.put(Downloads.Impl.COLUMN_FILE_NAME_HINT, mDestinationUri.toString());
         } else {
             values.put(Downloads.Impl.COLUMN_DESTINATION,
-                    (this.mUseSystemCache) ? Downloads.Impl.DESTINATION_SYSTEMCACHE_PARTITION : Downloads.Impl.DESTINATION_CACHE_PARTITION_PURGEABLE);
+                    Downloads.Impl.DESTINATION_CACHE_PARTITION_PURGEABLE);
         }
         // is the file supposed to be media-scannable?
         values.put(Downloads.Impl.COLUMN_MEDIA_SCANNED, (mScannable) ? SCANNABLE_VALUE_YES : SCANNABLE_VALUE_NO);


### PR DESCRIPTION
This PR reduces the scope of the DownloadManger API, as a lot of classes were publicly accessible which they probably shouldn't have been. This reduces their scope to package-scope. Furthermore, methods which were annotated with `@hide` have also had their scope reduced. 

Some code which is accessible only to system apps, or hidden because the original DownloadManager API wasn't finished (!) has been removed.

| Before | After |
| --- | --- |
| ![screen shot 2015-05-13 at 10 50 19](https://cloud.githubusercontent.com/assets/666285/7608816/0e2f240e-f965-11e4-937d-2c1512b84553.png) | ![screen shot 2015-05-13 at 11 41 14](https://cloud.githubusercontent.com/assets/666285/7608829/256ef388-f965-11e4-851b-0260cdf9a65b.png) |
