### PR TITLE
Allow custom database filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ public class Authority {
 
 ## Database Filename
 
-It is possible to override the database filename. See [Advanced Usage](https://github.com/novoda/download-manager/wiki/Advanced-Useage) for details.
+It is possible to override the database filename. See [Advanced Usage](https://github.com/novoda/download-manager/wiki/Advanced-Useage),
+ or take a look at the `demo_parallel` sample app for details.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -48,31 +48,7 @@ public class Authority {
 
 ## Database Filename
 
-By default the downloads database will be stored in your application data in a file named 'downloads.db'. Power users can override this
-by specifying a value for `com.novoda.downloadmanager.DatabaseFilename` in the metadata within the manifest.
-
-```xml
-<manifest
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.myorg.myapp" >
-
-  <uses-permission android:name="android.permission.INTERNET" />
-
-  <application
-    android:allowBackup="true"
-    android:icon="@mipmap/ic_launcher"
-    android:label="@string/app_name"
-    android:theme="@style/AppTheme">
-    .
-    .
-    .
-    <meta-data
-      android:name="com.novoda.downloadmanager.DatabaseFilename"
-      android:value="my_database.db" />
-  </application>
-
-</manifest>
-```
+It is possible to override the database filename. See [Advanced Usage](https://github.com/novoda/download-manager/wiki/Advanced-Useage) for details.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.novoda:download-manager:0.0.9'
+    compile 'com.novoda:download-manager:0.0.12'
 }
 ```
 
@@ -44,6 +44,34 @@ package com.novoda.downloadmanager;
 public class Authority {
     public static final String AUTHORITY = "com.your.unique.authority";
 }
+```
+
+## Database Filename
+
+By default the downloads database will be stored in your application data in a file named 'downloads.db'. Power users can override this
+by specifying a value for `com.novoda.downloadmanager.DatabaseFilename` in the metadata within the manifest.
+
+```xml
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.myorg.myapp" >
+
+  <uses-permission android:name="android.permission.INTERNET" />
+
+  <application
+    android:allowBackup="true"
+    android:icon="@mipmap/ic_launcher"
+    android:label="@string/app_name"
+    android:theme="@style/AppTheme">
+    .
+    .
+    .
+    <meta-data
+      android:name="com.novoda.downloadmanager.DatabaseFilename"
+      android:value="my_database.db" />
+  </application>
+
+</manifest>
 ```
 
 ## Links

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,7 @@
+0.0.12
+-------
+Now allows power users to override the default database filename.
+
 0.0.9
 -------
 

--- a/demo_parallel/build.gradle
+++ b/demo_parallel/build.gradle
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.2.0'
 }

--- a/demo_parallel/src/main/AndroidManifest.xml
+++ b/demo_parallel/src/main/AndroidManifest.xml
@@ -24,6 +24,10 @@
       android:name="com.novoda.downloadmanager.MaxConcurrentDownloads"
       android:value="@integer/max_concurrent_downloads" />
 
+    <meta-data
+      android:name="com.novoda.downloadmanager.DatabaseFilename"
+      android:value="@string/database_filename" />
+
   </application>
 
 </manifest>

--- a/demo_parallel/src/main/res/values/strings.xml
+++ b/demo_parallel/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
   <string name="no_downloads">No downloads yet.\nTap download and then refresh to query the download manager!</string>
   <string name="button_download_text">Download a podcast</string>
   <string name="button_refresh_text">Refresh</string>
+  <string name="database_filename">my_database.db</string>
 </resources>

--- a/demo_serial/build.gradle
+++ b/demo_serial/build.gradle
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:22.1.1'
+    compile 'com.android.support:appcompat-v7:22.2.0'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.1.1'
+    compile 'com.android.support:support-v4:22.2.0'
     compile 'com.novoda:notils:2.2.11'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -53,7 +53,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'download-manager'
-    publishVersion = '0.0.11'
+    publishVersion = '0.0.12'
     description = 'Download manager based on AOSP DM but allowing downloading to internal private storage.'
     website = 'https://github.com/novoda/download-manager'
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseFilenameProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseFilenameProvider.java
@@ -1,0 +1,45 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
+import com.novoda.notils.logger.simple.Log;
+
+class DatabaseFilenameProvider {
+    private static final String DATABASE_FILENAME = "com.novoda.downloadmanager.DatabaseFilename";
+    private final PackageManager packageManager;
+    private final String packageName;
+    private final String defaultFilename;
+
+    static DatabaseFilenameProvider newInstance(@NonNull Context context, @NonNull String defaultFilename) {
+        PackageManager packageManager = context.getPackageManager();
+        String packageName = context.getApplicationContext().getPackageName();
+        return new DatabaseFilenameProvider(packageManager, packageName, defaultFilename);
+    }
+
+    DatabaseFilenameProvider(@NonNull PackageManager packageManager, @NonNull String packageName, @NonNull String defaultFilename) {
+        this.packageManager = packageManager;
+        this.packageName = packageName;
+        this.defaultFilename = defaultFilename;
+    }
+
+    public String getDatabaseFilename() {
+        try {
+            ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
+            return getDatabaseFilename(applicationInfo.metaData);
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
+            return defaultFilename;
+        }
+    }
+
+    private String getDatabaseFilename(Bundle bundle) {
+        if (bundle == null) {
+            return defaultFilename;
+        }
+        return bundle.getString(DATABASE_FILENAME, defaultFilename);
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -238,8 +238,8 @@ public final class DownloadProvider extends ContentProvider {
      * an updated version of the database.
      */
     private final class DatabaseHelper extends SQLiteOpenHelper {
-        public DatabaseHelper(final Context context) {
-            super(context, DB_NAME, null, DB_VERSION);
+        public DatabaseHelper(final Context context, String databaseFilename) {
+            super(context, databaseFilename, null, DB_VERSION);
         }
 
         /**
@@ -439,7 +439,10 @@ public final class DownloadProvider extends ContentProvider {
             mSystemFacade = new RealSystemFacade(getContext());
         }
 
-        mOpenHelper = new DatabaseHelper(getContext());
+        Context context = getContext();
+        DatabaseFilenameProvider databaseFilenameProvider = DatabaseFilenameProvider.newInstance(context, DB_NAME);
+        String databaseFilename = databaseFilenameProvider.getDatabaseFilename();
+        mOpenHelper = new DatabaseHelper(context, databaseFilename);
         // Initialize the system uid
         mSystemUid = Process.SYSTEM_UID;
         // Initialize the default container uid. Package name hardcoded
@@ -456,7 +459,6 @@ public final class DownloadProvider extends ContentProvider {
         }
         // start the DownloadService class. don't wait for the 1st download to be issued.
         // saves us by getting some initialization code in DownloadService out of the way.
-        Context context = getContext();
         context.startService(new Intent(context, DownloadService.class));
 //        mDownloadsDataDir = StorageManager.getDownloadDataDirectory(getContext());
         mDownloadsDataDir = context.getCacheDir();

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DatabaseFilenameProviderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DatabaseFilenameProviderTest.java
@@ -1,0 +1,71 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DatabaseFilenameProviderTest {
+
+    private static final String PACKAGE_NAME = "PACKAGE_NAME";
+    private static final String DATABASE_FILENAME = "com.novoda.downloadmanager.DatabaseFilename";
+    private static final String DEFAULT_FILENAME = "DEFAULT_FILENAME";
+
+    @Mock
+    PackageManager packageManager;
+    @Mock
+    Bundle bundle;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void givenANullMetadataBundleWhenTheFilenameIsRetrievedThenTheDefaultValueIsUsed() throws Exception {
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenReturn(new StubApplicationInfo(null));
+        DatabaseFilenameProvider provider = new DatabaseFilenameProvider(packageManager, PACKAGE_NAME, DEFAULT_FILENAME);
+
+        String filename = provider.getDatabaseFilename();
+
+        assertThat(filename).isEqualTo(DEFAULT_FILENAME);
+    }
+
+    @Test
+    public void givenAPackageNameWhichIsNotFoundWhenTheFilenameIsRetrievedThenTheDefaultValueIsUsed() throws Exception {
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenThrow(new PackageManager.NameNotFoundException());
+        DatabaseFilenameProvider provider = new DatabaseFilenameProvider(packageManager, PACKAGE_NAME, DEFAULT_FILENAME);
+
+        String filename = provider.getDatabaseFilename();
+
+        assertThat(filename).isEqualTo(DEFAULT_FILENAME);
+    }
+
+    @Test
+    public void givenANonNullBundleWhenTheFilenameIsRetrievedThenTheValueFromTheBundleIsUsed() throws Exception {
+        String expected = "my_database.db";
+        when(bundle.getString(eq(DATABASE_FILENAME), anyString())).thenReturn(expected);
+        when(packageManager.getApplicationInfo(PACKAGE_NAME, PackageManager.GET_META_DATA)).thenReturn(new StubApplicationInfo(bundle));
+        DatabaseFilenameProvider provider = new DatabaseFilenameProvider(packageManager, PACKAGE_NAME, DEFAULT_FILENAME);
+
+        String filename = provider.getDatabaseFilename();
+
+        assertThat(filename).isEqualTo(expected);
+    }
+
+    static class StubApplicationInfo extends ApplicationInfo {
+        StubApplicationInfo(Bundle metaData) {
+            this.metaData = metaData;
+        }
+    }
+
+}


### PR DESCRIPTION
### The problem

A project upon which I'm working is already using a database with the filename `downloads.db`. For legacy reasons it is not possible to change this so it would be useful if `download-manager` could be configured to use an alternate database filename.

### The solution
Adds the ability to override the database filename via an AndroidManifest metadata value in a similar fashion to the existing `MaxConcurrentDownloads` implementation. This provides me with a simple way to overcome my specific problem while offering additional functionality for power users. All this without actually changing the default, out-of-the-box behaviour.

### Bonus points
I also fixed 3 (albeit simple) lint warnings.
![](http://media.giphy.com/media/44gu1V41ejJni/giphy.gif)

 