### PR TITLE
Replace data structures for more appropriate ones

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -64,7 +64,7 @@ class DownloadNotifier {
      * @see #buildNotificationTag(DownloadBatch)
      */
 //    @GuardedBy("mActiveNotifs")
-    private final SimpleArrayMap<String, Long> mActiveNotifs = new SimpleArrayMap<>();
+    private final SimpleArrayMap<String, Long> activeNotifs = new SimpleArrayMap<>();
 
     /**
      * Current speed of active downloads, mapped from {@link DownloadInfo#batchId}
@@ -106,7 +106,7 @@ class DownloadNotifier {
      * {@link DownloadInfo}, adding, collapsing, and removing as needed.
      */
     public void updateWith(Collection<DownloadBatch> batches) {
-        synchronized (mActiveNotifs) {
+        synchronized (activeNotifs) {
             SimpleArrayMap<String, Collection<DownloadBatch>> clusters = getClustersByNotificationTag(batches);
 
             showNotificationPerCluster(clusters);
@@ -207,11 +207,11 @@ class DownloadNotifier {
 
     private void useTimeWhenClusterFirstShownToAvoidShuffling(String tag, NotificationCompat.Builder builder) {
         final long firstShown;
-        if (mActiveNotifs.containsKey(tag)) {
-            firstShown = mActiveNotifs.get(tag);
+        if (activeNotifs.containsKey(tag)) {
+            firstShown = activeNotifs.get(tag);
         } else {
             firstShown = System.currentTimeMillis();
-            mActiveNotifs.put(tag, firstShown);
+            activeNotifs.put(tag, firstShown);
         }
         builder.setWhen(firstShown);
     }
@@ -422,11 +422,11 @@ class DownloadNotifier {
     }
 
     private void removeStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
-        for(int i = 0, size = mActiveNotifs.size(); i < size; i++) {
-            String tag = mActiveNotifs.keyAt(i);
+        for(int i = 0, size = activeNotifs.size(); i < size; i++) {
+            String tag = activeNotifs.keyAt(i);
             if (!clustered.containsKey(tag)) {
                 mNotifManager.cancel(tag.hashCode());
-                mActiveNotifs.removeAt(i);
+                activeNotifs.removeAt(i);
             }
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -37,7 +37,6 @@ import com.novoda.notils.logger.simple.Log;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -177,7 +176,7 @@ class DownloadNotifier {
         if (cluster.containsKey(tag)) {
             batches = cluster.get(tag);
         } else {
-            batches = new HashSet<>();
+            batches = new ArrayList<>();
             cluster.put(tag, batches); // TODO not sure if this is right compared to ArrayListMultiMap
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -422,7 +422,7 @@ class DownloadNotifier {
     }
 
     private void removeStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
-        for(int i = 0, size = activeNotifs.size(); i < size; i++) {
+        for (int i = 0, size = activeNotifs.size(); i < size; i++) {
             String tag = activeNotifs.keyAt(i);
             if (!clustered.containsKey(tag)) {
                 mNotifManager.cancel(tag.hashCode());

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -37,8 +37,6 @@ import com.novoda.notils.logger.simple.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -66,7 +64,7 @@ class DownloadNotifier {
      * @see #buildNotificationTag(DownloadBatch)
      */
 //    @GuardedBy("mActiveNotifs")
-    private final HashMap<String, Long> mActiveNotifs = new HashMap<>();
+    private final SimpleArrayMap<String, Long> mActiveNotifs = new SimpleArrayMap<>();
 
     /**
      * Current speed of active downloads, mapped from {@link DownloadInfo#batchId}
@@ -424,12 +422,11 @@ class DownloadNotifier {
     }
 
     private void removeStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
-        final Iterator<String> tags = mActiveNotifs.keySet().iterator();
-        while (tags.hasNext()) {
-            final String tag = tags.next();
+        for(int i = 0, size = mActiveNotifs.size(); i < size; i++) {
+            String tag = mActiveNotifs.keyAt(i);
             if (!clustered.containsKey(tag)) {
                 mNotifManager.cancel(tag.hashCode());
-                tags.remove();
+                mActiveNotifs.removeAt(i);
             }
         }
     }


### PR DESCRIPTION
This PR replaces the following data structures:

- Batches from `HashSet` to `ArrayList` because the insertion on an ArrayList is faster and there is no usage of any of the HashSet specific implementation advantatges
- mActiveNotifs and cluster from `HashMap` to `SimpleArrayMap` because the length of the items added to the maps are not too extensive, and so the optimised SimpleArrayMap is recommended (further detail at https://medium.com/google-developers/developing-for-android-ii-bb9a51f8c8b9)

Comment at https://github.com/novoda/download-manager/compare/Replace-data-structures?expand=1#diff-ee31e2ad08f5842e25b4b0175c130855L181 solved