### PR TITLE
Add extras column to DownloadsByBatch view so we can filter on it

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -160,6 +160,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             Downloads.Impl.COLUMN_TOTAL_BYTES,
             Downloads.Impl.COLUMN_LAST_MODIFICATION,
             Downloads.Impl.COLUMN_CURRENT_BYTES,
+            Downloads.Impl.COLUMN_NOTIFICATION_EXTRAS,
             Downloads.Impl.COLUMN_BATCH_ID,
             Downloads.Impl.Batches.COLUMN_TITLE,
             Downloads.Impl.Batches.COLUMN_DESCRIPTION,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -85,6 +85,11 @@ public class DownloadManager {
     public static final String COLUMN_BATCH_ID = Downloads.Impl.COLUMN_BATCH_ID;
 
     /**
+     * The extra supplied information for this download.
+     */
+    public static final String COLUMN_NOTIFICATION_EXTRAS = Downloads.Impl.COLUMN_NOTIFICATION_EXTRAS;
+
+    /**
      * The status of the batch that contains this download.
      */
     public static final String COLUMN_BATCH_STATUS = Downloads.Impl.Batches.COLUMN_STATUS;


### PR DESCRIPTION
Filtering on the extras column allows us to use `setExtra()` on a `Request` to tag a request and make it easier to retrieve it from a batch later on.

**Example**

```java
Request request = new Request(thumbnailUri);
request.setExtra("thumbnail");
downloadManager.enqueue(request);

// Later

Query query = new Query().setFilterByBatchId(batchId)
        .setFilterByExtras("thumbnail");
downloadManager.query(query);

```