### PR TITLE
Fixes too many callbacks about the rules for already downloaded files

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -440,12 +440,13 @@ class DownloadInfo {
      * create a {DownloadThread} and enqueue it into given
      * {@link Executor}.
      *
-     * @param collatedDownloadInfo
      * @return If actively downloading.
      */
     public boolean isReadyToDownload(CollatedDownloadInfo collatedDownloadInfo) {
         synchronized (this) {
-            return isClientReadyToDownload(collatedDownloadInfo) && isDownloadManagerReadyToDownload();
+            // This order MATTERS
+            // it means completed downloads will not be accounted for in later downloadInfo queries
+            return isDownloadManagerReadyToDownload() && isClientReadyToDownload(collatedDownloadInfo);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -196,7 +196,7 @@ class DownloadThread implements Runnable {
         long batchSizeInBytes = batchStatusRepository.getBatchSizeInBytes(mInfo.batchId);
 
         if (!mInfo.isReadyToDownload(new CollatedDownloadInfo(batchSizeInBytes))) {
-            Log.d("Download " + mInfo.mId + " is not ready to download: skipping");
+            Log.d("Download " + mInfo.mId + " is not ready to download; skipping");
             return;
         }
 


### PR DESCRIPTION
Because the logical order was changed this meant clients had access to the already successfully downloaded files and could check rules against them. https://github.com/novoda/download-manager/pull/45/files#diff-68db38a7048316539cb0931793be1808R447 Now we reverted back to the download manager doing the first check to stop this crazyness.