### PR TITLE
Scuba cleanup

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -256,20 +256,24 @@ public class DownloadManager {
     public static final int PAUSED_UNKNOWN = 4;
 
     /**
-     * Broadcast intent action sent by the download manager when a download completes.
+     * Broadcast intent action sent by the download manager when a download completes. The
+     * download's content:// uri is specified in the intent's data.
      */
-    public static final String ACTION_DOWNLOAD_COMPLETE = "android.intent.action.SCUBA_DOWNLOAD_COMPLETE";
+    public static final String ACTION_DOWNLOAD_COMPLETE = "com.novoda.downloadmanager.DOWNLOAD_COMPLETE";
 
     /**
      * Broadcast intent action sent by the download manager when a download wasn't started due to insufficient space
      */
-    public static final String ACTION_DOWNLOAD_INSUFFICIENT_SPACE = "android.intent.action.SCUBA_DOWNLOAD_INSUFFICIENT_SPACE";
+    public static final String ACTION_DOWNLOAD_INSUFFICIENT_SPACE = "com.novoda.downloadmanager.DOWNLOAD_INSUFFICIENT_SPACE";
 
     /**
      * Broadcast intent action sent by the download manager when the user clicks on a running
-     * download, either from a system notification or from the downloads UI.
+     * download, either from a system notification. The download's content: uri is specified
+     * in the intent's data if the click is associated with a single download,
+     * or {@link DownloadManager#CONTENT_URI} if the notification is associated with
+     * multiple downloads.
      */
-    public static final String ACTION_NOTIFICATION_CLICKED = "android.intent.action.SCUBA_DOWNLOAD_NOTIFICATION_CLICKED";
+    public static final String ACTION_NOTIFICATION_CLICKED = "com.novoda.downloadmaanger.DOWNLOAD_NOTIFICATION_CLICKED";
 
     /**
      * Intent action to launch an activity to display all downloads.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -276,17 +276,6 @@ public class DownloadManager {
     public static final String ACTION_NOTIFICATION_CLICKED = "com.novoda.downloadmaanger.DOWNLOAD_NOTIFICATION_CLICKED";
 
     /**
-     * Intent action to launch an activity to display all downloads.
-     */
-    public static final String ACTION_VIEW_DOWNLOADS = "android.intent.action.SCUBA_VIEW_DOWNLOADS";
-
-    /**
-     * Intent extra included with {@link #ACTION_VIEW_DOWNLOADS} to start DownloadApp in
-     * sort-by-size mode.
-     */
-    public static final String INTENT_EXTRAS_SORT_BY_SIZE = "android.app.DownloadManager.extra_sortBySize";
-
-    /**
      * Intent extra included with {@link #ACTION_DOWNLOAD_COMPLETE} intents, indicating the ID (as a
      * long) of the download that just completed.
      */

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -108,18 +108,6 @@ public final class Downloads {
         public static final Uri PUBLICLY_ACCESSIBLE_DOWNLOADS_URI = Uri.parse(AUTHORITY + "/" + PUBLICLY_ACCESSIBLE_DOWNLOADS_URI_SEGMENT);
 
         /**
-         * Broadcast Action: this is sent by the download manager to the app
-         * that had initiated a download when the user selects the notification
-         * associated with that download. The download's content: uri is specified
-         * in the intent's data if the click is associated with a single download,
-         * or Downloads.CONTENT_URI if the notification is associated with
-         * multiple downloads.
-         * Note: this is not currently sent for downloads that have completed
-         * successfully.
-         */
-        public static final String ACTION_NOTIFICATION_CLICKED = "android.intent.action.SCUBA_DOWNLOAD_NOTIFICATION_CLICKED";
-
-        /**
          * The name of the column containing the URI of the data being downloaded.
          * <P>Type: TEXT</P>
          * <P>Owner can Init/Read</P>

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -26,7 +26,7 @@ import android.provider.BaseColumns;
  *
  * @pending
  */
-final class Downloads {
+public final class Downloads {
     private Downloads() {
     }
 
@@ -36,8 +36,10 @@ final class Downloads {
      * Exposes constants used to interact with the download manager's
      * content provider.
      * The constants URI ... STATUS are the names of columns in the downloads table.
+     *
+     * @hide
      */
-    static final class Impl implements BaseColumns {
+    public static final class Impl implements BaseColumns {
 
         private Impl() {
         }
@@ -104,13 +106,6 @@ final class Downloads {
          * permissions to access this downloaded file)
          */
         public static final Uri PUBLICLY_ACCESSIBLE_DOWNLOADS_URI = Uri.parse(AUTHORITY + "/" + PUBLICLY_ACCESSIBLE_DOWNLOADS_URI_SEGMENT);
-
-        /**
-         * Broadcast Action: this is sent by the download manager to the app
-         * that had initiated a download when that download completes. The
-         * download's content: uri is specified in the intent's data.
-         */
-        public static final String ACTION_DOWNLOAD_COMPLETED = "android.intent.action.SCUBA_DOWNLOAD_COMPLETED";
 
         /**
          * Broadcast Action: this is sent by the download manager to the app
@@ -700,6 +695,20 @@ final class Downloads {
          */
         public static final int STATUS_TOO_MANY_REDIRECTS = 497;
 
+        /**
+         * This download has failed because requesting application has been
+         * blocked by {NetworkPolicyManager}.
+         *
+         * @hide
+         * @deprecated since behavior now uses
+         * {@link #STATUS_WAITING_FOR_NETWORK}
+         */
+        @Deprecated
+        public static final int STATUS_BLOCKED = 498;
+
+        /**
+         * {@hide}
+         */
         public static String statusToString(int status) {
             switch (status) {
                 case STATUS_PENDING:
@@ -748,6 +757,8 @@ final class Downloads {
                     return "HTTP_EXCEPTION";
                 case STATUS_TOO_MANY_REDIRECTS:
                     return "TOO_MANY_REDIRECTS";
+                case STATUS_BLOCKED:
+                    return "BLOCKED";
                 default:
                     return Integer.toString(status);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -26,7 +26,7 @@ import android.provider.BaseColumns;
  *
  * @pending
  */
-public final class Downloads {
+final class Downloads {
     private Downloads() {
     }
 
@@ -36,10 +36,8 @@ public final class Downloads {
      * Exposes constants used to interact with the download manager's
      * content provider.
      * The constants URI ... STATUS are the names of columns in the downloads table.
-     *
-     * @hide
      */
-    public static final class Impl implements BaseColumns {
+    static final class Impl implements BaseColumns {
 
         private Impl() {
         }
@@ -683,21 +681,7 @@ public final class Downloads {
          */
         public static final int STATUS_TOO_MANY_REDIRECTS = 497;
 
-        /**
-         * This download has failed because requesting application has been
-         * blocked by {NetworkPolicyManager}.
-         *
-         * @hide
-         * @deprecated since behavior now uses
-         * {@link #STATUS_WAITING_FOR_NETWORK}
-         */
-        @Deprecated
-        public static final int STATUS_BLOCKED = 498;
-
-        /**
-         * {@hide}
-         */
-        public static String statusToString(int status) {
+        static String statusToString(int status) {
             switch (status) {
                 case STATUS_PENDING:
                     return "PENDING";
@@ -745,8 +729,6 @@ public final class Downloads {
                     return "HTTP_EXCEPTION";
                 case STATUS_TOO_MANY_REDIRECTS:
                     return "TOO_MANY_REDIRECTS";
-                case STATUS_BLOCKED:
-                    return "BLOCKED";
                 default:
                     return Integer.toString(status);
             }


### PR DESCRIPTION
Removes references to "scuba" in the code. This was used as a unique identifier to avoid collisions with `android.app.DownloadManager` in MUBI.