### PR TITLE
Remove Logging and add extensible public api

### DIFF
--- a/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -30,8 +30,8 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         setContentView(R.layout.activity_main);
         listView = (ListView) findViewById(R.id.main_downloads_list);
         downloadManager = DownloadManagerBuilder.create()
-                .with(getContentResolver())
-                .build();
+                .withVerboseLogging()
+                .build(getContentResolver());
 
         setupDownloadingExample();
         setupQueryingExample();

--- a/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 
+import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
@@ -28,7 +29,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         com.novoda.notils.logger.simple.Log.setShowLogs(true);
         setContentView(R.layout.activity_main);
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        downloadManager = DownloadManagerBuilder.newInstance()
+        downloadManager = DownloadManagerBuilder.create()
                 .with(getContentResolver())
                 .build();
 

--- a/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -28,7 +28,9 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         com.novoda.notils.logger.simple.Log.setShowLogs(true);
         setContentView(R.layout.activity_main);
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        downloadManager = new DownloadManager(getContentResolver());
+        downloadManager = DownloadManagerBuilder.newInstance()
+                .with(getContentResolver())
+                .build();
 
         setupDownloadingExample();
         setupQueryingExample();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -9,7 +9,7 @@ public class DownloadManagerBuilder {
     private ContentResolver contentResolver;
     private boolean verboseLogging;
 
-    public static DownloadManagerBuilder newInstance() {
+    public static DownloadManagerBuilder create() {
         return new DownloadManagerBuilder();
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -6,8 +6,11 @@ import com.novoda.downloadmanager.lib.DownloadManager;
 
 public class DownloadManagerBuilder {
 
-    private ContentResolver contentResolver;
     private boolean verboseLogging;
+
+    DownloadManagerBuilder() {
+        // use the create method, Alex's favourite
+    }
 
     public static DownloadManagerBuilder create() {
         return new DownloadManagerBuilder();
@@ -18,14 +21,9 @@ public class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder with(ContentResolver contentResolver) {
-        this.contentResolver = contentResolver;
-        return this;
-    }
-
-    public DownloadManager build() {
+    public DownloadManager build(ContentResolver contentResolver) {
         if (contentResolver == null) {
-            throw new IllegalStateException("You must use a ContentResolver with the DownloadManager. (use with(ContentResolver resolver);");
+            throw new IllegalStateException("You must use a ContentResolver with the DownloadManager.");
         }
         return new DownloadManager(contentResolver, verboseLogging);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -1,0 +1,33 @@
+package com.novoda.downloadmanager;
+
+import android.content.ContentResolver;
+
+import com.novoda.downloadmanager.lib.DownloadManager;
+
+public class DownloadManagerBuilder {
+
+    private ContentResolver contentResolver;
+    private boolean verboseLogging;
+
+    public static DownloadManagerBuilder newInstance() {
+        return new DownloadManagerBuilder();
+    }
+
+    public DownloadManagerBuilder withVerboseLogging() {
+        this.verboseLogging = true;
+        return this;
+    }
+
+    public DownloadManagerBuilder with(ContentResolver contentResolver) {
+        this.contentResolver = contentResolver;
+        return this;
+    }
+
+    public DownloadManager build() {
+        if (contentResolver == null) {
+            throw new IllegalStateException("You must use a ContentResolver with the DownloadManager. (use with(ContentResolver resolver);");
+        }
+        return new DownloadManager(contentResolver, verboseLogging);
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -320,11 +320,17 @@ public class DownloadManager {
             "'placeholder' AS " + COLUMN_REASON
     };
 
-    private ContentResolver mResolver;
+    private final ContentResolver mResolver;
+    private final boolean verboseLogging;
     private Uri mBaseUri = Downloads.Impl.CONTENT_URI;
 
     public DownloadManager(ContentResolver resolver) {
-        mResolver = resolver;
+        this(resolver, false);
+    }
+
+    public DownloadManager(ContentResolver contentResolver, boolean verboseLogging) {
+        this.mResolver = contentResolver;
+        this.verboseLogging = verboseLogging;
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -528,8 +528,9 @@ public class DownloadManager {
             for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
                 int status = cursor.getInt(cursor.getColumnIndex(COLUMN_STATUS));
                 if (status != STATUS_SUCCESSFUL && status != STATUS_FAILED) {
-                    throw new IllegalArgumentException("Cannot restart incomplete download: "
-                            + cursor.getLong(cursor.getColumnIndex(COLUMN_ID)));
+                    throw new IllegalArgumentException(
+                            "Cannot restart incomplete download: "
+                                    + cursor.getLong(cursor.getColumnIndex(COLUMN_ID)));
                 }
             }
         } finally {
@@ -627,8 +628,9 @@ public class DownloadManager {
         values.put(Downloads.Impl.COLUMN_STATUS, Downloads.Impl.STATUS_SUCCESS);
         values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, length);
         values.put(Downloads.Impl.COLUMN_MEDIA_SCANNED, (isMediaScannerScannable) ? Request.SCANNABLE_VALUE_YES : Request.SCANNABLE_VALUE_NO);
-        values.put(Downloads.Impl.COLUMN_VISIBILITY, (showNotification) ?
-                Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION : Request.VISIBILITY_HIDDEN);
+        values.put(
+                Downloads.Impl.COLUMN_VISIBILITY, (showNotification) ?
+                        Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION : Request.VISIBILITY_HIDDEN);
         Uri downloadUri = mResolver.insert(Downloads.Impl.CONTENT_URI, values);
         if (downloadUri == null) {
             return -1;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -321,7 +321,7 @@ public class DownloadManager {
     };
 
     private final ContentResolver mResolver;
-    private final boolean verboseLogging;
+
     private Uri mBaseUri = Downloads.Impl.CONTENT_URI;
 
     public DownloadManager(ContentResolver resolver) {
@@ -330,7 +330,7 @@ public class DownloadManager {
 
     public DownloadManager(ContentResolver contentResolver, boolean verboseLogging) {
         this.mResolver = contentResolver;
-        this.verboseLogging = verboseLogging;
+        DownloadProvider.VERBOSE_LOGGING = verboseLogging;
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -422,12 +422,13 @@ public final class DownloadProvider extends ContentProvider {
 
         private void createHeadersTable(SQLiteDatabase db) {
             db.execSQL("DROP TABLE IF EXISTS " + Downloads.Impl.RequestHeaders.HEADERS_DB_TABLE);
-            db.execSQL("CREATE TABLE " + Downloads.Impl.RequestHeaders.HEADERS_DB_TABLE + "(" +
-                    "id INTEGER PRIMARY KEY AUTOINCREMENT," +
-                    Downloads.Impl.RequestHeaders.COLUMN_DOWNLOAD_ID + " INTEGER NOT NULL," +
-                    Downloads.Impl.RequestHeaders.COLUMN_HEADER + " TEXT NOT NULL," +
-                    Downloads.Impl.RequestHeaders.COLUMN_VALUE + " TEXT NOT NULL" +
-                    ");");
+            db.execSQL(
+                    "CREATE TABLE " + Downloads.Impl.RequestHeaders.HEADERS_DB_TABLE + "(" +
+                            "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                            Downloads.Impl.RequestHeaders.COLUMN_DOWNLOAD_ID + " INTEGER NOT NULL," +
+                            Downloads.Impl.RequestHeaders.COLUMN_HEADER + " TEXT NOT NULL," +
+                            Downloads.Impl.RequestHeaders.COLUMN_VALUE + " TEXT NOT NULL" +
+                            ");");
         }
     }
 
@@ -535,8 +536,9 @@ public final class DownloadProvider extends ContentProvider {
                     && (dest == Downloads.Impl.DESTINATION_CACHE_PARTITION
                     || dest == Downloads.Impl.DESTINATION_CACHE_PARTITION_NOROAMING
                     || dest == Downloads.Impl.DESTINATION_SYSTEMCACHE_PARTITION)) {
-                throw new SecurityException("setting destination to : " + dest +
-                        " not allowed, unless PERMISSION_ACCESS_ADVANCED is granted");
+                throw new SecurityException(
+                        "setting destination to : " + dest +
+                                " not allowed, unless PERMISSION_ACCESS_ADVANCED is granted");
             }
             // for public API behavior, if an app has CACHE_NON_PURGEABLE permission, automatically
             // switch to non-purgeable download
@@ -728,19 +730,22 @@ public final class DownloadProvider extends ContentProvider {
             values.remove(Downloads.Impl._DATA);
             values.remove(Downloads.Impl.COLUMN_STATUS);
         }
-        enforceAllowedValues(values, Downloads.Impl.COLUMN_DESTINATION,
+        enforceAllowedValues(
+                values, Downloads.Impl.COLUMN_DESTINATION,
                 Downloads.Impl.DESTINATION_CACHE_PARTITION_PURGEABLE,
                 Downloads.Impl.DESTINATION_FILE_URI,
                 Downloads.Impl.DESTINATION_NON_DOWNLOADMANAGER_DOWNLOAD);
 
         if (getContext().checkCallingOrSelfPermission(Downloads.Impl.PERMISSION_NO_NOTIFICATION) == PackageManager.PERMISSION_GRANTED) {
-            enforceAllowedValues(values, Downloads.Impl.COLUMN_VISIBILITY,
+            enforceAllowedValues(
+                    values, Downloads.Impl.COLUMN_VISIBILITY,
                     Request.VISIBILITY_HIDDEN,
                     Request.VISIBILITY_VISIBLE,
                     Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
                     Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
         } else {
-            enforceAllowedValues(values, Downloads.Impl.COLUMN_VISIBILITY,
+            enforceAllowedValues(
+                    values, Downloads.Impl.COLUMN_VISIBILITY,
                     Request.VISIBILITY_VISIBLE,
                     Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
                     Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
@@ -819,8 +824,9 @@ public final class DownloadProvider extends ContentProvider {
 
         if (match == REQUEST_HEADERS_URI) {
             if (projection != null || selection != null || sort != null) {
-                throw new UnsupportedOperationException("Request header queries do not support "
-                        + "projections, selections or sorting");
+                throw new UnsupportedOperationException(
+                        "Request header queries do not support "
+                                + "projections, selections or sorting");
             }
             return queryRequestHeaders(db, uri);
         }
@@ -945,7 +951,8 @@ public final class DownloadProvider extends ContentProvider {
                 + getDownloadIdFromUri(uri);
         String[] projection = new String[]{Downloads.Impl.RequestHeaders.COLUMN_HEADER,
                 Downloads.Impl.RequestHeaders.COLUMN_VALUE};
-        return db.query(Downloads.Impl.RequestHeaders.HEADERS_DB_TABLE, projection, where,
+        return db.query(
+                Downloads.Impl.RequestHeaders.HEADERS_DB_TABLE, projection, where,
                 null, null, null, null);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -37,7 +37,6 @@ import android.os.Process;
 import android.provider.OpenableColumns;
 import android.text.TextUtils;
 
-import com.novoda.downloadmanager.BuildConfig;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.File;
@@ -117,6 +116,8 @@ public final class DownloadProvider extends ContentProvider {
      * is publicly accessible.
      */
     private static final int PUBLIC_DOWNLOAD_ID = 6;
+
+    public static boolean VERBOSE_LOGGING;
 
     static {
         sURIMatcher.addURI(AUTHORITY, "my_downloads", MY_DOWNLOADS);
@@ -848,7 +849,9 @@ public final class DownloadProvider extends ContentProvider {
             }
         }
 
-        logVerboseQueryInfo(projection, selection, selectionArgs, sort, db);
+        if (VERBOSE_LOGGING) {
+            logVerboseQueryInfo(projection, selection, selectionArgs, sort, db);
+        }
 
         Cursor ret = db.query(DB_TABLE, projection, fullSelection.getSelection(),
                 fullSelection.getParameters(), null, null, sort);
@@ -863,8 +866,11 @@ public final class DownloadProvider extends ContentProvider {
         return ret;
     }
 
-    private void logVerboseQueryInfo(String[] projection, final String selection,
-                                     final String[] selectionArgs, final String sort, SQLiteDatabase db) {
+    private void logVerboseQueryInfo(String[] projection,
+                                     final String selection,
+                                     final String[] selectionArgs,
+                                     final String sort,
+                                     SQLiteDatabase db) {
         java.lang.StringBuilder sb = new java.lang.StringBuilder();
         sb.append("starting query, database is ");
         if (db != null) {
@@ -1126,7 +1132,9 @@ public final class DownloadProvider extends ContentProvider {
      */
     @Override
     public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
-        logVerboseOpenFileInfo(uri, mode);
+        if (VERBOSE_LOGGING) {
+            logVerboseOpenFileInfo(uri, mode);
+        }
 
         Cursor cursor = query(uri, new String[]{"_data"}, null, null, null);
         String path;


### PR DESCRIPTION
Toggles off the verbose logging that we should not be doing.
Logs are off by default for any new versions of the library.

This is done with a static flag (it is in a content provider so I cannot pass it the flag through construction). This implies you only have one instance of DownloadManager if you have two one with logging on and one with logging off the latest created will win.

Alternative would be to check the system property for verbose logging and then only log in those situtations? This still would mean 2 instances of the manager would favor the latest flag, so no gain...

Formatted some of the code so the diff is a bit bigger.

This fixes #19 which will give performance improvements for all clients.