### PR TITLE
Removes unnecessary full loop

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
@@ -26,6 +26,8 @@ class BatchStatusRepository {
             STATUS_SUCCESS
     );
 
+    private static final int PRIORITISED_STATUSES_SIZE = PRIORITISED_STATUSES.size();
+
     private final ContentResolver resolver;
 
     public BatchStatusRepository(ContentResolver resolver) {
@@ -40,7 +42,7 @@ class BatchStatusRepository {
 
     int getBatchStatus(long batchId) {
         Cursor cursor = null;
-        SparseIntArray statusCounts = new SparseIntArray(8);
+        SparseIntArray statusCounts = new SparseIntArray(PRIORITISED_STATUSES_SIZE);
         try {
             String[] selectionArgs = {String.valueOf(batchId)};
             cursor = resolver.query(ALL_DOWNLOADS_CONTENT_URI,


### PR DESCRIPTION
This PR checks for any `status_error` while gathering the values directly from the database and aborts the execution if one is found.

This improvement prevents unnecessary further data gathering from the content provider and removes completely a full loop through all the values gathered looking for a `status_error`