### PR TITLE
31 bug/serialised downloads dont show as queued

### DIFF
--- a/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
+++ b/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
     private static final String TAG = MainActivity.class.getSimpleName();
-    private static final String BIG_FILE = "http://open.live.bbc.co.uk/mediaselector/5/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p02ss0fm.mp3";
+    private static final String BIG_FILE = "http://ipv4.download.thinkbroadband.com/200MB.zip";
     private static final String BBC_COMEDY_IMAGE = "http://ichef.bbci.co.uk/images/ic/640x360/p02ss0cf.jpg";
 
     private DownloadManager downloadManager;

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
     private static final String TAG = MainActivity.class.getSimpleName();
-    private static final String BIG_FILE = "http://open.live.bbc.co.uk/mediaselector/5/redir/version/2.0/mediaset/audio-nondrm-download/proto/http/vpid/p02ss0fm.mp3";
+    private static final String BIG_FILE = "http://ipv4.download.thinkbroadband.com/200MB.zip";
     private static final String BBC_COMEDY_IMAGE = "http://ichef.bbci.co.uk/images/ic/640x360/p02ss0cf.jpg";
 
     private DownloadManager downloadManager;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -476,11 +476,19 @@ class DownloadInfo {
         synchronized (this) {
             final boolean isActive = mSubmittedTask != null && !mSubmittedTask.isDone();
             if (!isActive) {
+                updateStatus(DownloadManager.STATUS_PENDING);
                 mTask = new DownloadThread(mContext, mSystemFacade, this, mStorageManager, mNotifier);
                 mSubmittedTask = executor.submit(mTask);
             }
             return isActive;
         }
+    }
+
+    public void updateStatus(int status) {
+        mStatus = status;
+        getDownloadStatusContentValues().clear();
+        getDownloadStatusContentValues().put(Downloads.Impl.COLUMN_STATUS, mStatus);
+        mContext.getContentResolver().update(getAllDownloadsUri(), getDownloadStatusContentValues(), null, null);
     }
 
     private boolean isClientReadyToDownload() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -27,10 +27,6 @@ import java.util.concurrent.Future;
 class DownloadInfo {
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
 
-    public ContentValues getDownloadStatusContentValues() {
-        return downloadStatusContentValues;
-    }
-
     // TODO: move towards these in-memory objects being sources of truth, and
 
     // periodically pushing to provider.
@@ -486,9 +482,9 @@ class DownloadInfo {
 
     public void updateStatus(int status) {
         mStatus = status;
-        getDownloadStatusContentValues().clear();
-        getDownloadStatusContentValues().put(Downloads.Impl.COLUMN_STATUS, mStatus);
-        mContext.getContentResolver().update(getAllDownloadsUri(), getDownloadStatusContentValues(), null, null);
+        downloadStatusContentValues.clear();
+        downloadStatusContentValues.put(Downloads.Impl.COLUMN_STATUS, mStatus);
+        mContext.getContentResolver().update(getAllDownloadsUri(), downloadStatusContentValues, null, null);
     }
 
     private boolean isClientReadyToDownload() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -27,6 +27,10 @@ import java.util.concurrent.Future;
 class DownloadInfo {
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
 
+    public ContentValues getDownloadStatusContentValues() {
+        return downloadStatusContentValues;
+    }
+
     // TODO: move towards these in-memory objects being sources of truth, and
 
     // periodically pushing to provider.
@@ -472,13 +476,6 @@ class DownloadInfo {
         synchronized (this) {
             final boolean isActive = mSubmittedTask != null && !mSubmittedTask.isDone();
             if (!isActive) {
-                if (mStatus != Downloads.Impl.STATUS_RUNNING) {
-                    mStatus = Downloads.Impl.STATUS_RUNNING;
-                    downloadStatusContentValues.clear();
-                    downloadStatusContentValues.put(Downloads.Impl.COLUMN_STATUS, mStatus);
-                    mContext.getContentResolver().update(getAllDownloadsUri(), downloadStatusContentValues, null, null);
-                }
-
                 mTask = new DownloadThread(mContext, mSystemFacade, this, mStorageManager, mNotifier);
                 mSubmittedTask = executor.submit(mTask);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -165,10 +165,7 @@ class DownloadThread implements Runnable {
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
         try {
             if (mInfo.mStatus != Downloads.Impl.STATUS_RUNNING) {
-                mInfo.mStatus = Downloads.Impl.STATUS_RUNNING;
-                mInfo.getDownloadStatusContentValues().clear();
-                mInfo.getDownloadStatusContentValues().put(Downloads.Impl.COLUMN_STATUS, mInfo.mStatus);
-                mContext.getContentResolver().update(mInfo.getAllDownloadsUri(), mInfo.getDownloadStatusContentValues(), null, null);
+                mInfo.updateStatus(DownloadManager.STATUS_RUNNING);
             }
             runInternal();
         } finally {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -164,6 +164,12 @@ class DownloadThread implements Runnable {
     public void run() {
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND);
         try {
+            if (mInfo.mStatus != Downloads.Impl.STATUS_RUNNING) {
+                mInfo.mStatus = Downloads.Impl.STATUS_RUNNING;
+                mInfo.getDownloadStatusContentValues().clear();
+                mInfo.getDownloadStatusContentValues().put(Downloads.Impl.COLUMN_STATUS, mInfo.mStatus);
+                mContext.getContentResolver().update(mInfo.getAllDownloadsUri(), mInfo.getDownloadStatusContentValues(), null, null);
+            }
             runInternal();
         } finally {
             mNotifier.notifyDownloadSpeed(mInfo.mId, 0);
@@ -353,7 +359,9 @@ class DownloadThread implements Runnable {
                 throw new StopRequestException(STATUS_HTTP_DATA_ERROR, e);
 
             } finally {
-                if (conn != null) conn.disconnect();
+                if (conn != null) {
+                    conn.disconnect();
+                }
             }
         }
 


### PR DESCRIPTION
Downloads were being set to `RUNNING` before they were actually ran by the Executor service, this PR now applies the RUNNING status in the `runnable run()` instead of when the task is submitted.

Submitted tasks are set to `PENDING` no gif since the demo project isn't loading for me (or @Electryc even on master) but works fine in our external project, gotta have faith!

**SIDEEFFECT -** 
this causes the serialised notification to no longer be stacked, no affect on parallel (this behaviour matches play music)