### PR TITLE
Optimisation Fix - Get full batch size in one query

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
@@ -84,18 +84,15 @@ class BatchStatusRepository {
         long totalSize = 0;
         try {
             String[] selectionArgs = {String.valueOf(batchId)};
-            cursor = resolver.query(ALL_DOWNLOADS_CONTENT_URI,
-                    null,
+            cursor = resolver.query(
+                    ALL_DOWNLOADS_CONTENT_URI,
+                    new String[]{"sum(" + COLUMN_TOTAL_BYTES + ")"},
                     COLUMN_BATCH_ID + " = ?",
                     selectionArgs,
                     null);
 
-            int totalBytesColumnIndex = cursor.getColumnIndexOrThrow(COLUMN_TOTAL_BYTES);
-
-            while (cursor.moveToNext()) {
-                int individualDownloadSize = cursor.getInt(totalBytesColumnIndex);
-                totalSize += individualDownloadSize;
-            }
+            cursor.moveToFirst();
+            totalSize = cursor.getLong(0);
         } finally {
             if (cursor != null) {
                 cursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -190,7 +190,9 @@ class DownloadThread implements Runnable {
             return;
         }
 
-        if (!mInfo.isReadyToDownload(new CollatedDownloadInfo(batchStatusRepository.getBatchSizeInBytes(mInfo.batchId)))) {
+        long batchSizeInBytes = batchStatusRepository.getBatchSizeInBytes(mInfo.batchId);
+
+        if (!mInfo.isReadyToDownload(new CollatedDownloadInfo(batchSizeInBytes))) {
             Log.d("Download " + mInfo.mId + " is not ready to download: skipping");
             return;
         }


### PR DESCRIPTION
This PR replaces a full loop over all the rows retrieved by a query by one single query that does all the sums in the query itself