### PR TITLE
Adds javadoc for documenting the method isAllowedToDownload

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadClientReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadClientReadyChecker.java
@@ -3,6 +3,9 @@ package com.novoda.downloadmanager.lib;
 public interface DownloadClientReadyChecker {
     Ready READY = new Ready();
 
+    /**
+     * Warning: This method is executed on a background thread
+     */
     boolean isAllowedToDownload();
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadClientReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadClientReadyChecker.java
@@ -4,7 +4,7 @@ public interface DownloadClientReadyChecker {
     Ready READY = new Ready();
 
     /**
-     * Warning: This method is executed on a background thread
+     * This method is executed on a background thread
      */
     boolean isAllowedToDownload();
 


### PR DESCRIPTION
## Description of the task

It is of relevance for the client to be aware of that the method `isAllowedToDownload` will be called from a background thread.

This task adds a Javadoc in order to document this fact to the public API