### PR TITLE
Cache requested bitmap for notifications

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -14,21 +14,34 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
 
     private final OkHttpClient client;
 
+    private String imageUrl;
+    private Bitmap bitmap;
+
     public OkHttpNotificationImageRetriever() {
         client = new OkHttpClient();
     }
 
     @Override
     public Bitmap retrieveImage(String imageUrl) {
+        if (imageUrl.equals(this.imageUrl)) {
+            return bitmap;
+        }
+
+        this.imageUrl = imageUrl;
+        if (bitmap != null && !bitmap.isRecycled()) {
+            bitmap.recycle();
+            bitmap = null;
+        }
         Request request = new Request.Builder()
                 .get()
-                .url(imageUrl)
+                .url(this.imageUrl)
                 .build();
         try {
             Response response = client.newCall(request).execute();
             InputStream inputStream = response.body().byteStream();
             try {
-                return BitmapFactory.decodeStream(inputStream);
+                bitmap = BitmapFactory.decodeStream(inputStream);
+                return bitmap;
             } finally {
                 inputStream.close();
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -38,8 +38,8 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
             Response response = client.newCall(request).execute();
             InputStream inputStream = response.body().byteStream();
             try {
-                this.imageUrl = imageUrl;
                 bitmap = BitmapFactory.decodeStream(inputStream);
+                this.imageUrl = imageUrl;
                 return bitmap;
             } finally {
                 inputStream.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -32,7 +32,7 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
     private Bitmap fetchBitmap(String imageUrl) {
         Request request = new Request.Builder()
                 .get()
-                .url(this.imageUrl)
+                .url(imageUrl)
                 .build();
         try {
             Response response = client.newCall(request).execute();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -26,16 +26,10 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
         if (imageUrl.equals(this.imageUrl)) {
             return bitmap;
         }
-
-        this.imageUrl = imageUrl;
-        if (bitmap != null && !bitmap.isRecycled()) {
-            bitmap.recycle();
-            bitmap = null;
-        }
-        return fetchBitmap();
+        return fetchBitmap(imageUrl);
     }
 
-    private Bitmap fetchBitmap() {
+    private Bitmap fetchBitmap(String imageUrl) {
         Request request = new Request.Builder()
                 .get()
                 .url(this.imageUrl)
@@ -44,6 +38,8 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
             Response response = client.newCall(request).execute();
             InputStream inputStream = response.body().byteStream();
             try {
+                this.imageUrl = imageUrl;
+                cleanupOldBitmap();
                 bitmap = BitmapFactory.decodeStream(inputStream);
                 return bitmap;
             } finally {
@@ -52,5 +48,15 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
         } catch (IOException e) {
             return null;
         }
+    }
+
+    private void cleanupOldBitmap() {
+        if (bitmap == null) {
+            return;
+        }
+        if (!bitmap.isRecycled()) {
+            bitmap.recycle();
+        }
+        bitmap = null;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -32,6 +32,10 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
             bitmap.recycle();
             bitmap = null;
         }
+        return fetchBitmap();
+    }
+
+    private Bitmap fetchBitmap() {
         Request request = new Request.Builder()
                 .get()
                 .url(this.imageUrl)

--- a/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/OkHttpNotificationImageRetriever.java
@@ -39,7 +39,6 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
             InputStream inputStream = response.body().byteStream();
             try {
                 this.imageUrl = imageUrl;
-                cleanupOldBitmap();
                 bitmap = BitmapFactory.decodeStream(inputStream);
                 return bitmap;
             } finally {
@@ -48,15 +47,5 @@ class OkHttpNotificationImageRetriever implements NotificationImageRetriever {
         } catch (IOException e) {
             return null;
         }
-    }
-
-    private void cleanupOldBitmap() {
-        if (bitmap == null) {
-            return;
-        }
-        if (!bitmap.isRecycled()) {
-            bitmap.recycle();
-        }
-        bitmap = null;
     }
 }


### PR DESCRIPTION
Currently the image for a download notification is fetched from the network every time the notification is updated. This causes memory usage to grow rapidly which causes GC to happen more often. It also wastes network bandwidth.

The retriever will now cache the latest Bitmap and return it without a network request when the same URL is requested.

## Memory Allocations

Before | After
---|---
![screen shot 2015-06-05 at 14 59 05](https://cloud.githubusercontent.com/assets/466546/8007411/8b523fe4-0b93-11e5-9b08-057639d698c4.png)|![screen shot 2015-06-05 at 14 59 13](https://cloud.githubusercontent.com/assets/466546/8007408/86551c0a-0b93-11e5-97ae-a92410e06b91.png)
