### PR TITLE
Configurable max concurrent downloads

### DIFF
--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -22,6 +22,11 @@ android {
         manifestPlaceholders = [downloadAuthority: "${applicationId}"]
     }
 
+    productFlavors {
+        serial
+        parallel
+    }
+
     lintOptions {
         abortOnError false
     }

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <meta-data
       android:name="com.novoda.downloadmanager.MaxConcurrentDownloads"
-      android:value="1" />
+      android:value="@integer/max_concurrent_downloads" />
 
   </application>
 

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="com.novoda.downloadmanager.demo"
-  xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.novoda.downloadmanager.demo">
 
   <uses-permission android:name="android.permission.INTERNET" />
 
@@ -19,6 +18,10 @@
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
+
+    <meta-data
+      android:name="com.novoda.downloadmanager.MaxConcurrentDownloads"
+      android:value="1" />
 
   </application>
 

--- a/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -17,8 +17,8 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
     private static final String TAG = MainActivity.class.getSimpleName();
-    private static final String BIG_FILE = "http://downloads.bbc.co.uk/podcasts/radio4/fricomedy/fricomedy_20150501-1855a.mp3";
-    private static final String BBC_COMEDY_IMAGE = "http://ichef.bbci.co.uk/podcasts/artwork/266/fricomedy.jpg";
+    private static final String BIG_FILE = "http://open.live.bbc.co.uk/mediaselector/5/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p02ss0fm.mp3";
+    private static final String BBC_COMEDY_IMAGE = "http://ichef.bbci.co.uk/images/ic/640x360/p02ss0cf.jpg";
 
     private DownloadManager downloadManager;
     private ListView listView;
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         request.setDestinationInInternalFilesDir(this, Environment.DIRECTORY_MOVIES, "podcast.mp3");
         request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
         request.setBigPictureUrl(BBC_COMEDY_IMAGE);
-        request.setTitle("BBC Friday Night Comedy");
+        request.setTitle("BBC Innuendo Bingo");
         request.setDescription("Nothing to do with beards.");
         request.setMimeType("audio/mp3");
 

--- a/demo/src/main/res/values/integers.xml
+++ b/demo/src/main/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer name="max_concurrent_downloads">1</integer>
+</resources>

--- a/demo/src/parallel/res/values/integers.xml
+++ b/demo/src/parallel/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <integer name="max_concurrent_downloads">5</integer>
+</resources>

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -1,0 +1,48 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import com.novoda.notils.logger.simple.Log;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+class DownloadExecutorFactory {
+    private static final int KEEP_ALIVE_TIME = 10;
+    private static final int DEFAULT_MAX_CONCURRENT_DOWNLOADS = 5;
+    private static final String METADATA_MAX_CONCURRENT_DOWNLOADS = "com.novoda.downloadmanager.MaxConcurrentDownloads";
+
+    public ExecutorService createExecutor(Context context) {
+        int maxConcurrentDownloads = getMaximumConcurrentDownloads(context);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                maxConcurrentDownloads,
+                maxConcurrentDownloads,
+                KEEP_ALIVE_TIME,
+                TimeUnit.SECONDS,
+                new LinkedBlockingQueue<Runnable>());
+        executor.allowCoreThreadTimeOut(true);
+        return executor;
+    }
+
+    private int getMaximumConcurrentDownloads(Context context) {
+        try {
+            String packageName = context.getApplicationContext().getPackageName();
+            PackageManager packageManager = context.getPackageManager();
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            Bundle bundle = applicationInfo.metaData;
+            if (bundle == null) {
+                return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+            }
+
+            return bundle.getInt(METADATA_MAX_CONCURRENT_DOWNLOADS, DEFAULT_MAX_CONCURRENT_DOWNLOADS);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("Meta data value not found: " + e.getMessage());
+        }
+        return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -30,9 +30,9 @@ class DownloadExecutorFactory {
     }
 
     private int getMaximumConcurrentDownloads(Context context) {
+        String packageName = context.getApplicationContext().getPackageName();
+        PackageManager packageManager = context.getPackageManager();
         try {
-            String packageName = context.getApplicationContext().getPackageName();
-            PackageManager packageManager = context.getPackageManager();
             ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
             Bundle bundle = applicationInfo.metaData;
             if (bundle == null) {
@@ -41,7 +41,7 @@ class DownloadExecutorFactory {
 
             return bundle.getInt(METADATA_MAX_CONCURRENT_DOWNLOADS, DEFAULT_MAX_CONCURRENT_DOWNLOADS);
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e("Meta data value not found: " + e.getMessage());
+            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
         }
         return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -43,9 +43,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import static android.text.format.DateUtils.MINUTE_IN_MILLIS;
 
@@ -89,19 +86,7 @@ public class DownloadService extends Service {
 //    @GuardedBy("mDownloads")
     private final Map<Long, DownloadInfo> mDownloads = new HashMap<Long, DownloadInfo>();
 
-    private final ExecutorService mExecutor = buildDownloadExecutor();
-
-    private static ExecutorService buildDownloadExecutor() {
-        final int maxConcurrent = 5;
-
-        // Create a bounded thread pool for executing downloads; it creates
-        // threads as needed (up to maximum) and reclaims them when finished.
-        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                maxConcurrent, maxConcurrent, 10, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<Runnable>());
-        executor.allowCoreThreadTimeOut(true);
-        return executor;
-    }
+    private ExecutorService mExecutor;
 
     private DownloadScanner mScanner;
 
@@ -163,6 +148,8 @@ public class DownloadService extends Service {
         getContentResolver().registerContentObserver(
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI,
                 true, mObserver);
+
+        mExecutor = new DownloadExecutorFactory().createExecutor(this);
     }
 
     private NotificationImageRetriever getNotificationImageRetriever() {


### PR DESCRIPTION
Adds the possibility to configure the max concurrent downloads. As the download manager is a per app basis component, in order to specify the max number the client would have to include the following `meta-data` in its `AndroidManifest.xml` rather than relying on the `DownloadManagerBuilder`:

```xml
<meta-data
      android:name="com.novoda.downloadmanager.MaxConcurrentDownloads"
      android:value="1" />
```

If the `meta-data` tag is not present, the download manager will default to a maximum of 5 concurrent downloads maintaining the old behaviour. 

The specified value basically configures the `maximumPoolSize` of the `ThreadPoolExecutor`.  

_Note: The demo project now has 2 flavours - serial and parallel - in order to demo the usage of both cases_
