### PR TITLE
Fix bug wrong download status when is not ready to download

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -462,6 +462,10 @@ class DownloadInfo {
         }
     }
 
+    public boolean isActive() {
+        return mSubmittedTask != null && !mSubmittedTask.isDone();
+    }
+
     public void updateStatus(int status) {
         mStatus = status;
         downloadStatusContentValues.clear();
@@ -470,14 +474,7 @@ class DownloadInfo {
     }
 
     private boolean isClientReadyToDownload() {
-        ConnectivityManager connectivityManager = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-        if (networkInfo != null && networkInfo.isConnected()) {
-            return true;
-        } else {
-            return false;
-        }
-        //return downloadClientReadyChecker.isAllowedToDownload();
+        return downloadClientReadyChecker.isAllowedToDownload();
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -444,7 +444,7 @@ class DownloadInfo {
      */
     public boolean isReadyToDownload() {
         synchronized (this) {
-            return isDownloadManagerReadyToDownload() && isClientReadyToDownload();
+            return isClientReadyToDownload() && isDownloadManagerReadyToDownload();
         }
     }
 
@@ -470,7 +470,14 @@ class DownloadInfo {
     }
 
     private boolean isClientReadyToDownload() {
-        return downloadClientReadyChecker.isAllowedToDownload();
+        ConnectivityManager connectivityManager = (ConnectivityManager) mContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+        if (networkInfo != null && networkInfo.isConnected()) {
+            return true;
+        } else {
+            return false;
+        }
+        //return downloadClientReadyChecker.isAllowedToDownload();
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -419,9 +419,12 @@ public class DownloadService extends Service {
 
     private boolean kickOffDownloadTaskIfReady(boolean isActive, DownloadInfo info) {
         boolean isReadyToDownload = info.isReadyToDownload();
-        if (isReadyToDownload) {
+        boolean downloadIsActive = info.isActive();
+
+        if (isReadyToDownload || downloadIsActive) {
             isActive |= info.startDownloadIfNotActive(mExecutor);
         }
+
         return isActive;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -187,6 +187,12 @@ class DownloadThread implements Runnable {
             Log.d("Download " + mInfo.mId + " already failed: status = " + downloadStatus + "; skipping");
             return;
         }
+
+        if (!mInfo.isReadyToDownload()) {
+            Log.d("Download " + mInfo.mId + " is not ready to download: skipping");
+            return;
+        }
+
         if (downloadStatus != Downloads.Impl.STATUS_RUNNING) {
             mInfo.updateStatus(Downloads.Impl.STATUS_RUNNING);
             updateBatchStatus(mInfo.batchId, mInfo.mId);


### PR DESCRIPTION
## Description of the bug ##

When there are several queued items to be downloaded, the following bug occurs

Force the `DownloadClientReadyChecker` to return false under some circumstances, for example when there is no Wi-Fi

- 2 queued items
- 1 item is downloading, 1 item is queued
- Switch off Wi-Fi

Expected:
- 2 items moved to queued
- No notification

Result:
- Previous downloading item moves to queued
- Previous queued item moves to downloading
- Notification stays in place

## Solution implemented ##

- The submitted thread for a particular download now does a check against the `DownloadClientReadyChecker`
- The `DownloadService` is stopped only if there are no any active download threads

Paired with @ronocod 