### PR TITLE
Add tests around configuring concurrent downloads limit

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "22.0.1"
 
     defaultConfig {
         minSdkVersion 14

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -43,6 +43,10 @@ dependencies {
     compile 'com.android.support:support-v4:22.1.1'
     compile 'com.novoda:notils:2.2.11'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.easytesting:fest-assert-core:2.0M10'
 }
 
 publish {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProvider.java
@@ -1,0 +1,46 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import com.novoda.notils.logger.simple.Log;
+
+class ConcurrentDownloadsLimitProvider {
+
+    private static final int DEFAULT_MAX_CONCURRENT_DOWNLOADS = 5;
+    private static final String METADATA_MAX_CONCURRENT_DOWNLOADS = "com.novoda.downloadmanager.MaxConcurrentDownloads";
+
+    private final PackageManager packageManager;
+    private final String packageName;
+
+    static ConcurrentDownloadsLimitProvider newInstance(Context context) {
+        PackageManager packageManager = context.getPackageManager();
+        String packageName = context.getApplicationContext().getPackageName();
+        return new ConcurrentDownloadsLimitProvider(packageManager, packageName);
+    }
+
+    ConcurrentDownloadsLimitProvider(PackageManager packageManager, String packageName) {
+        this.packageManager = packageManager;
+        this.packageName = packageName;
+    }
+
+    public int getConcurrentDownloadsLimit() {
+        try {
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            return getMaximumConcurrentDownloads(applicationInfo.metaData);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
+            return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+        }
+    }
+
+    private int getMaximumConcurrentDownloads(Bundle bundle) {
+        if (bundle == null) {
+            return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
+        }
+        return bundle.getInt(METADATA_MAX_CONCURRENT_DOWNLOADS, DEFAULT_MAX_CONCURRENT_DOWNLOADS);
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -1,24 +1,27 @@
 package com.novoda.downloadmanager.lib;
 
 import android.content.Context;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageManager;
-import android.os.Bundle;
 
-import com.novoda.notils.logger.simple.Log;
-
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 class DownloadExecutorFactory {
-    private static final int KEEP_ALIVE_TIME = 10;
-    private static final int DEFAULT_MAX_CONCURRENT_DOWNLOADS = 5;
-    private static final String METADATA_MAX_CONCURRENT_DOWNLOADS = "com.novoda.downloadmanager.MaxConcurrentDownloads";
 
-    public ExecutorService createExecutor(Context context) {
-        int maxConcurrentDownloads = getMaximumConcurrentDownloads(context);
+    private static final int KEEP_ALIVE_TIME = 10;
+
+    private final ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider;
+
+    static DownloadExecutorFactory newInstance(Context context) {
+        return new DownloadExecutorFactory(ConcurrentDownloadsLimitProvider.newInstance(context));
+    }
+
+    DownloadExecutorFactory(ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider) {
+        this.concurrentDownloadsLimitProvider = concurrentDownloadsLimitProvider;
+    }
+
+    public ThreadPoolExecutor createExecutor() {
+        int maxConcurrentDownloads = concurrentDownloadsLimitProvider.getConcurrentDownloadsLimit();
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
                 maxConcurrentDownloads,
                 maxConcurrentDownloads,
@@ -29,20 +32,4 @@ class DownloadExecutorFactory {
         return executor;
     }
 
-    private int getMaximumConcurrentDownloads(Context context) {
-        String packageName = context.getApplicationContext().getPackageName();
-        PackageManager packageManager = context.getPackageManager();
-        try {
-            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
-            Bundle bundle = applicationInfo.metaData;
-            if (bundle == null) {
-                return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
-            }
-
-            return bundle.getInt(METADATA_MAX_CONCURRENT_DOWNLOADS, DEFAULT_MAX_CONCURRENT_DOWNLOADS);
-        } catch (PackageManager.NameNotFoundException e) {
-            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
-        }
-        return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
-    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager.lib;
 
-import android.content.Context;
-
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -11,10 +9,6 @@ class DownloadExecutorFactory {
     private static final int KEEP_ALIVE_TIME = 10;
 
     private final ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider;
-
-    static DownloadExecutorFactory newInstance(Context context) {
-        return new DownloadExecutorFactory(ConcurrentDownloadsLimitProvider.newInstance(context));
-    }
 
     DownloadExecutorFactory(ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider) {
         this.concurrentDownloadsLimitProvider = concurrentDownloadsLimitProvider;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager.lib;
 
+import android.content.Context;
+
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -8,14 +10,19 @@ class DownloadExecutorFactory {
 
     private static final int KEEP_ALIVE_TIME = 10;
 
-    private final ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider;
+    private final int maxConcurrentDownloads;
 
-    DownloadExecutorFactory(ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider) {
-        this.concurrentDownloadsLimitProvider = concurrentDownloadsLimitProvider;
+    static DownloadExecutorFactory newInstance(Context context) {
+        ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider = ConcurrentDownloadsLimitProvider.newInstance(context);
+        int maxConcurrentDownloads = concurrentDownloadsLimitProvider.getConcurrentDownloadsLimit();
+        return new DownloadExecutorFactory(maxConcurrentDownloads);
+    }
+
+    DownloadExecutorFactory(int maxConcurrentDownloads) {
+        this.maxConcurrentDownloads = maxConcurrentDownloads;
     }
 
     public ThreadPoolExecutor createExecutor() {
-        int maxConcurrentDownloads = concurrentDownloadsLimitProvider.getConcurrentDownloadsLimit();
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
                 maxConcurrentDownloads,
                 maxConcurrentDownloads,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadExecutorFactory.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager.lib;
 
-import android.content.Context;
-
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -10,19 +8,14 @@ class DownloadExecutorFactory {
 
     private static final int KEEP_ALIVE_TIME = 10;
 
-    private final int maxConcurrentDownloads;
+    private final ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider;
 
-    static DownloadExecutorFactory newInstance(Context context) {
-        ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider = ConcurrentDownloadsLimitProvider.newInstance(context);
-        int maxConcurrentDownloads = concurrentDownloadsLimitProvider.getConcurrentDownloadsLimit();
-        return new DownloadExecutorFactory(maxConcurrentDownloads);
-    }
-
-    DownloadExecutorFactory(int maxConcurrentDownloads) {
-        this.maxConcurrentDownloads = maxConcurrentDownloads;
+    DownloadExecutorFactory(ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider) {
+        this.concurrentDownloadsLimitProvider = concurrentDownloadsLimitProvider;
     }
 
     public ThreadPoolExecutor createExecutor() {
+        int maxConcurrentDownloads = concurrentDownloadsLimitProvider.getConcurrentDownloadsLimit();
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
                 maxConcurrentDownloads,
                 maxConcurrentDownloads,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -149,7 +149,8 @@ public class DownloadService extends Service {
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI,
                 true, mObserver);
 
-        mExecutor = DownloadExecutorFactory.newInstance(this).createExecutor();
+        ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider = ConcurrentDownloadsLimitProvider.newInstance(this);
+        mExecutor = new DownloadExecutorFactory(concurrentDownloadsLimitProvider).createExecutor();
     }
 
     private NotificationImageRetriever getNotificationImageRetriever() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -149,7 +149,7 @@ public class DownloadService extends Service {
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI,
                 true, mObserver);
 
-        mExecutor = new DownloadExecutorFactory().createExecutor(this);
+        mExecutor = DownloadExecutorFactory.newInstance(this).createExecutor();
     }
 
     private NotificationImageRetriever getNotificationImageRetriever() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -149,8 +149,7 @@ public class DownloadService extends Service {
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI,
                 true, mObserver);
 
-        ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider = ConcurrentDownloadsLimitProvider.newInstance(this);
-        mExecutor = new DownloadExecutorFactory(concurrentDownloadsLimitProvider).createExecutor();
+        mExecutor = DownloadExecutorFactory.newInstance(this).createExecutor();
     }
 
     private NotificationImageRetriever getNotificationImageRetriever() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -149,7 +149,9 @@ public class DownloadService extends Service {
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI,
                 true, mObserver);
 
-        mExecutor = DownloadExecutorFactory.newInstance(this).createExecutor();
+        ConcurrentDownloadsLimitProvider concurrentDownloadsLimitProvider = ConcurrentDownloadsLimitProvider.newInstance(this);
+        DownloadExecutorFactory factory = new DownloadExecutorFactory(concurrentDownloadsLimitProvider);
+        mExecutor = factory.createExecutor();
     }
 
     private NotificationImageRetriever getNotificationImageRetriever() {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProviderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProviderTest.java
@@ -1,0 +1,70 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ConcurrentDownloadsLimitProviderTest {
+
+    private static final String PACKAGE_NAME = "PACKAGE_NAME";
+    private static final String METADATA_MAX_CONCURRENT_DOWNLOADS = "com.novoda.downloadmanager.MaxConcurrentDownloads";
+
+    @Mock
+    PackageManager packageManager;
+    @Mock
+    Bundle bundle;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void givenANullMetadataBundleWhenTheLimitIsRetrievedThenItIsTheDefaultValue() throws Exception {
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenReturn(new StubApplicationInfo(null));
+        ConcurrentDownloadsLimitProvider provider = new ConcurrentDownloadsLimitProvider(packageManager, PACKAGE_NAME);
+
+        int concurrentDownloadsLimit = provider.getConcurrentDownloadsLimit();
+
+        assertThat(concurrentDownloadsLimit).isEqualTo(5);
+    }
+
+    @Test
+    public void givenAPackageNameWhichIsNotFoundWhenTheLimitIsRetrievedThenTheDefaultValueIsUsed() throws Exception {
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenThrow(new PackageManager.NameNotFoundException());
+        ConcurrentDownloadsLimitProvider provider = new ConcurrentDownloadsLimitProvider(packageManager, PACKAGE_NAME);
+
+        int concurrentDownloadsLimit = provider.getConcurrentDownloadsLimit();
+
+        assertThat(concurrentDownloadsLimit).isEqualTo(5);
+    }
+
+    @Test
+    public void givenANonNullBundleWhenTheLimitIsRetrievedThenTheValueFromTheBundleIsUsed() throws Exception {
+        int expected = 8;
+        when(bundle.getInt(eq(METADATA_MAX_CONCURRENT_DOWNLOADS), anyInt())).thenReturn(expected);
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenReturn(new StubApplicationInfo(bundle));
+        ConcurrentDownloadsLimitProvider provider = new ConcurrentDownloadsLimitProvider(packageManager, PACKAGE_NAME);
+
+        int concurrentDownloadsLimit = provider.getConcurrentDownloadsLimit();
+
+        assertThat(concurrentDownloadsLimit).isEqualTo(expected);
+    }
+
+    static class StubApplicationInfo extends ApplicationInfo {
+        StubApplicationInfo(Bundle metaData) {
+            this.metaData = metaData;
+        }
+    }
+
+}

--- a/library/src/test/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProviderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProviderTest.java
@@ -30,7 +30,7 @@ public class ConcurrentDownloadsLimitProviderTest {
     }
 
     @Test
-    public void givenANullMetadataBundleWhenTheLimitIsRetrievedThenItIsTheDefaultValue() throws Exception {
+    public void givenANullMetadataBundleWhenTheLimitIsRetrievedThenTheDefaultValueIsUsed() throws Exception {
         when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenReturn(new StubApplicationInfo(null));
         ConcurrentDownloadsLimitProvider provider = new ConcurrentDownloadsLimitProvider(packageManager, PACKAGE_NAME);
 

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
@@ -1,0 +1,39 @@
+package com.novoda.downloadmanager.lib;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DownloadExecutorFactoryTest {
+
+    @Mock
+    ConcurrentDownloadsLimitProvider metadataReader;
+    DownloadExecutorFactory factory;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        factory = new DownloadExecutorFactory(metadataReader);
+    }
+
+    @Test
+    public void givenALimitProviderWhenTheExecutorIsCreatedThenTheCorrectLimitIsUsed() throws Exception {
+        int expectedLimit = 3;
+        givenALimitOf(expectedLimit);
+
+        ThreadPoolExecutor executor = factory.createExecutor();
+
+        assertThat(executor.getMaximumPoolSize()).isEqualTo(expectedLimit);
+    }
+
+    private void givenALimitOf(int expected) {
+        when(metadataReader.getConcurrentDownloadsLimit()).thenReturn(expected);
+    }
+
+}

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DownloadExecutorFactoryTest {
@@ -22,7 +23,8 @@ public class DownloadExecutorFactoryTest {
     @Test
     public void givenALimitProviderWhenTheExecutorIsCreatedThenTheCorrectLimitIsUsed() throws Exception {
         int expectedLimit = 8;
-        DownloadExecutorFactory factory = new DownloadExecutorFactory(expectedLimit);
+        when(metadataReader.getConcurrentDownloadsLimit()).thenReturn(expectedLimit);
+        DownloadExecutorFactory factory = new DownloadExecutorFactory(metadataReader);
 
         ThreadPoolExecutor executor = factory.createExecutor();
 

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadExecutorFactoryTest.java
@@ -7,33 +7,27 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import static org.fest.assertions.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DownloadExecutorFactoryTest {
 
     @Mock
     ConcurrentDownloadsLimitProvider metadataReader;
-    DownloadExecutorFactory factory;
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
-        factory = new DownloadExecutorFactory(metadataReader);
     }
 
     @Test
     public void givenALimitProviderWhenTheExecutorIsCreatedThenTheCorrectLimitIsUsed() throws Exception {
-        int expectedLimit = 3;
-        givenALimitOf(expectedLimit);
+        int expectedLimit = 8;
+        DownloadExecutorFactory factory = new DownloadExecutorFactory(expectedLimit);
 
         ThreadPoolExecutor executor = factory.createExecutor();
 
         assertThat(executor.getMaximumPoolSize()).isEqualTo(expectedLimit);
     }
 
-    private void givenALimitOf(int expected) {
-        when(metadataReader.getConcurrentDownloadsLimit()).thenReturn(expected);
-    }
 
 }


### PR DESCRIPTION
* Tests creation of the `ThreadPoolExecutor` to make sure that the thread pool is the correct size as this controls the number of concurrent downloads allowed.
* Updates build tools and Gradle versions.
* Adds JUnit, Mockito and Fest for testing.

![screen shot 2015-06-05 at 13 58 31](https://cloud.githubusercontent.com/assets/466546/8006362/fa26e73e-0b8a-11e5-864d-1eab0e374ee1.png)
