### PR TITLE
Handle batch failures, cancellation and notifications

### DIFF
--- a/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
+++ b/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
@@ -11,9 +11,9 @@ import android.widget.ListView;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
 import com.novoda.downloadmanager.lib.DownloadManager;
+import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
-import com.novoda.downloadmanager.lib.RequestBatch;
 
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         Uri uri = Uri.parse(BIG_FILE);
         final Request request = new Request(uri);
         request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "penguins.dat");
-        request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
         request.setTitle("Family of Penguins");
         request.setDescription("These are not the beards you're looking for");
         request.setBigPictureUrl(PENGUINS_IMAGE);

--- a/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
+++ b/demo_parallel/src/main/java/com/novoda/downloadmanager/demo/parallel/MainActivity.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager.demo.parallel;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -42,17 +43,17 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
 
     private void setupDownloadingExample() {
         Uri uri = Uri.parse(BIG_FILE);
-        final Request request = new Request(uri);
-        request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "penguins.dat");
-        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
-        request.setTitle("Family of Penguins");
-        request.setDescription("These are not the beards you're looking for");
-        request.setBigPictureUrl(PENGUINS_IMAGE);
+        final Request request = new Request(uri)
+                .setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "penguins.dat")
+                .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE)
+                .setTitle("Family of Penguins")
+                .setDescription("These are not the beards you're looking for")
+                .setBigPictureUrl(PENGUINS_IMAGE);
 
         findViewById(R.id.main_download_button).setOnClickListener(
                 new View.OnClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onClick(@NonNull View v) {
                         long requestId = downloadManager.enqueue(request);
                         Log.d(TAG, "Download starting with id: " + requestId);
                     }
@@ -60,15 +61,19 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
     }
 
     private void setupQueryingExample() {
-        QueryForDownloadsAsyncTask.newInstance(downloadManager, this).execute(new Query());
+        queryForDownloads();
         findViewById(R.id.main_refresh_button).setOnClickListener(
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        QueryForDownloadsAsyncTask.newInstance(downloadManager, MainActivity.this).execute(new Query());
+                        queryForDownloads();
                     }
                 });
         listView.setEmptyView(findViewById(R.id.main_no_downloads_view));
+    }
+
+    private void queryForDownloads() {
+        QueryForDownloadsAsyncTask.newInstance(downloadManager, MainActivity.this).execute(new Query());
     }
 
     @Override

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
     private static final String TAG = MainActivity.class.getSimpleName();
-    private static final String BIG_FILE = "http://download.thinkbroadband.com/100MB.zip";
+    private static final String BIG_FILE = "http://download.thinkbroadband.com/10MB.zip";
     private static final String BEARD_IMAGE = "http://i.imgur.com/9JL2QVl.jpg";
 
     private DownloadManager downloadManager;

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
     private static final String TAG = MainActivity.class.getSimpleName();
-    private static final String BIG_FILE = "http://download.thinkbroadband.com/10MB.zip";
+    private static final String BIG_FILE = "http://download.thinkbroadband.com/50MB.zip";
     private static final String BEARD_IMAGE = "http://i.imgur.com/9JL2QVl.jpg";
 
     private DownloadManager downloadManager;

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -61,9 +61,9 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         final Request request = new Request(uri)
                 .setTitle("A Single Beard")
                 .setDescription("Fine facial hair")
-                .setBigPictureUrl(BEARD_IMAGE);
-        request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "example.beard");
-        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
+                .setBigPictureUrl(BEARD_IMAGE)
+                .setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "example.beard")
+                .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
 
         long requestId = downloadManager.enqueue(request);
         Log.d(TAG, "Download enqueued with request ID: " + requestId);
@@ -74,12 +74,12 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
                 .withTitle("Large Beard Shipment")
                 .withDescription("Goatees galore")
                 .withBigPictureUrl(BEARD_IMAGE)
+                .withVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE)
                 .build();
 
         Uri uri = Uri.parse(BIG_FILE);
         final Request request = new Request(uri);
         request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "beard.shipment");
-        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
         request.setExtra("beard_1");
 
         batch.addRequest(request);

--- a/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
+++ b/demo_serial/src/main/java/com/novoda/downloadmanager/demo/serial/MainActivity.java
@@ -12,6 +12,7 @@ import android.widget.ListView;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
 import com.novoda.downloadmanager.lib.DownloadManager;
+import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
 import com.novoda.downloadmanager.lib.RequestBatch;
@@ -62,7 +63,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
                 .setDescription("Fine facial hair")
                 .setBigPictureUrl(BEARD_IMAGE);
         request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "example.beard");
-        request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
 
         long requestId = downloadManager.enqueue(request);
         Log.d(TAG, "Download enqueued with request ID: " + requestId);
@@ -78,7 +79,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         Uri uri = Uri.parse(BIG_FILE);
         final Request request = new Request(uri);
         request.setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "beard.shipment");
-        request.setNotificationVisibility(Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+        request.setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
         request.setExtra("beard_1");
 
         batch.addRequest(request);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/ActiveBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/ActiveBatch.java
@@ -1,0 +1,34 @@
+package com.novoda.downloadmanager.lib;
+
+import java.util.List;
+
+class ActiveBatch {
+
+    private final long batchId;
+    private final BatchInfo info;
+    private final List<DownloadInfo> downloads;
+    private final int status;
+
+    public ActiveBatch(long batchId, BatchInfo info, List<DownloadInfo> downloads, int status) {
+        this.batchId = batchId;
+        this.info = info;
+        this.downloads = downloads;
+        this.status = status;
+    }
+
+    public long getBatchId() {
+        return batchId;
+    }
+
+    public BatchInfo getInfo() {
+        return info;
+    }
+
+    public List<DownloadInfo> getDownloads() {
+        return downloads;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
@@ -4,11 +4,14 @@ class BatchInfo {
     private final String title;
     private final String description;
     private final String bigPictureUrl;
+    @NotificationVisibility.Value
+    private final int visibility;
 
-    public BatchInfo(String title, String description, String bigPictureUrl) {
+    public BatchInfo(String title, String description, String bigPictureUrl, @NotificationVisibility.Value int visibility) {
         this.title = title;
         this.description = description;
         this.bigPictureUrl = bigPictureUrl;
+        this.visibility = visibility;
     }
 
     public String getTitle() {
@@ -21,5 +24,10 @@ class BatchInfo {
 
     public String getBigPictureUrl() {
         return bigPictureUrl;
+    }
+
+    @NotificationVisibility.Value
+    public int getVisibility() {
+        return visibility;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
@@ -13,23 +13,6 @@ import static com.novoda.downloadmanager.lib.Downloads.Impl.*;
 class BatchStatusUpdater {
 
     private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
-            // Failed
-            STATUS_INSUFFICIENT_SPACE_ERROR,
-            STATUS_DEVICE_NOT_FOUND_ERROR,
-            STATUS_BAD_REQUEST,
-            STATUS_NOT_ACCEPTABLE,
-            STATUS_LENGTH_REQUIRED,
-            STATUS_PRECONDITION_FAILED,
-            STATUS_FILE_ALREADY_EXISTS_ERROR,
-            STATUS_CANNOT_RESUME,
-            STATUS_UNKNOWN_ERROR,
-            STATUS_FILE_ERROR,
-            STATUS_UNHANDLED_REDIRECT,
-            STATUS_UNHANDLED_HTTP_CODE,
-            STATUS_HTTP_DATA_ERROR,
-            STATUS_HTTP_EXCEPTION,
-            STATUS_TOO_MANY_REDIRECTS,
-
             // Cancelled
             STATUS_CANCELED,
 
@@ -80,6 +63,14 @@ class BatchStatusUpdater {
                 statusCounts.put(status, statusCounts.get(status) + 1);
             }
 
+            // check for error statuses first
+            for (int i = 0; i < statusCounts.size(); i++) {
+                int statusCode = statusCounts.keyAt(i);
+                if (Downloads.Impl.isStatusError(statusCode) && statusCounts.get(statusCode) > 0) {
+                    return statusCode;
+                }
+            }
+
             for (Integer status : PRIORITISED_STATUSES) {
                 if (statusCounts.get(status) > 0) {
                     return status;
@@ -94,5 +85,4 @@ class BatchStatusUpdater {
             }
         }
     }
-
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
@@ -13,22 +13,16 @@ import static com.novoda.downloadmanager.lib.Downloads.Impl.*;
 class BatchStatusUpdater {
 
     private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
-            // Cancelled
             STATUS_CANCELED,
-
-            // Running
             STATUS_RUNNING,
 
-            // Paused
+            // Paused statuses
             STATUS_PAUSED_BY_APP,
             STATUS_WAITING_TO_RETRY,
             STATUS_WAITING_FOR_NETWORK,
             STATUS_QUEUED_FOR_WIFI,
 
-            // Pending
             STATUS_PENDING,
-
-            // Success
             STATUS_SUCCESS
     );
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusUpdater.java
@@ -1,0 +1,98 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.util.SparseIntArray;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.novoda.downloadmanager.lib.Downloads.Impl.*;
+
+class BatchStatusUpdater {
+
+    private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
+            // Failed
+            STATUS_INSUFFICIENT_SPACE_ERROR,
+            STATUS_DEVICE_NOT_FOUND_ERROR,
+            STATUS_BAD_REQUEST,
+            STATUS_NOT_ACCEPTABLE,
+            STATUS_LENGTH_REQUIRED,
+            STATUS_PRECONDITION_FAILED,
+            STATUS_FILE_ALREADY_EXISTS_ERROR,
+            STATUS_CANNOT_RESUME,
+            STATUS_UNKNOWN_ERROR,
+            STATUS_FILE_ERROR,
+            STATUS_UNHANDLED_REDIRECT,
+            STATUS_UNHANDLED_HTTP_CODE,
+            STATUS_HTTP_DATA_ERROR,
+            STATUS_HTTP_EXCEPTION,
+            STATUS_TOO_MANY_REDIRECTS,
+
+            // Cancelled
+            STATUS_CANCELED,
+
+            // Running
+            STATUS_RUNNING,
+
+            // Paused
+            STATUS_PAUSED_BY_APP,
+            STATUS_WAITING_TO_RETRY,
+            STATUS_WAITING_FOR_NETWORK,
+            STATUS_QUEUED_FOR_WIFI,
+
+            // Pending
+            STATUS_PENDING,
+
+            // Success
+            STATUS_SUCCESS
+    );
+
+    private final ContentResolver resolver;
+
+    public BatchStatusUpdater(ContentResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    void updateBatchStatus(long batchId, int status) {
+        ContentValues values = new ContentValues();
+        values.put(Batches.COLUMN_STATUS, status);
+        resolver.update(BATCH_CONTENT_URI, values, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
+    }
+
+    int getBatchStatus(long batchId) {
+        Cursor cursor = null;
+        try {
+            String[] selectionArgs = {String.valueOf(batchId)};
+            cursor = resolver.query(ALL_DOWNLOADS_CONTENT_URI,
+                    null,
+                    COLUMN_BATCH_ID + " = ?",
+                    selectionArgs,
+                    null);
+
+            int statusColumnIndex = cursor.getColumnIndexOrThrow(COLUMN_STATUS);
+
+            SparseIntArray statusCounts = new SparseIntArray();
+
+            while (cursor.moveToNext()) {
+                int status = cursor.getInt(statusColumnIndex);
+                statusCounts.put(status, statusCounts.get(status) + 1);
+            }
+
+            for (Integer status : PRIORITISED_STATUSES) {
+                if (statusCounts.get(status) > 0) {
+                    return status;
+                }
+            }
+
+            return STATUS_UNKNOWN_ERROR;
+
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -134,7 +134,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         Downloads.Impl.Batches.COLUMN_TITLE + " TEXT NOT NULL," +
                         Downloads.Impl.Batches.COLUMN_DESCRIPTION + " TEXT NOT NULL," +
                         Downloads.Impl.Batches.COLUMN_BIG_PICTURE + " TEXT NOT NULL," +
-                        Downloads.Impl.Batches.COLUMN_STATUS + " INTEGER" +
+                        Downloads.Impl.Batches.COLUMN_STATUS + " INTEGER," +
+                        Downloads.Impl.Batches.COLUMN_VISIBILITY + " INTEGER" +
                         ");");
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -133,7 +133,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         Downloads.Impl.Batches._ID + " INTEGER PRIMARY KEY AUTOINCREMENT," +
                         Downloads.Impl.Batches.COLUMN_TITLE + " TEXT NOT NULL," +
                         Downloads.Impl.Batches.COLUMN_DESCRIPTION + " TEXT NOT NULL," +
-                        Downloads.Impl.Batches.COLUMN_BIG_PICTURE + " TEXT NOT NULL" +
+                        Downloads.Impl.Batches.COLUMN_BIG_PICTURE + " TEXT NOT NULL," +
+                        Downloads.Impl.Batches.COLUMN_STATUS + " INTEGER" +
                         ");");
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadBatch.java
@@ -2,14 +2,14 @@ package com.novoda.downloadmanager.lib;
 
 import java.util.List;
 
-class ActiveBatch {
+class DownloadBatch {
 
     private final long batchId;
     private final BatchInfo info;
     private final List<DownloadInfo> downloads;
     private final int status;
 
-    public ActiveBatch(long batchId, BatchInfo info, List<DownloadInfo> downloads, int status) {
+    public DownloadBatch(long batchId, BatchInfo info, List<DownloadInfo> downloads, int status) {
         this.batchId = batchId;
         this.info = info;
         this.downloads = downloads;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Future;
  */
 class DownloadInfo {
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
+    private static final int UNKNOWN_BYTES = -1;
 
     // TODO: move towards these in-memory objects being sources of truth, and
 
@@ -584,5 +585,9 @@ class DownloadInfo {
         } finally {
             cursor.close();
         }
+    }
+
+    public boolean hasTotalBytes() {
+        return mTotalBytes != UNKNOWN_BYTES;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -472,7 +472,6 @@ class DownloadInfo {
         synchronized (this) {
             final boolean isActive = mSubmittedTask != null && !mSubmittedTask.isDone();
             if (!isActive) {
-                updateStatus(Downloads.Impl.STATUS_PENDING);
                 DownloadThread downloadThread = new DownloadThread(mContext, mSystemFacade, this, mStorageManager, mNotifier);
                 mSubmittedTask = executor.submit(downloadThread);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -13,6 +13,8 @@ import android.os.Environment;
 import android.text.TextUtils;
 import android.util.Pair;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -470,10 +472,13 @@ class DownloadInfo {
 
     public boolean startDownloadIfNotActive(ExecutorService executor) {
         synchronized (this) {
-            final boolean isActive = mSubmittedTask != null && !mSubmittedTask.isDone();
-            if (!isActive) {
+            boolean isActive;
+            if (mSubmittedTask == null) {
                 DownloadThread downloadThread = new DownloadThread(mContext, mSystemFacade, this, mStorageManager, mNotifier);
                 mSubmittedTask = executor.submit(downloadThread);
+                isActive = true;
+            } else {
+                isActive = !mSubmittedTask.isDone();
             }
             return isActive;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -352,7 +352,7 @@ class DownloadInfo {
         if (!Downloads.Impl.isStatusCompleted(mStatus)) {
             return false;
         }
-        if (mVisibility == Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED) {
+        if (mVisibility == NotificationVisibility.ACTIVE_OR_COMPLETE) {
             return true;
         }
         return false;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -352,7 +352,7 @@ class DownloadInfo {
         if (!Downloads.Impl.isStatusCompleted(mStatus)) {
             return false;
         }
-        if (mVisibility == Downloads.Impl.VISIBILITY_VISIBLE_NOTIFY_COMPLETED) {
+        if (mVisibility == Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED) {
             return true;
         }
         return false;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -13,8 +13,6 @@ import android.os.Environment;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -644,7 +644,7 @@ public class DownloadManager {
         values.put(Downloads.Impl.COLUMN_MEDIA_SCANNED, (isMediaScannerScannable) ? Request.SCANNABLE_VALUE_YES : Request.SCANNABLE_VALUE_NO);
         values.put(
                 Downloads.Impl.COLUMN_VISIBILITY, (showNotification) ?
-                        Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION : Request.VISIBILITY_HIDDEN);
+                        NotificationVisibility.ONLY_WHEN_COMPLETE : NotificationVisibility.HIDDEN);
         Uri downloadUri = mResolver.insert(Downloads.Impl.CONTENT_URI, values);
         if (downloadUri == null) {
             return -1;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -714,6 +714,7 @@ public class DownloadManager {
 
     private long insert(RequestBatch batch) {
         ContentValues values = batch.toContentValues();
+        values.put(Downloads.Impl.Batches.COLUMN_STATUS, Downloads.Impl.STATUS_PENDING);
         Uri batchUri = mResolver.insert(Downloads.Impl.BATCH_CONTENT_URI, values);
         return ContentUris.parseId(batchUri);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -185,17 +185,17 @@ class DownloadNotifier {
     }
 
     private void showNotificationPerCluster(Map<String, List<DownloadBatch>> clusters) {
-        for (String tag : clusters.keySet()) {
-            int type = getNotificationTagType(tag);
-            List<DownloadBatch> cluster = clusters.get(tag);
+        for (String notificationId : clusters.keySet()) {
+            int type = getNotificationTagType(notificationId);
+            List<DownloadBatch> cluster = clusters.get(notificationId);
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext);
-            useTimeWhenClusterFirstShownToAvoidShuffling(tag, builder);
+            useTimeWhenClusterFirstShownToAvoidShuffling(notificationId, builder);
             buildIcon(type, builder);
-            buildActionIntents(tag, type, cluster, builder);
+            buildActionIntents(notificationId, type, cluster, builder);
 
             Notification notification = buildTitlesAndDescription(type, cluster, builder);
-            mNotifManager.notify(tag.hashCode(), notification);
+            mNotifManager.notify(notificationId.hashCode(), notification);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -290,7 +290,7 @@ class DownloadNotifier {
             synchronized (mDownloadSpeed) {
                 for (DownloadBatch batch : cluster) {
                     for (DownloadInfo info : batch.getDownloads()) {
-                        if (info.mTotalBytes != -1) {
+                        if (info.hasTotalBytes()) {
                             currentBytes += info.mCurrentBytes;
                             totalBytes += info.mTotalBytes;
                             Long bytesPerSecond = mDownloadSpeed.get(info.mId);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -80,14 +80,6 @@ class DownloadNotifier {
     // LongSparseLongArray
     private final LongSparseArray<Long> mDownloadSpeed = new LongSparseArray<>();
 
-    /**
-     * Last time speed was reproted, mapped from {@link DownloadInfo#batchId} to
-     * {@link SystemClock#elapsedRealtime()}.
-     */
-//    @GuardedBy("mDownloadSpeed")
-    // LongSparseLongArray
-    private final LongSparseArray<Long> mDownloadTouch = new LongSparseArray<>();
-
     private final Resources resources;
 
     public DownloadNotifier(Context context, NotificationImageRetriever imageRetriever, Resources resources) {
@@ -109,10 +101,8 @@ class DownloadNotifier {
         synchronized (mDownloadSpeed) {
             if (bytesPerSecond != 0) {
                 mDownloadSpeed.put(id, bytesPerSecond);
-                mDownloadTouch.put(id, SystemClock.elapsedRealtime());
             } else {
                 mDownloadSpeed.remove(id);
-                mDownloadTouch.remove(id);
             }
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -43,8 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.novoda.downloadmanager.lib.Request.*;
-
 /**
  * Update {@link NotificationManager} to reflect current {@link DownloadInfo}
  * states. Collapses similar downloads into a single notification, and builds
@@ -464,8 +462,8 @@ class DownloadNotifier {
     private static boolean areAnyFailedAndVisible(List<DownloadInfo> downloads) {
         for (DownloadInfo download : downloads) {
             boolean isFailed = Downloads.Impl.isStatusError(download.mStatus) && !Downloads.Impl.isStatusCancelled(download.mStatus);
-            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION
-                    || download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
+            boolean isVisible = download.mVisibility == NotificationVisibility.ONLY_WHEN_COMPLETE
+                    || download.mVisibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
             if (isFailed && isVisible) {
                 return true;
             }
@@ -476,8 +474,8 @@ class DownloadNotifier {
     private static boolean areAnyCancelledAndVisible(List<DownloadInfo> downloads) {
         for (DownloadInfo download : downloads) {
             boolean isCancelled = Downloads.Impl.isStatusCancelled(download.mStatus);
-            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION
-                    || download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
+            boolean isVisible = download.mVisibility == NotificationVisibility.ONLY_WHEN_COMPLETE
+                    || download.mVisibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
             if (isCancelled && isVisible) {
                 return true;
             }
@@ -488,8 +486,8 @@ class DownloadNotifier {
     private static boolean areAnyActiveAndVisible(List<DownloadInfo> downloads) {
         for (DownloadInfo download : downloads) {
             boolean isActive = download.mStatus == Downloads.Impl.STATUS_RUNNING;
-            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE
-                    || download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
+            boolean isVisible = download.mVisibility == NotificationVisibility.ONLY_WHEN_ACTIVE
+                    || download.mVisibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
             if (isActive && isVisible) {
                 return true;
             }
@@ -501,8 +499,8 @@ class DownloadNotifier {
     private static boolean areAllSuccessfulAndVisible(List<DownloadInfo> downloads) {
         for (DownloadInfo download : downloads) {
             boolean isSuccessful = Downloads.Impl.isStatusSuccess(download.mStatus);
-            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION
-                    || download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
+            boolean isVisible = download.mVisibility == NotificationVisibility.ONLY_WHEN_COMPLETE
+                    || download.mVisibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
             if (!(isSuccessful && isVisible)) {
                 return false;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -243,8 +243,8 @@ class DownloadNotifier {
             builder.setOngoing(true);
 
             DownloadInfo info = cluster.iterator().next();
-            uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, info.mId);
-            Intent cancelIntent = new Intent(Constants.ACTION_CANCEL, uri, mContext, DownloadReceiver.class);
+            Intent cancelIntent = new Intent(Constants.ACTION_CANCEL, null, mContext, DownloadReceiver.class);
+            cancelIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, info.batchId);
             PendingIntent pendingCancelIntent = PendingIntent.getBroadcast(mContext, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT);
             builder.addAction(R.drawable.dl__ic_action_cancel, "Cancel", pendingCancelIntent);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -16,7 +16,6 @@
 
 package com.novoda.downloadmanager.lib;
 
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -26,7 +25,6 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.Build;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
@@ -125,17 +123,12 @@ class DownloadNotifier {
      */
     public void updateWith(List<ActiveBatch> batches) {
         synchronized (mActiveNotifs) {
-            updateWithLocked(batches);
+            Map<String, List<ActiveBatch>> clusters = getClustersByNotificationTag(batches);
+
+            showNotificationPerCluster(clusters);
+
+            removeStaleTagsThatWereNotRenewed(clusters);
         }
-    }
-
-    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    private void updateWithLocked(List<ActiveBatch> batches) {
-        Map<String, List<ActiveBatch>> clusters = getClustersByNotificationTag(batches);
-
-        showNotificationPerCluster(clusters);
-
-        removeStaleTagsThatWereNotRenewed(clusters);
     }
 
     private void showNotificationPerCluster(Map<String, List<ActiveBatch>> clusters) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -25,7 +25,6 @@ import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.net.Uri;
-import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.util.LongSparseArray;
@@ -126,7 +125,7 @@ class DownloadNotifier {
         Map<String, List<ActiveBatch>> clustered = new HashMap<>();
 
         for (ActiveBatch batch : batches) {
-            final String tag = buildNotificationTag(batch);
+            String tag = buildNotificationTag(batch);
 
             addBatchToCluster(tag, clustered, batch);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -267,9 +267,11 @@ class DownloadNotifier {
 
             final Intent intent = new Intent(action, uri, mContext, DownloadReceiver.class);
             intent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, getDownloadIds(cluster));
+            intent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
             builder.setContentIntent(PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT));
 
             final Intent hideIntent = new Intent(Constants.ACTION_HIDE, uri, mContext, DownloadReceiver.class);
+            hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
             builder.setDeleteIntent(PendingIntent.getBroadcast(mContext, 0, hideIntent, 0));
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -488,7 +488,7 @@ class DownloadNotifier {
     private static boolean areAnyActiveAndVisible(List<DownloadInfo> downloads) {
         for (DownloadInfo download : downloads) {
             boolean isActive = download.mStatus == Downloads.Impl.STATUS_RUNNING;
-            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE
+            boolean isVisible = download.mVisibility == VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE
                     || download.mVisibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
             if (isActive && isVisible) {
                 return true;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -64,7 +64,7 @@ class DownloadNotifier {
      * Currently active notifications, mapped from clustering tag to timestamp
      * when first shown.
      *
-     * @see #buildNotificationTag(ActiveBatch)
+     * @see #buildNotificationTag(DownloadBatch)
      */
 //    @GuardedBy("mActiveNotifs")
     private final HashMap<String, Long> mActiveNotifs = new HashMap<>();
@@ -108,9 +108,9 @@ class DownloadNotifier {
      * Update {@link NotificationManager} to reflect the given set of
      * {@link DownloadInfo}, adding, collapsing, and removing as needed.
      */
-    public void updateWith(List<ActiveBatch> batches) {
+    public void updateWith(List<DownloadBatch> batches) {
         synchronized (mActiveNotifs) {
-            Map<String, List<ActiveBatch>> clusters = getClustersByNotificationTag(batches);
+            Map<String, List<DownloadBatch>> clusters = getClustersByNotificationTag(batches);
 
             showNotificationPerCluster(clusters);
 
@@ -119,10 +119,10 @@ class DownloadNotifier {
     }
 
     @NonNull
-    private Map<String, List<ActiveBatch>> getClustersByNotificationTag(List<ActiveBatch> batches) {
-        Map<String, List<ActiveBatch>> clustered = new HashMap<>();
+    private Map<String, List<DownloadBatch>> getClustersByNotificationTag(List<DownloadBatch> batches) {
+        Map<String, List<DownloadBatch>> clustered = new HashMap<>();
 
-        for (ActiveBatch batch : batches) {
+        for (DownloadBatch batch : batches) {
             String tag = buildNotificationTag(batch);
 
             addBatchToCluster(tag, clustered, batch);
@@ -135,7 +135,7 @@ class DownloadNotifier {
      * Build tag used for collapsing several {@link DownloadInfo} into a single
      * {@link Notification}.
      */
-    private String buildNotificationTag(ActiveBatch batch) {
+    private String buildNotificationTag(DownloadBatch batch) {
         int status = batch.getStatus();
         int visibility = batch.getInfo().getVisibility();
         if (status == Downloads.Impl.STATUS_QUEUED_FOR_WIFI) {
@@ -167,12 +167,12 @@ class DownloadNotifier {
                 || visibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
     }
 
-    private void addBatchToCluster(String tag, Map<String, List<ActiveBatch>> cluster, ActiveBatch batch) {
+    private void addBatchToCluster(String tag, Map<String, List<DownloadBatch>> cluster, DownloadBatch batch) {
         if (tag == null) {
             return;
         }
 
-        List<ActiveBatch> batches;
+        List<DownloadBatch> batches;
 
         if (cluster.containsKey(tag)) {
             batches = cluster.get(tag);
@@ -184,10 +184,10 @@ class DownloadNotifier {
         batches.add(batch);
     }
 
-    private void showNotificationPerCluster(Map<String, List<ActiveBatch>> clusters) {
+    private void showNotificationPerCluster(Map<String, List<DownloadBatch>> clusters) {
         for (String tag : clusters.keySet()) {
             int type = getNotificationTagType(tag);
-            List<ActiveBatch> cluster = clusters.get(tag);
+            List<DownloadBatch> cluster = clusters.get(tag);
 
             NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext);
             useTimeWhenClusterFirstShownToAvoidShuffling(tag, builder);
@@ -201,7 +201,7 @@ class DownloadNotifier {
 
     /**
      * Return the cluster type of the given as created by
-     * {@link #buildNotificationTag(ActiveBatch)}.
+     * {@link #buildNotificationTag(DownloadBatch)}.
      */
     private static int getNotificationTagType(String tag) {
         return Integer.parseInt(tag.substring(0, tag.indexOf(':')));
@@ -236,7 +236,7 @@ class DownloadNotifier {
         }
     }
 
-    private void buildActionIntents(String tag, int type, List<ActiveBatch> cluster, NotificationCompat.Builder builder) {
+    private void buildActionIntents(String tag, int type, List<DownloadBatch> cluster, NotificationCompat.Builder builder) {
         if (type == TYPE_ACTIVE || type == TYPE_WAITING) {
             // build a synthetic uri for intent identification purposes
             Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
@@ -245,14 +245,14 @@ class DownloadNotifier {
             builder.setContentIntent(PendingIntent.getBroadcast(mContext, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             builder.setOngoing(true);
 
-            ActiveBatch batch = cluster.iterator().next();
+            DownloadBatch batch = cluster.iterator().next();
             Intent cancelIntent = new Intent(Constants.ACTION_CANCEL, null, mContext, DownloadReceiver.class);
             cancelIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
             PendingIntent pendingCancelIntent = PendingIntent.getBroadcast(mContext, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT);
             builder.addAction(R.drawable.dl__ic_action_cancel, "Cancel", pendingCancelIntent);
 
         } else if (type == TYPE_SUCCESS) {
-            ActiveBatch batch = cluster.iterator().next();
+            DownloadBatch batch = cluster.iterator().next();
             // TODO: Decide how we handle notification clicks
             DownloadInfo downloadInfo = batch.getDownloads().get(0);
             Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, downloadInfo.mId);
@@ -278,7 +278,7 @@ class DownloadNotifier {
 
     private Notification buildTitlesAndDescription(
             int type,
-            List<ActiveBatch> cluster,
+            List<DownloadBatch> cluster,
             NotificationCompat.Builder builder) {
 
         String remainingText = null;
@@ -288,7 +288,7 @@ class DownloadNotifier {
             long totalBytes = 0;
             long totalBytesPerSecond = 0;
             synchronized (mDownloadSpeed) {
-                for (ActiveBatch batch : cluster) {
+                for (DownloadBatch batch : cluster) {
                     for (DownloadInfo info : batch.getDownloads()) {
                         if (info.mTotalBytes != -1) {
                             currentBytes += info.mCurrentBytes;
@@ -317,13 +317,13 @@ class DownloadNotifier {
             }
         }
 
-        Set<ActiveBatch> currentBatches = new HashSet<>();
-        for (ActiveBatch batch : cluster) {
+        Set<DownloadBatch> currentBatches = new HashSet<>();
+        for (DownloadBatch batch : cluster) {
             currentBatches.add(batch);
         }
 
         if (currentBatches.size() == 1) {
-            ActiveBatch batch = currentBatches.iterator().next();
+            DownloadBatch batch = currentBatches.iterator().next();
             return buildSingleNotification(type, builder, batch, remainingText, percentText);
 
         } else {
@@ -350,7 +350,7 @@ class DownloadNotifier {
         }
     }
 
-    private Notification buildSingleNotification(int type, NotificationCompat.Builder builder, ActiveBatch batch, String remainingText, String percentText) {
+    private Notification buildSingleNotification(int type, NotificationCompat.Builder builder, DownloadBatch batch, String remainingText, String percentText) {
 
         NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle();
         String imageUrl = batch.getInfo().getBigPictureUrl();
@@ -393,10 +393,10 @@ class DownloadNotifier {
         style.setSummaryText(description);
     }
 
-    private Notification buildStackedNotification(int type, NotificationCompat.Builder builder, Set<ActiveBatch> currentBatches, String remainingText, String percentText) {
+    private Notification buildStackedNotification(int type, NotificationCompat.Builder builder, Set<DownloadBatch> currentBatches, String remainingText, String percentText) {
         final NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
 
-        for (ActiveBatch batch : currentBatches) {
+        for (DownloadBatch batch : currentBatches) {
             inboxStyle.addLine(getDownloadTitle(batch.getInfo()));
         }
 
@@ -423,7 +423,7 @@ class DownloadNotifier {
         style.setSummaryText(description);
     }
 
-    private void removeStaleTagsThatWereNotRenewed(Map<String, List<ActiveBatch>> clustered) {
+    private void removeStaleTagsThatWereNotRenewed(Map<String, List<DownloadBatch>> clustered) {
         final Iterator<String> tags = mActiveNotifs.keySet().iterator();
         while (tags.hasNext()) {
             final String tag = tags.next();
@@ -443,9 +443,9 @@ class DownloadNotifier {
         }
     }
 
-    private long[] getDownloadIds(List<ActiveBatch> batches) {
+    private long[] getDownloadIds(List<DownloadBatch> batches) {
         List<Long> ids = new ArrayList<>();
-        for (ActiveBatch batch : batches) {
+        for (DownloadBatch batch : batches) {
             for (DownloadInfo downloadInfo : batch.getDownloads()) {
                 ids.add(downloadInfo.mId);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -171,6 +171,12 @@ public final class DownloadProvider extends ContentProvider {
             Downloads.Impl.COLUMN_DELETED,
             Downloads.Impl.COLUMN_NOTIFICATION_EXTRAS,
             Downloads.Impl.COLUMN_BIG_PICTURE,
+            Downloads.Impl.COLUMN_BATCH_ID,
+            Downloads.Impl.Batches._ID,
+            Downloads.Impl.Batches.COLUMN_STATUS,
+            Downloads.Impl.Batches.COLUMN_TITLE,
+            Downloads.Impl.Batches.COLUMN_DESCRIPTION,
+            Downloads.Impl.Batches.COLUMN_BIG_PICTURE,
             OpenableColumns.DISPLAY_NAME,
             OpenableColumns.SIZE,
     };
@@ -635,9 +641,7 @@ public final class DownloadProvider extends ContentProvider {
      * Starts a database query
      */
     @Override
-    public Cursor query(final Uri uri, String[] projection,
-                        final String selection, final String[] selectionArgs,
-                        final String sort) {
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sort) {
 
         Helpers.validateSelection(selection, sAppReadableColumnsSet);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -34,6 +34,7 @@ import android.os.Binder;
 import android.os.ParcelFileDescriptor;
 import android.os.Process;
 import android.provider.OpenableColumns;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
@@ -177,6 +178,7 @@ public final class DownloadProvider extends ContentProvider {
             Downloads.Impl.Batches.COLUMN_TITLE,
             Downloads.Impl.Batches.COLUMN_DESCRIPTION,
             Downloads.Impl.Batches.COLUMN_BIG_PICTURE,
+            Downloads.Impl.Batches.COLUMN_VISIBILITY,
             OpenableColumns.DISPLAY_NAME,
             OpenableColumns.SIZE,
     };
@@ -641,7 +643,7 @@ public final class DownloadProvider extends ContentProvider {
      * Starts a database query
      */
     @Override
-    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sort) {
+    public Cursor query(@NonNull Uri uri, String[] projection, String selection, String[] selectionArgs, String sort) {
 
         Helpers.validateSelection(selection, sAppReadableColumnsSet);
 
@@ -952,8 +954,7 @@ public final class DownloadProvider extends ContentProvider {
      * Deletes a row in the database
      */
     @Override
-    public int delete(final Uri uri, final String where,
-                      final String[] whereArgs) {
+    public int delete(@NonNull Uri uri, String where, String[] whereArgs) {
 
         Helpers.validateSelection(where, sAppReadableColumnsSet);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -658,8 +658,9 @@ public final class DownloadProvider extends ContentProvider {
                 return queryDownloads(uri, projection, selection, selectionArgs, sort, db, match);
             case BATCHES:
             case BATCHES_ID:
-                return db.query(Downloads.Impl.Batches.BATCHES_DB_TABLE, projection, selection,
-                        selectionArgs, null, null, sort);
+                SqlSelection batchSelection = getWhereClause(uri, selection, selectionArgs, match);
+                return db.query(Downloads.Impl.Batches.BATCHES_DB_TABLE, projection, batchSelection.getSelection(),
+                        batchSelection.getParameters(), null, null, sort);
             case REQUEST_HEADERS_URI:
                 if (projection != null || selection != null || sort != null) {
                     throw new UnsupportedOperationException(
@@ -898,7 +899,9 @@ public final class DownloadProvider extends ContentProvider {
                 break;
             case BATCHES:
             case BATCHES_ID:
-                count = db.update(Downloads.Impl.Batches.BATCHES_DB_TABLE, values, where, whereArgs);
+                SqlSelection batchSelection = getWhereClause(uri, where, whereArgs, match);
+                count = db.update(Downloads.Impl.Batches.BATCHES_DB_TABLE, values, batchSelection.getSelection(),
+                        batchSelection.getParameters());
                 break;
             default:
                 Log.d("updating unknown/invalid URI: " + uri);
@@ -940,6 +943,9 @@ public final class DownloadProvider extends ContentProvider {
                 uriMatch == PUBLIC_DOWNLOAD_ID) {
             selection.appendClause(Downloads.Impl._ID + " = ?", getDownloadIdFromUri(uri));
         }
+        if (uriMatch == BATCHES_ID) {
+            selection.appendClause(Downloads.Impl.Batches._ID + " = ?", ContentUris.parseId(uri));
+        }
         if ((uriMatch == MY_DOWNLOADS || uriMatch == MY_DOWNLOADS_ID)
                 && getContext().checkCallingPermission(Downloads.Impl.PERMISSION_ACCESS_ALL)
                 != PackageManager.PERMISSION_GRANTED) {
@@ -969,6 +975,11 @@ public final class DownloadProvider extends ContentProvider {
                 SqlSelection selection = getWhereClause(uri, where, whereArgs, match);
                 deleteRequestHeaders(db, selection.getSelection(), selection.getParameters());
                 count = db.delete(Downloads.Impl.TABLE_NAME, selection.getSelection(), selection.getParameters());
+                break;
+            case BATCHES:
+            case BATCHES_ID:
+                SqlSelection batchSelection = getWhereClause(uri, where, whereArgs, match);
+                count = db.delete(Downloads.Impl.Batches.BATCHES_DB_TABLE, batchSelection.getSelection(), batchSelection.getParameters());
                 break;
 
             default:

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -392,9 +392,9 @@ public final class DownloadProvider extends ContentProvider {
         Integer vis = values.getAsInteger(Downloads.Impl.COLUMN_VISIBILITY);
         if (vis == null) {
             if (dest == Downloads.Impl.DESTINATION_EXTERNAL) {
-                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, NotificationVisibility.ACTIVE_OR_COMPLETE);
             } else {
-                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_HIDDEN);
+                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, NotificationVisibility.HIDDEN);
             }
         } else {
             filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, vis);
@@ -571,16 +571,16 @@ public final class DownloadProvider extends ContentProvider {
         if (getContext().checkCallingOrSelfPermission(Downloads.Impl.PERMISSION_NO_NOTIFICATION) == PackageManager.PERMISSION_GRANTED) {
             enforceAllowedValues(
                     values, Downloads.Impl.COLUMN_VISIBILITY,
-                    Request.VISIBILITY_HIDDEN,
-                    Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE,
-                    Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
-                    Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
+                    NotificationVisibility.HIDDEN,
+                    NotificationVisibility.ONLY_WHEN_ACTIVE,
+                    NotificationVisibility.ACTIVE_OR_COMPLETE,
+                    NotificationVisibility.ONLY_WHEN_COMPLETE);
         } else {
             enforceAllowedValues(
                     values, Downloads.Impl.COLUMN_VISIBILITY,
-                    Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE,
-                    Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
-                    Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
+                    NotificationVisibility.ONLY_WHEN_ACTIVE,
+                    NotificationVisibility.ACTIVE_OR_COMPLETE,
+                    NotificationVisibility.ONLY_WHEN_COMPLETE);
         }
 
         // remove the rest of the columns that are allowed (with any value)

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -392,9 +392,9 @@ public final class DownloadProvider extends ContentProvider {
         Integer vis = values.getAsInteger(Downloads.Impl.COLUMN_VISIBILITY);
         if (vis == null) {
             if (dest == Downloads.Impl.DESTINATION_EXTERNAL) {
-                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Downloads.Impl.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
+                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
             } else {
-                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Downloads.Impl.VISIBILITY_HIDDEN);
+                filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_HIDDEN);
             }
         } else {
             filteredValues.put(Downloads.Impl.COLUMN_VISIBILITY, vis);
@@ -572,13 +572,13 @@ public final class DownloadProvider extends ContentProvider {
             enforceAllowedValues(
                     values, Downloads.Impl.COLUMN_VISIBILITY,
                     Request.VISIBILITY_HIDDEN,
-                    Request.VISIBILITY_VISIBLE,
+                    Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE,
                     Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
                     Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
         } else {
             enforceAllowedValues(
                     values, Downloads.Impl.COLUMN_VISIBILITY,
-                    Request.VISIBILITY_VISIBLE,
+                    Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE,
                     Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED,
                     Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -13,6 +13,7 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.provider.BaseColumns;
+import android.support.annotation.NonNull;
 import android.widget.Toast;
 
 import com.novoda.notils.logger.simple.Log;
@@ -42,16 +43,14 @@ public class DownloadReceiver extends BroadcastReceiver {
     }
 
     @Override
-    public void onReceive(final Context context, final Intent intent) {
+    public void onReceive(@NonNull Context context, @NonNull Intent intent) {
         String action = intent.getAction();
-        if (ACTION_BOOT_COMPLETED.equals(action)) {
-            startService(context);
-        } else if (ACTION_MEDIA_MOUNTED.equals(action)) {
+        if (ACTION_BOOT_COMPLETED.equals(action)
+                || ACTION_MEDIA_MOUNTED.equals(action)
+                || ACTION_RETRY.equals(action)) {
             startService(context);
         } else if (CONNECTIVITY_ACTION.equals(action)) {
             checkConnectivityToStartService(context);
-        } else if (ACTION_RETRY.equals(action)) {
-            startService(context);
         } else if (ACTION_OPEN.equals(action)
                 || ACTION_LIST.equals(action)
                 || ACTION_HIDE.equals(action)
@@ -211,9 +210,9 @@ public class DownloadReceiver extends BroadcastReceiver {
         return context.getContentResolver().query(
                 Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, null,
                 Downloads.Impl.COLUMN_TITLE + " = ? AND " +
-                    Downloads.Impl.COLUMN_STATUS + " <= ?",
-                new String[] { title.toUpperCase(),
-                        String.valueOf(Downloads.Impl.STATUS_SUCCESS) }, null);
+                        Downloads.Impl.COLUMN_STATUS + " <= ?",
+                new String[]{title.toUpperCase(),
+                        String.valueOf(Downloads.Impl.STATUS_SUCCESS)}, null);
     }
 
     private static int getInt(Cursor cursor, String col) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -160,7 +160,7 @@ public class DownloadReceiver extends BroadcastReceiver {
 
         if (Downloads.Impl.isStatusCompleted(status) && (visibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED || visibility == VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION)) {
             ContentValues values = new ContentValues();
-            values.put(Downloads.Impl.COLUMN_VISIBILITY, Downloads.Impl.VISIBILITY_VISIBLE);
+            values.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE);
             context.getContentResolver().update(uri, values, null, null);
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -22,8 +22,8 @@ import static android.content.Intent.ACTION_BOOT_COMPLETED;
 import static android.content.Intent.ACTION_MEDIA_MOUNTED;
 import static android.net.ConnectivityManager.CONNECTIVITY_ACTION;
 import static com.novoda.downloadmanager.lib.Constants.*;
-import static com.novoda.downloadmanager.lib.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
-import static com.novoda.downloadmanager.lib.Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION;
+import static com.novoda.downloadmanager.lib.NotificationVisibility.ACTIVE_OR_COMPLETE;
+import static com.novoda.downloadmanager.lib.NotificationVisibility.ONLY_WHEN_COMPLETE;
 
 /**
  * Receives system broadcasts (boot, network connectivity)
@@ -158,9 +158,9 @@ public class DownloadReceiver extends BroadcastReceiver {
             cursor.close();
         }
 
-        if (Downloads.Impl.isStatusCompleted(status) && (visibility == VISIBILITY_VISIBLE_NOTIFY_COMPLETED || visibility == VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION)) {
+        if (Downloads.Impl.isStatusCompleted(status) && (visibility == ACTIVE_OR_COMPLETE || visibility == ONLY_WHEN_COMPLETE)) {
             ContentValues values = new ContentValues();
-            values.put(Downloads.Impl.COLUMN_VISIBILITY, Request.VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE);
+            values.put(Downloads.Impl.COLUMN_VISIBILITY, NotificationVisibility.ONLY_WHEN_ACTIVE);
             context.getContentResolver().update(uri, values, null, null);
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -190,11 +190,16 @@ public class DownloadService extends Service {
 
     @Override
     public void onDestroy() {
+        shutDown();
+        Log.v("Service onDestroy");
+        super.onDestroy();
+    }
+
+    private void shutDown() {
+        Log.d("Shutting down service");
         getContentResolver().unregisterContentObserver(mObserver);
         mScanner.shutdown();
         mUpdateThread.quit();
-        Log.v("Service onDestroy");
-        super.onDestroy();
     }
 
     /**
@@ -273,9 +278,7 @@ public class DownloadService extends Service {
                     if (DEBUG_LIFECYCLE) {
                         Log.v("Nothing left; stopped");
                     }
-                    getContentResolver().unregisterContentObserver(mObserver);
-                    mScanner.shutdown();
-                    mUpdateThread.quit();
+                    shutDown();
                 }
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -340,7 +340,7 @@ public class DownloadService extends Service {
 
         cleanUpStaleDownloadsThatDisappeared(staleDownloadIds, mDownloads);
 
-        List<ActiveBatch> batches = fetchBatches(mDownloads.values());
+        List<DownloadBatch> batches = fetchBatches(mDownloads.values());
         updateUserVisibleNotification(batches);
 
 
@@ -357,8 +357,8 @@ public class DownloadService extends Service {
         return isActive;
     }
 
-    private List<ActiveBatch> fetchBatches(Collection<DownloadInfo> downloads) {
-        List<ActiveBatch> batches = new ArrayList<>();
+    private List<DownloadBatch> fetchBatches(Collection<DownloadInfo> downloads) {
+        List<DownloadBatch> batches = new ArrayList<>();
         Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, null, null, null, null);
         batches.clear();
         try {
@@ -381,7 +381,7 @@ public class DownloadService extends Service {
                         batchDownloads.add(downloadInfo);
                     }
                 }
-                batches.add(new ActiveBatch(id, batchInfo, batchDownloads, status));
+                batches.add(new DownloadBatch(id, batchInfo, batchDownloads, status));
             }
         } finally {
             batchesCursor.close();
@@ -437,7 +437,7 @@ public class DownloadService extends Service {
         }
     }
 
-    private void updateUserVisibleNotification(List<ActiveBatch> batches) {
+    private void updateUserVisibleNotification(List<DownloadBatch> batches) {
         mNotifier.updateWith(batches);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -415,7 +415,7 @@ public class DownloadService extends Service {
 
     private boolean kickOffDownloadTaskIfReady(boolean isActive, DownloadInfo info) {
         boolean isReadyToDownload = info.isReadyToDownload();
-        Log.e("Ready to download: " + isReadyToDownload + " received isActive: " + isActive + " for id: " + info.mId);
+        Log.v("Ready to download: " + isReadyToDownload + " received isActive: " + isActive + " for id: " + info.mId);
         if (isReadyToDownload) {
             isActive |= info.startDownloadIfNotActive(mExecutor);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -364,7 +364,7 @@ public class DownloadService extends Service {
                 String description = batchesCursor.getString(batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_DESCRIPTION));
                 String bigPictureUrl = batchesCursor.getString(batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_BIG_PICTURE));
 
-                batches.put(id, new BatchInfo(title, description, bigPictureUrl, visibility));
+                batches.put(id, new BatchInfo(title, description, bigPictureUrl));
             }
         } finally {
             batchesCursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -360,6 +360,7 @@ public class DownloadService extends Service {
         batches.clear();
         try {
             int idColumn = batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches._ID);
+            int visibilityColumn = batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_VISIBILITY);
             while (batchesCursor.moveToNext()) {
                 long id = batchesCursor.getLong(idColumn);
 
@@ -367,8 +368,9 @@ public class DownloadService extends Service {
                 String description = batchesCursor.getString(batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_DESCRIPTION));
                 String bigPictureUrl = batchesCursor.getString(batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_BIG_PICTURE));
                 int status = batchesCursor.getInt(batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches.COLUMN_STATUS));
+                @NotificationVisibility.Value int visibility = batchesCursor.getInt(visibilityColumn);
 
-                BatchInfo batchInfo = new BatchInfo(title, description, bigPictureUrl);
+                BatchInfo batchInfo = new BatchInfo(title, description, bigPictureUrl, visibility);
 
                 List<DownloadInfo> batchDownloads = new ArrayList<>();
                 for (DownloadInfo downloadInfo : downloads) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -412,8 +412,9 @@ public class DownloadService extends Service {
     }
 
     private boolean kickOffDownloadTaskIfReady(boolean isActive, DownloadInfo info) {
-        Log.e("Ready to download: " + info.isReadyToDownload() + " received isActive: " + isActive + " for id: " + info.mId);
-        if (info.isReadyToDownload()) {
+        boolean isReadyToDownload = info.isReadyToDownload();
+        Log.e("Ready to download: " + isReadyToDownload + " received isActive: " + isActive + " for id: " + info.mId);
+        if (isReadyToDownload) {
             isActive |= info.startDownloadIfNotActive(mExecutor);
         }
         return isActive;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -166,6 +166,7 @@ class DownloadThread implements Runnable {
         try {
             if (mInfo.mStatus != Downloads.Impl.STATUS_RUNNING) {
                 mInfo.updateStatus(Downloads.Impl.STATUS_RUNNING);
+                updateBatchStatus(mInfo.batchId);
             }
             runInternal();
         } finally {
@@ -187,7 +188,7 @@ class DownloadThread implements Runnable {
         String errorMsg = null;
 
 //        final NetworkPolicyManager netPolicy = NetworkPolicyManager.from(mContext);
-        final PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
+        PowerManager pm = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
 
         try {
             wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, TAG);
@@ -823,6 +824,16 @@ class DownloadThread implements Runnable {
             values.put(Downloads.Impl.COLUMN_ERROR_MSG, errorMsg);
         }
         mContext.getContentResolver().update(mInfo.getAllDownloadsUri(), values, null, null);
+
+        updateBatchStatus(mInfo.batchId);
+    }
+
+    private void updateBatchStatus(long batchId) {
+        BatchStatusUpdater batchStatusUpdater = new BatchStatusUpdater(mContext.getContentResolver());
+        int batchStatus = batchStatusUpdater.getBatchStatus(batchId);
+        batchStatusUpdater.updateBatchStatus(batchId, batchStatus);
+
+        Log.d("Batch " + batchId + " status: " + batchStatus);
     }
 
     public static long getHeaderFieldLong(URLConnection conn, String field, long defaultValue) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -822,6 +822,7 @@ class DownloadThread implements Runnable {
     }
 
     private void notifyThroughDatabase(State state, int finalStatus, String errorMsg, int numFailed) {
+        mInfo.mStatus = finalStatus;
         ContentValues values = new ContentValues();
         values.put(Downloads.Impl.COLUMN_STATUS, finalStatus);
         values.put(Downloads.Impl._DATA, state.mFilename);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -649,7 +649,6 @@ class DownloadThread implements Runnable {
         readResponseHeaders(state, conn);
 
         state.mFilename = Helpers.generateSaveFile(
-                mContext,
                 mInfo.mUri,
                 mInfo.mHint,
                 state.mContentDisposition,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -168,7 +168,7 @@ class DownloadThread implements Runnable {
         try {
             runInternal();
         } finally {
-            mNotifier.notifyDownloadSpeed(mInfo.batchId, 0);
+            mNotifier.notifyDownloadSpeed(mInfo.mId, 0);
         }
     }
 
@@ -555,7 +555,7 @@ class DownloadThread implements Runnable {
 
             // Only notify once we have a full sample window
             if (state.mSpeedSampleStart != 0) {
-                mNotifier.notifyDownloadSpeed(mInfo.batchId, state.mSpeed);
+                mNotifier.notifyDownloadSpeed(mInfo.mId, state.mSpeed);
             }
 
             state.mSpeedSampleStart = now;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -819,6 +819,15 @@ final class Downloads {
              * <P>Owner can Read</P>
              */
             public static final String COLUMN_STATUS = "batch_status";
+
+            /**
+             * The name of the column containing the flags that controls whether the
+             * batch is displayed by the UI. See the {@link NotificationVisibility} constants for
+             * a list of legal values.
+             * <P>Type: INTEGER</P>
+             * <P>Owner can Init/Read/Write</P>
+             */
+            public static final String COLUMN_VISIBILITY = "visibility";
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -825,6 +825,13 @@ final class Downloads {
              * A URL that will be used to show a big picture style notification
              */
             public static final String COLUMN_BIG_PICTURE = "batch_notificationBigPictureResourceId";
+
+            /**
+             * The status of the batch.
+             * <P>Type: INTEGER</P>
+             * <P>Owner can Read</P>
+             */
+            public static final String COLUMN_STATUS = "batch_status";
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -764,24 +764,6 @@ final class Downloads {
         }
 
         /**
-         * This download is visible but only shows in the notifications
-         * while it's in progress.
-         */
-        public static final int VISIBILITY_VISIBLE = DownloadManager.Request.VISIBILITY_VISIBLE;
-
-        /**
-         * This download is visible and shows in the notifications while
-         * in progress and after completion.
-         */
-        public static final int VISIBILITY_VISIBLE_NOTIFY_COMPLETED =
-                DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
-
-        /**
-         * This download doesn't show in the UI or in the notifications.
-         */
-        public static final int VISIBILITY_HIDDEN = DownloadManager.Request.VISIBILITY_HIDDEN;
-
-        /**
          * Constants related to HTTP request headers associated with each download.
          */
         public static class RequestHeaders implements BaseColumns {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -705,6 +705,11 @@ final class Downloads {
          */
         public static final int STATUS_TOO_MANY_REDIRECTS = 497;
 
+        /**
+         * This download couldn't be completed because another download in the batch failed.
+         */
+        public static final int STATUS_BATCH_FAILED = 498;
+
         static String statusToString(int status) {
             switch (status) {
                 case STATUS_PENDING:

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
@@ -70,7 +70,7 @@ class Helpers {
     /**
      * Creates a filename (where the file should be saved) from info about a download.
      */
-    static String generateSaveFile(Context context, String url, String hint, String contentDisposition,
+    static String generateSaveFile(String url, String hint, String contentDisposition,
                                    String contentLocation, String mimeType, int destination, long contentLength,
                                    StorageManager storageManager) throws StopRequestException {
         if (contentLength < 0) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
@@ -16,7 +16,6 @@
 
 package com.novoda.downloadmanager.lib;
 
-import android.content.Context;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.SystemClock;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationVisibility.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationVisibility.java
@@ -1,0 +1,25 @@
+package com.novoda.downloadmanager.lib;
+
+public class NotificationVisibility {
+    /**
+     * This download is visible but only shows in the notifications
+     * while it's in progress.
+     */
+    public static final int ONLY_WHEN_ACTIVE = 0;
+    /**
+     * This download is visible and shows in the notifications while
+     * in progress and after completion.
+     */
+    public static final int ACTIVE_OR_COMPLETE = 1;
+    /**
+     * This download doesn't show in the UI or in the notifications.
+     */
+    public static final int HIDDEN = 2;
+    /**
+     * This download shows in the notifications after completion ONLY.
+     * It is usuable only with
+     * {@link DownloadManager#addCompletedDownload(String, String,
+     * boolean, String, String, long, boolean)}.
+     */
+    public static final int ONLY_WHEN_COMPLETE = 3;
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationVisibility.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationVisibility.java
@@ -1,5 +1,10 @@
 package com.novoda.downloadmanager.lib;
 
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 public class NotificationVisibility {
     /**
      * This download is visible but only shows in the notifications
@@ -22,4 +27,9 @@ public class NotificationVisibility {
      * boolean, String, String, long, boolean)}.
      */
     public static final int ONLY_WHEN_COMPLETE = 3;
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({ONLY_WHEN_ACTIVE, ACTIVE_OR_COMPLETE, HIDDEN, ONLY_WHEN_COMPLETE})
+    public @interface Value {
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -69,7 +69,7 @@ public class Request {
      * This download is visible but only shows in the notifications
      * while it's in progress.
      */
-    public static final int VISIBILITY_VISIBLE = 0;
+    public static final int VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE = 0;
 
     /**
      * This download is visible and shows in the notifications while
@@ -92,10 +92,10 @@ public class Request {
 
     /**
      * can take any of the following values: {@link #VISIBILITY_HIDDEN}
-     * {@link #VISIBILITY_VISIBLE_NOTIFY_COMPLETED}, {@link #VISIBILITY_VISIBLE},
+     * {@link #VISIBILITY_VISIBLE_NOTIFY_COMPLETED}, {@link #VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE},
      * {@link #VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION}
      */
-    private int mNotificationVisibility = VISIBILITY_VISIBLE;
+    private int mNotificationVisibility = VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE;
 
     /**
      * @param uri the HTTP URI to download.
@@ -340,7 +340,7 @@ public class Request {
      */
     @Deprecated
     public Request setShowRunningNotification(boolean show) {
-        return (show) ? setNotificationVisibility(VISIBILITY_VISIBLE) : setNotificationVisibility(VISIBILITY_HIDDEN);
+        return (show) ? setNotificationVisibility(VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE) : setNotificationVisibility(VISIBILITY_HIDDEN);
     }
 
     /**
@@ -351,7 +351,7 @@ public class Request {
      * By default, a notification is shown only when the download is in progress.
      * <p/>
      * It can take the following values: {@link #VISIBILITY_HIDDEN},
-     * {@link #VISIBILITY_VISIBLE},
+     * {@link #VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE},
      * {@link #VISIBILITY_VISIBLE_NOTIFY_COMPLETED}.
      * <p/>
      * If set to {@link #VISIBILITY_HIDDEN}, this requires the permission

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -455,6 +455,7 @@ public class Request {
                 .withTitle(mTitle.toString())
                 .withDescription(mDescription.toString())
                 .withBigPictureUrl(bigPictureUrl)
+                .withVisibility(mNotificationVisibility)
                 .build();
         requestBatch.addRequest(this);
         return requestBatch;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -66,36 +66,11 @@ public class Request {
     static final int SCANNABLE_VALUE_NO = 2;
 
     /**
-     * This download is visible but only shows in the notifications
-     * while it's in progress.
+     * can take any of the following values: {@link NotificationVisibility#HIDDEN}
+     * {@link NotificationVisibility#ACTIVE_OR_COMPLETE}, {@link NotificationVisibility#ONLY_WHEN_ACTIVE},
+     * {@link NotificationVisibility#ONLY_WHEN_COMPLETE}
      */
-    public static final int VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE = 0;
-
-    /**
-     * This download is visible and shows in the notifications while
-     * in progress and after completion.
-     */
-    public static final int VISIBILITY_VISIBLE_NOTIFY_COMPLETED = 1;
-
-    /**
-     * This download doesn't show in the UI or in the notifications.
-     */
-    public static final int VISIBILITY_HIDDEN = 2;
-
-    /**
-     * This download shows in the notifications after completion ONLY.
-     * It is usuable only with
-     * {@link DownloadManager#addCompletedDownload(String, String,
-     * boolean, String, String, long, boolean)}.
-     */
-    public static final int VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION = 3;
-
-    /**
-     * can take any of the following values: {@link #VISIBILITY_HIDDEN}
-     * {@link #VISIBILITY_VISIBLE_NOTIFY_COMPLETED}, {@link #VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE},
-     * {@link #VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION}
-     */
-    private int mNotificationVisibility = VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE;
+    private int mNotificationVisibility = NotificationVisibility.ONLY_WHEN_ACTIVE;
 
     /**
      * @param uri the HTTP URI to download.
@@ -340,7 +315,7 @@ public class Request {
      */
     @Deprecated
     public Request setShowRunningNotification(boolean show) {
-        return (show) ? setNotificationVisibility(VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE) : setNotificationVisibility(VISIBILITY_HIDDEN);
+        return (show) ? setNotificationVisibility(NotificationVisibility.ONLY_WHEN_ACTIVE) : setNotificationVisibility(NotificationVisibility.HIDDEN);
     }
 
     /**
@@ -350,11 +325,11 @@ public class Request {
      * through the system {@link android.app.NotificationManager}.
      * By default, a notification is shown only when the download is in progress.
      * <p/>
-     * It can take the following values: {@link #VISIBILITY_HIDDEN},
-     * {@link #VISIBILITY_VISIBLE_ONLY_WHEN_ACTIVE},
-     * {@link #VISIBILITY_VISIBLE_NOTIFY_COMPLETED}.
+     * It can take the following values: {@link NotificationVisibility#HIDDEN},
+     * {@link NotificationVisibility#ONLY_WHEN_ACTIVE},
+     * {@link NotificationVisibility#ONLY_WHEN_COMPLETE}.
      * <p/>
-     * If set to {@link #VISIBILITY_HIDDEN}, this requires the permission
+     * If set to {@link NotificationVisibility#HIDDEN}, this requires the permission
      * android.permission.DOWNLOAD_WITHOUT_NOTIFICATION.
      *
      * @param visibility the visibility setting value

--- a/library/src/main/java/com/novoda/downloadmanager/lib/RequestBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/RequestBatch.java
@@ -40,6 +40,7 @@ public class RequestBatch {
         values.put(Downloads.Impl.Batches.COLUMN_TITLE, batchInfo.getTitle());
         values.put(Downloads.Impl.Batches.COLUMN_DESCRIPTION, batchInfo.getDescription());
         values.put(Downloads.Impl.Batches.COLUMN_BIG_PICTURE, batchInfo.getBigPictureUrl());
+        values.put(Downloads.Impl.Batches.COLUMN_VISIBILITY, batchInfo.getVisibility());
         return values;
     }
 
@@ -48,6 +49,8 @@ public class RequestBatch {
         private String title;
         private String description;
         private String bigPictureUrl;
+        @NotificationVisibility.Value
+        private int visibility;
 
         public Builder withTitle(String title) {
             this.title = title;
@@ -64,9 +67,13 @@ public class RequestBatch {
             return this;
         }
 
+        public Builder withVisibility(@NotificationVisibility.Value int visibility) {
+            this.visibility = visibility;
+            return this;
+        }
 
         public RequestBatch build() {
-            BatchInfo batchInfo = new BatchInfo(title, description, bigPictureUrl);
+            BatchInfo batchInfo = new BatchInfo(title, description, bigPictureUrl, visibility);
             return new RequestBatch(batchInfo, new ArrayList<Request>());
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
@@ -88,7 +88,7 @@ public class SizeLimitActivity extends Activity implements DialogInterface.OnCan
         } else {
             builder.setTitle("Queue for download later?") // R.string.wifi_recommended_title
                     .setMessage("Starting this " + sizeString + " download now may shorten your batter life and/or result in " +
-                            "excessive useage of your mobile data connection. Which can lead to charges by your mobile operator " +
+                            "excessive usage of your mobile data connection. Which can lead to charges by your mobile operator " +
                             "depending on your data plan." +
                             "\n\n Touch " + queueText + " to start this download the next time you're connected to a Wi-Fi network.") // getString(R.string.wifi_recommended_body, sizeString, queueText)
                     .setPositiveButton("", this) // R.string.button_start_now


### PR DESCRIPTION
* Rework the `DownloadService`, `DownloadThread`, `DownloadReceiver` and `DownloadNotifier` to operate in terms of batches, instead of individual downloads
* Adds status and notification visibility columns to the Batch table
* Update the status of the batch when the status of a corresponding download changes
* Fix downloads not being marked as active when they begin downloading: https://github.com/novoda/download-manager/commit/8af7cc38d088581fa401fd527d978298a45b0d94
* Handles cancellation correctly for an entire batch of downloads
* Stops retrying on 404 errors

Next steps for a new PR:
* Removed unused columns on the `Request` table
* Allow querying for batch status from the API
* Fix `OpenHelper` trying to use system DownloadManager as our DownloadManager
* Test with `DownloadClientReadyChecker` functionality from https://github.com/novoda/download-manager/pull/30
* Handle clicking on the notification to open a Downloads screen