### PR TITLE
Adds documentation for the new DownloadClientReadyChecker functionality

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -5,6 +5,11 @@ import android.content.Context;
 
 import com.novoda.downloadmanager.lib.DownloadManager;
 
+/**
+ * A client can specify whether the downloads are allowed to proceed by implementing
+ * {@link com.novoda.downloadmanager.lib.DownloadClientReadyChecker} on your Activity class
+ *
+ */
 public class DownloadManagerBuilder {
 
     private final Context context;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -7,7 +7,7 @@ import com.novoda.downloadmanager.lib.DownloadManager;
 
 /**
  * A client can specify whether the downloads are allowed to proceed by implementing
- * {@link com.novoda.downloadmanager.lib.DownloadClientReadyChecker} on your Activity class
+ * {@link com.novoda.downloadmanager.lib.DownloadClientReadyChecker} on your Application class
  *
  */
 public class DownloadManagerBuilder {


### PR DESCRIPTION
## Description of the task

We have a new feature that allows a client to tell the DownloadManager if a download can proceed or not.

This PR adds that information to the public DownloadManagerBuilder