### PR TITLE
Enforces passing a Context via the DM Builder

### DIFF
--- a/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
+++ b/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         com.novoda.notils.logger.simple.Log.setShowLogs(true);
         setContentView(R.layout.activity_main);
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        downloadManager = DownloadManagerBuilder.create()
+        downloadManager = DownloadManagerBuilder.from(this)
                 .withVerboseLogging()
                 .build(getContentResolver());
 
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
     private void setupDownloadingExample() {
         Uri uri = Uri.parse(BIG_FILE);
         final Request request = new Request(uri);
-        request.setDestinationInInternalFilesDir(this, Environment.DIRECTORY_MOVIES, "podcast.mp3");
+        request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "podcast.mp3");
         request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
         request.setBigPictureUrl(BBC_COMEDY_IMAGE);
         request.setTitle("BBC Innuendo Bingo");

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -30,7 +30,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         com.novoda.notils.logger.simple.Log.setShowLogs(true);
         setContentView(R.layout.activity_main);
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        downloadManager = DownloadManagerBuilder.create()
+        downloadManager = DownloadManagerBuilder.from(this)
                 .withVerboseLogging()
                 .build(getContentResolver());
 
@@ -41,7 +41,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
     private void setupDownloadingExample() {
         Uri uri = Uri.parse(BIG_FILE);
         final Request request = new Request(uri);
-        request.setDestinationInInternalFilesDir(this, Environment.DIRECTORY_MOVIES, "podcast.mp3");
+        request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "podcast.mp3");
         request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
         request.setBigPictureUrl(BBC_COMEDY_IMAGE);
         request.setTitle("BBC Innuendo Bingo");

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -1,19 +1,22 @@
 package com.novoda.downloadmanager;
 
 import android.content.ContentResolver;
+import android.content.Context;
 
 import com.novoda.downloadmanager.lib.DownloadManager;
 
 public class DownloadManagerBuilder {
 
+    private final Context context;
+
     private boolean verboseLogging;
 
-    DownloadManagerBuilder() {
-        // use the create method, Alex's favourite
+    DownloadManagerBuilder(Context context) {
+        this.context = context;
     }
 
-    public static DownloadManagerBuilder create() {
-        return new DownloadManagerBuilder();
+    public static DownloadManagerBuilder from(Context context) {
+        return new DownloadManagerBuilder(context.getApplicationContext());
     }
 
     public DownloadManagerBuilder withVerboseLogging() {
@@ -25,7 +28,7 @@ public class DownloadManagerBuilder {
         if (contentResolver == null) {
             throw new IllegalStateException("You must use a ContentResolver with the DownloadManager.");
         }
-        return new DownloadManager(contentResolver, verboseLogging);
+        return new DownloadManager(context, contentResolver, verboseLogging);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -324,13 +324,14 @@ public class DownloadManager {
 
     private Uri mBaseUri = Downloads.Impl.CONTENT_URI;
 
-    public DownloadManager(ContentResolver resolver) {
-        this(resolver, false);
+    public DownloadManager(Context context, ContentResolver resolver) {
+        this(context, resolver, false);
     }
 
-    public DownloadManager(ContentResolver contentResolver, boolean verboseLogging) {
+    public DownloadManager(Context context, ContentResolver contentResolver, boolean verboseLogging) {
         this.mResolver = contentResolver;
-        DownloadProvider.VERBOSE_LOGGING = verboseLogging;
+        GlobalState.setContext(context);
+        GlobalState.setVerboseLogging(verboseLogging);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -117,8 +117,6 @@ public final class DownloadProvider extends ContentProvider {
      */
     private static final int PUBLIC_DOWNLOAD_ID = 6;
 
-    public static boolean VERBOSE_LOGGING;
-
     static {
         sURIMatcher.addURI(AUTHORITY, "my_downloads", MY_DOWNLOADS);
         sURIMatcher.addURI(AUTHORITY, "my_downloads/#", MY_DOWNLOADS_ID);
@@ -855,7 +853,7 @@ public final class DownloadProvider extends ContentProvider {
             }
         }
 
-        if (VERBOSE_LOGGING) {
+        if (GlobalState.hasVerboseLogging()) {
             logVerboseQueryInfo(projection, selection, selectionArgs, sort, db);
         }
 
@@ -1139,7 +1137,7 @@ public final class DownloadProvider extends ContentProvider {
      */
     @Override
     public ParcelFileDescriptor openFile(Uri uri, String mode) throws FileNotFoundException {
-        if (VERBOSE_LOGGING) {
+        if (GlobalState.hasVerboseLogging()) {
             logVerboseOpenFileInfo(uri, mode);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -1221,29 +1221,28 @@ public final class DownloadProvider extends ContentProvider {
         }
     }
 
-    private static final void copyInteger(String key, ContentValues from, ContentValues to) {
+    private static void copyInteger(String key, ContentValues from, ContentValues to) {
         Integer i = from.getAsInteger(key);
         if (i != null) {
             to.put(key, i);
         }
     }
 
-    private static final void copyBoolean(String key, ContentValues from, ContentValues to) {
+    private static void copyBoolean(String key, ContentValues from, ContentValues to) {
         Boolean b = from.getAsBoolean(key);
         if (b != null) {
             to.put(key, b);
         }
     }
 
-    private static final void copyString(String key, ContentValues from, ContentValues to) {
+    private static void copyString(String key, ContentValues from, ContentValues to) {
         String s = from.getAsString(key);
         if (s != null) {
             to.put(key, s);
         }
     }
 
-    private static final void copyStringWithDefault(String key, ContentValues from,
-                                                    ContentValues to, String defaultValue) {
+    private static void copyStringWithDefault(String key, ContentValues from, ContentValues to, String defaultValue) {
         copyString(key, from, to);
         if (!to.containsKey(key)) {
             to.put(key, defaultValue);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/GlobalState.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/GlobalState.java
@@ -1,0 +1,25 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.Context;
+
+class GlobalState {
+
+    private static Context context;
+    private static boolean verboseLogging;
+
+    public static void setContext(Context context) {
+        GlobalState.context = context;
+    }
+
+    public static Context getContext() {
+        return context;
+    }
+
+    public static boolean hasVerboseLogging() {
+        return verboseLogging;
+    }
+
+    public static void setVerboseLogging(boolean verboseLogging) {
+        GlobalState.verboseLogging = verboseLogging;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -140,19 +140,16 @@ public class Request {
      * The downloaded file is not scanned by MediaScanner. But it can be
      * made scannable by calling {@link #allowScanningByMediaScanner()}.
      *
-     * @param context the {@link android.content.Context} to use in determining the external
-     *                files directory
      * @param dirType the directory type to pass to
-     *                {@link android.content.Context#getExternalFilesDir(String)}
+     *                {@link Context#getExternalFilesDir(String)}
      * @param subPath the path within the external directory, including the
      *                destination filename
      * @return this object
      * @throws IllegalStateException If the external storage directory
      *                               cannot be found or created.
      */
-    public Request setDestinationInExternalFilesDir(Context context, String dirType,
-                                                    String subPath) {
-        final File file = context.getExternalFilesDir(dirType);
+    public Request setDestinationInExternalFilesDir(String dirType, String subPath) {
+        final File file = GlobalState.getContext().getExternalFilesDir(dirType);
         if (file == null) {
             throw new IllegalStateException("Failed to get external storage files directory");
         } else if (file.exists()) {
@@ -176,21 +173,17 @@ public class Request {
      * The downloaded file is not scanned by MediaScanner. But it can be
      * made scannable by calling {@link #allowScanningByMediaScanner()}.
      *
-     * @param context the {@link android.content.Context} to use in determining the external
-     *                files directory
      * @param dirType the directory type to pass to
-     *                {@link android.content.Context#getExternalFilesDir(String)}
+     *                {@link Context#getExternalFilesDir(String)}
      * @param subPath the path within the external directory, including the
      *                destination filename
      * @return this object
      * @throws IllegalStateException If the external storage directory
      *                               cannot be found or created.
      */
-    public Request setDestinationInInternalFilesDir(Context context, String dirType, String subPath) {
-        final File file = new File(context.getFilesDir(), dirType);
-        if (file == null) {
-            throw new IllegalStateException("Failed to get external storage files directory");
-        } else if (file.exists()) {
+    public Request setDestinationInInternalFilesDir(String dirType, String subPath) {
+        final File file = new File(GlobalState.getContext().getFilesDir(), dirType);
+        if (file.exists()) {
             if (!file.isDirectory()) {
                 throw new IllegalStateException(file.getAbsolutePath() + " already exists and is not a directory");
             }


### PR DESCRIPTION
Enforces passing a Context via the DM Builder

This means we don't need to pass in a Context to create a Request
 
Note this is a BREAKING CHANGE! since we've changed the API but it is an improvement since it didn't make sense having to pass in the Context for each Request