### PR TITLE
Add ability to delete batches

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
@@ -6,11 +6,13 @@ class Download {
     private final String title;
     private final String fileName;
     private final int downloadStatus;
+    private final long batchId;
 
-    public Download(String title, String fileName, int downloadStatus) {
+    public Download(String title, String fileName, int downloadStatus, long batchId) {
         this.title = title;
         this.fileName = fileName;
         this.downloadStatus = downloadStatus;
+        this.batchId = batchId;
     }
 
     public String getTitle() {
@@ -35,5 +37,9 @@ class Download {
         } else {
             return "WTH";
         }
+    }
+
+    public long getBatchId() {
+        return batchId;
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DownloadAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DownloadAdapter.java
@@ -1,19 +1,24 @@
 package com.novoda.downloadmanager.demo.extended;
 
+import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
+import android.widget.Button;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
+import com.novoda.notils.caster.Views;
 
 import java.util.List;
 
 class DownloadAdapter extends BaseAdapter {
     private final List<Download> downloads;
+    private final Listener listener;
 
-    public DownloadAdapter(List<Download> downloads) {
+    public DownloadAdapter(List<Download> downloads, Listener listener) {
         this.downloads = downloads;
+        this.listener = listener;
     }
 
     @Override
@@ -35,13 +40,24 @@ class DownloadAdapter extends BaseAdapter {
     public View getView(int position, View convertView, ViewGroup parent) {
         View view = View.inflate(parent.getContext(), R.layout.list_item_download, null);
 
-        Download download = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
+        final Download download = getItem(position);
+        TextView titleTextView = Views.findById(view, R.id.download_title_text);
+        TextView locationTextView = Views.findById(view, R.id.download_location_text);
+        Button deleteButton = Views.findById(view, R.id.download_delete_button);
 
         titleTextView.setText(download.getTitle());
         locationTextView.setText(download.getDownloadStatusText() + " : " + download.getFileName());
+        deleteButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(@NonNull View v) {
+                listener.onDelete(download);
+            }
+        });
 
         return view;
+    }
+
+    interface Listener {
+        void onDelete(Download download);
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
@@ -110,7 +110,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         DownloadAdapter adapter = new DownloadAdapter(downloads, new DownloadAdapter.Listener() {
             @Override
             public void onDelete(Download download) {
-                downloadManager.removeBatch(download.getBatchId());
+                downloadManager.removeBatches(download.getBatchId());
             }
         });
         listView.setAdapter(adapter);

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
@@ -107,7 +107,13 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
 
     @Override
     public void onQueryResult(List<Download> downloads) {
-        listView.setAdapter(new DownloadAdapter(downloads));
+        DownloadAdapter adapter = new DownloadAdapter(downloads, new DownloadAdapter.Listener() {
+            @Override
+            public void onDelete(Download download) {
+                downloadManager.removeBatch(download.getBatchId());
+            }
+        });
+        listView.setAdapter(adapter);
     }
 
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
@@ -33,7 +33,8 @@ public class QueryForDownloadsAsyncTask extends AsyncTask<Query, Void, List<Down
                 String title = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_TITLE));
                 String fileName = cursor.getString(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_LOCAL_FILENAME));
                 int downloadStatus = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS));
-                downloads.add(new Download(title, fileName, downloadStatus));
+                long batchId = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadManager.COLUMN_BATCH_ID));
+                downloads.add(new Download(title, fileName, downloadStatus, batchId));
             }
         } finally {
             cursor.close();

--- a/demo-extended/src/main/res/layout/list_item_download.xml
+++ b/demo-extended/src/main/res/layout/list_item_download.xml
@@ -23,5 +23,5 @@
     android:id="@+id/download_delete_button"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:text="DELETE BATCH" />
+    android:text="@string/button_delete_text" />
 </LinearLayout>

--- a/demo-extended/src/main/res/layout/list_item_download.xml
+++ b/demo-extended/src/main/res/layout/list_item_download.xml
@@ -2,17 +2,26 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
+  xmlns:tools="http://schemas.android.com/tools"
   android:orientation="vertical">
 
   <TextView
     android:id="@+id/download_title_text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceLarge" />
+    android:textAppearance="?android:attr/textAppearanceLarge"
+    tools:text="Title"/>
 
   <TextView
     android:id="@+id/download_location_text"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:textAppearance="?android:attr/textAppearanceMedium" />
+    android:textAppearance="?android:attr/textAppearanceMedium"
+    tools:text="Location"/>
+
+  <Button
+    android:id="@+id/download_delete_button"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="DELETE BATCH" />
 </LinearLayout>

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
   <string name="button_refresh_text">Refresh</string>
   <string name="button_single_download_text">Download a single item</string>
   <string name="button_batch_download_text">Download a batch of items</string>
+  <string name="button_delete_text">Delete batch</string>
 
   <string name="database_filename" translate="false">my_database.db</string>
 </resources>

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -128,7 +128,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         Downloads.Impl.Batches.COLUMN_DESCRIPTION + " TEXT," +
                         Downloads.Impl.Batches.COLUMN_BIG_PICTURE + " TEXT," +
                         Downloads.Impl.Batches.COLUMN_STATUS + " INTEGER," +
-                        Downloads.Impl.Batches.COLUMN_VISIBILITY + " INTEGER" +
+                        Downloads.Impl.Batches.COLUMN_VISIBILITY + " INTEGER," +
+                        Downloads.Impl.Batches.COLUMN_DELETED + " BOOLEAN NOT NULL DEFAULT 0" +
                         ");");
     }
 
@@ -154,7 +155,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             Downloads.Impl.COLUMN_DESTINATION,
             Downloads.Impl.COLUMN_URI,
             Downloads.Impl.COLUMN_STATUS,
-            Downloads.Impl.COLUMN_DELETED,
+            Downloads.Impl.DOWNLOADS_TABLE_NAME + "." + Downloads.Impl.COLUMN_DELETED,
             Downloads.Impl.COLUMN_FILE_NAME_HINT,
             Downloads.Impl.COLUMN_MIME_TYPE,
             Downloads.Impl.COLUMN_TOTAL_BYTES,
@@ -166,7 +167,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             Downloads.Impl.Batches.COLUMN_DESCRIPTION,
             Downloads.Impl.Batches.COLUMN_BIG_PICTURE,
             Downloads.Impl.Batches.COLUMN_VISIBILITY,
-            Downloads.Impl.Batches.COLUMN_STATUS
+            Downloads.Impl.Batches.COLUMN_STATUS,
+            Downloads.Impl.Batches.BATCHES_TABLE_NAME + "." + Downloads.Impl.Batches.COLUMN_DELETED,
     };
 
     private String projectionFrom(String[] array) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -468,7 +468,7 @@ public class DownloadManager {
     }
 
     /**
-     * Cancel downloads and remove them from the download manager.  Each download will be stopped if
+     * Cancel batch downloads and remove them from the download manager.  Each download will be stopped if
      * it was running, and it will no longer be accessible through the download manager.
      * If there is a downloaded file, partial or complete, it is deleted.
      *
@@ -476,7 +476,7 @@ public class DownloadManager {
      * @return the number of downloads actually removed
      */
     public int removeBatch(long... ids) {
-        return markDownloadRowForDeletion(ids);
+        return markBatchRowForDeletion(ids);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -402,7 +402,7 @@ public class DownloadManager {
             cursor = mResolver.query(Downloads.Impl.CONTENT_URI, new String[]{"_id"}, Downloads.Impl.COLUMN_FILE_NAME_HINT + "=?", new String[]{uri.toString()}, null);
             if (cursor.moveToFirst()) {
                 long id = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
-                markDownloadRowForDeletion(id);
+                markDownloadRowsForDeletion(id);
                 return;
             }
             Log.e("Didn't delete anything for uri: " + uri);
@@ -421,7 +421,7 @@ public class DownloadManager {
      * @param ids the IDs of the downloads to be marked 'deleted'
      * @return the number of downloads actually updated
      */
-    public int markDownloadRowForDeletion(long... ids) {
+    public int markDownloadRowsForDeletion(long... ids) {
         if (ids == null || ids.length == 0) {
             throw new IllegalArgumentException("called with nothing to remove. input param 'ids' can't be null");
         }
@@ -443,17 +443,17 @@ public class DownloadManager {
      * @param ids the IDs of the downloads to remove
      * @return the number of downloads actually removed
      */
-    public int removeDownload(long... ids) {
-        return markDownloadRowForDeletion(ids);
+    public int removeDownloads(long... ids) {
+        return markDownloadRowsForDeletion(ids);
     }
 
     /**
      * Marks the specified batch as 'to be deleted'. Actual cleanup of this row is done in DownloadService.
      *
-     * @param ids the IDs of the downloads to be marked 'deleted'
-     * @return the number of downloads actually updated
+     * @param ids the IDs of the batches to be marked 'deleted'
+     * @return the number of batches actually updated
      */
-    public int markBatchRowForDeletion(long... ids) {
+    public int markBatchRowsForDeletion(long... ids) {
         if (ids == null || ids.length == 0) {
             throw new IllegalArgumentException("called with nothing to remove. input param 'ids' can't be null");
         }
@@ -470,13 +470,13 @@ public class DownloadManager {
     /**
      * Cancel batch downloads and remove them from the download manager.  Each download will be stopped if
      * it was running, and it will no longer be accessible through the download manager.
-     * If there is a downloaded file, partial or complete, it is deleted.
+     * If there are any downloaded files, partial or complete, they will be deleted.
      *
-     * @param ids the IDs of the downloads to remove
-     * @return the number of downloads actually removed
+     * @param ids the IDs of the batches to remove
+     * @return the number of batches actually removed
      */
-    public int removeBatch(long... ids) {
-        return markBatchRowForDeletion(ids);
+    public int removeBatches(long... ids) {
+        return markBatchRowsForDeletion(ids);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -409,13 +409,13 @@ public class DownloadManager {
         mResolver.update(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, values, COLUMN_BATCH_ID + "=?", new String[] { String.valueOf(id) });
     }
 
-    public void markDownloadForDeletion(URI uri) {
+    public void removeDownload(URI uri) {
         Cursor cursor = null;
         try {
             cursor = mResolver.query(Downloads.Impl.CONTENT_URI, new String[]{"_id"}, Downloads.Impl.COLUMN_FILE_NAME_HINT + "=?", new String[]{uri.toString()}, null);
             if (cursor.moveToFirst()) {
                 long id = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
-                markDownloadRowsForDeletion(id);
+                removeDownloads(id);
                 return;
             }
             Log.e("Didn't delete anything for uri: " + uri);
@@ -427,14 +427,14 @@ public class DownloadManager {
     }
 
     /**
-     * Marks the specified download as 'to be deleted'. This is done when a completed download
-     * is to be removed but the row was stored without enough info to delete the corresponding
-     * metadata from Mediaprovider database. Actual cleanup of this row is done in DownloadService.
+     * Cancel downloads and remove them from the download manager.  Each download will be stopped if
+     * it was running, and it will no longer be accessible through the download manager.
+     * If there is a downloaded file, partial or complete, it is deleted.
      *
-     * @param ids the IDs of the downloads to be marked 'deleted'
-     * @return the number of downloads actually updated
+     * @param ids the IDs of the downloads to remove
+     * @return the number of downloads actually removed
      */
-    public int markDownloadRowsForDeletion(long... ids) {
+    public int removeDownloads(long... ids) {
         if (ids == null || ids.length == 0) {
             throw new IllegalArgumentException("called with nothing to remove. input param 'ids' can't be null");
         }
@@ -449,24 +449,14 @@ public class DownloadManager {
     }
 
     /**
-     * Cancel downloads and remove them from the download manager.  Each download will be stopped if
+     * Cancel batch downloads and remove them from the download manager.  Each download will be stopped if
      * it was running, and it will no longer be accessible through the download manager.
-     * If there is a downloaded file, partial or complete, it is deleted.
+     * If there are any downloaded files, partial or complete, they will be deleted.
      *
-     * @param ids the IDs of the downloads to remove
-     * @return the number of downloads actually removed
+     * @param ids the IDs of the batches to remove
+     * @return the number of batches actually removed
      */
-    public int removeDownloads(long... ids) {
-        return markDownloadRowsForDeletion(ids);
-    }
-
-    /**
-     * Marks the specified batch as 'to be deleted'. Actual cleanup of this row is done in DownloadService.
-     *
-     * @param ids the IDs of the batches to be marked 'deleted'
-     * @return the number of batches actually updated
-     */
-    public int markBatchRowsForDeletion(long... ids) {
+    public int removeBatches(long... ids) {
         if (ids == null || ids.length == 0) {
             throw new IllegalArgumentException("called with nothing to remove. input param 'ids' can't be null");
         }
@@ -478,18 +468,6 @@ public class DownloadManager {
             return mResolver.update(ContentUris.withAppendedId(Downloads.Impl.BATCH_CONTENT_URI, ids[0]), values, null, null);
         }
         return mResolver.update(Downloads.Impl.BATCH_CONTENT_URI, values, getWhereClauseForIds(ids), longArrayToStringArray(ids));
-    }
-
-    /**
-     * Cancel batch downloads and remove them from the download manager.  Each download will be stopped if
-     * it was running, and it will no longer be accessible through the download manager.
-     * If there are any downloaded files, partial or complete, they will be deleted.
-     *
-     * @param ids the IDs of the batches to remove
-     * @return the number of batches actually removed
-     */
-    public int removeBatches(long... ids) {
-        return markBatchRowsForDeletion(ids);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -410,14 +410,9 @@ public class DownloadService extends Service {
             }
         }
 
-        StringBuilder whereClause = new StringBuilder();
-        whereClause.append("(").append(ids.get(0));
-        for (int i = 1; i < ids.size(); i++) {
-            whereClause.append(",").append(ids.get(i));
-        }
-        whereClause.append(")");
-
-        resolver.delete(Downloads.Impl.BATCH_CONTENT_URI, Downloads.Impl.Batches._ID + " IN ?", new String[]{whereClause.toString()});
+        String selection = TextUtils.join(", ", ids);
+        String[] selectionArgs = {selection};
+        resolver.delete(Downloads.Impl.BATCH_CONTENT_URI, Downloads.Impl.Batches._ID + " IN (?)", selectionArgs);
     }
 
     private void updateTotalBytesFor(DownloadInfo info) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -806,6 +806,13 @@ final class Downloads {
              * <P>Owner can Init/Read/Write</P>
              */
             public static final String COLUMN_VISIBILITY = "visibility";
+
+            /**
+             * Set to true if this batch is deleted. Its downloads will also be deleted.
+             * <P>Type: BOOLEAN</P>
+             * <P>Owner can Read</P>
+             */
+            public static final String COLUMN_DELETED = "deleted";
         }
     }
 


### PR DESCRIPTION
Adds marking batches for deletion to the public API.

The `DownloadService` will find batches that have been marked for deletion and:
* delete the files for their downloads
* delete the DB entries for those downloads
* delete the DB entries for the batches themselves

Before Deletion | After Deletion
---|---
![before](https://cloud.githubusercontent.com/assets/466546/8479204/15e76fea-20ce-11e5-8dc2-fa2934fc29d2.png) | ![after](https://cloud.githubusercontent.com/assets/466546/8479203/15d1dd9c-20ce-11e5-950a-64778033f02b.png)