### PR TITLE
Fix wrong item deletion looping through a list of items

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -23,7 +23,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.support.annotation.NonNull;
 import android.support.v4.util.SimpleArrayMap;
-import android.text.TextUtils;
 
 import com.novoda.notils.logger.simple.Log;
 
@@ -188,15 +187,6 @@ class DownloadNotifier {
         }
 
         return staleTags;
-    }
-
-    static CharSequence getDownloadTitle(BatchInfo batch) {
-        String title = batch.getTitle();
-        if (TextUtils.isEmpty(title)) {
-            return "unknown";
-        } else {
-            return title;
-        }
     }
 
     public void dumpSpeeds() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -20,7 +20,6 @@ import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.content.res.Resources;
 import android.support.annotation.NonNull;
 import android.support.v4.util.SimpleArrayMap;
 
@@ -55,14 +54,7 @@ class DownloadNotifier {
 
     private final NotificationDisplayer notificationDisplayer;
 
-    public static DownloadNotifier newInstance(Context context, NotificationImageRetriever imageRetriever, Resources resources) {
-        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        NotificationDisplayer notificationDisplayer = new NotificationDisplayer(context, notificationManager, imageRetriever, resources);
-
-        return new DownloadNotifier(context, notificationDisplayer);
-    }
-
-    DownloadNotifier(Context context, NotificationDisplayer notificationDisplayer) {
+    public DownloadNotifier(Context context, NotificationDisplayer notificationDisplayer) {
         this.context = context;
         this.notificationDisplayer = notificationDisplayer;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -422,7 +422,7 @@ class DownloadNotifier {
     }
 
     private void removeStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
-        for (int i = 0, size = activeNotifs.size(); i < size; i++) {
+        for (int i = activeNotifs.size() - 1; i >= 0; i--) {
             String tag = activeNotifs.keyAt(i);
             if (!clustered.containsKey(tag)) {
                 mNotifManager.cancel(tag.hashCode());

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -19,26 +19,17 @@ package com.novoda.downloadmanager.lib;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.ContentUris;
 import android.content.Context;
-import android.content.Intent;
 import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
-import android.support.v4.util.LongSparseArray;
 import android.support.v4.util.SimpleArrayMap;
 import android.text.TextUtils;
-import android.text.format.DateUtils;
 
-import com.novoda.downloadmanager.R;
 import com.novoda.notils.logger.simple.Log;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Update {@link NotificationManager} to reflect current {@link DownloadInfo}
@@ -47,15 +38,13 @@ import java.util.concurrent.TimeUnit;
  */
 class DownloadNotifier {
 
-    private static final int TYPE_ACTIVE = 1;
-    private static final int TYPE_WAITING = 2;
-    private static final int TYPE_SUCCESS = 3;
-    private static final int TYPE_FAILED = 4;
-    private static final int TYPE_CANCELLED = 5;
+    static final int TYPE_ACTIVE = 1;
+    static final int TYPE_WAITING = 2;
+    static final int TYPE_SUCCESS = 3;
+    static final int TYPE_FAILED = 4;
+    static final int TYPE_CANCELLED = 5;
 
-    private final Context mContext;
-    private final NotificationImageRetriever imageRetriever;
-    private final NotificationManager mNotifManager;
+    private final Context context;
 
     /**
      * Currently active notifications, mapped from clustering tag to timestamp
@@ -63,28 +52,24 @@ class DownloadNotifier {
      *
      * @see #buildNotificationTag(DownloadBatch)
      */
-//    @GuardedBy("mActiveNotifs")
-    private final SimpleArrayMap<String, Long> activeNotifs = new SimpleArrayMap<>();
+    private final SimpleArrayMap<String, Long> activeNotifications = new SimpleArrayMap<>();
 
-    /**
-     * Current speed of active downloads, mapped from {@link DownloadInfo#batchId}
-     * to speed in bytes per second.
-     */
-//    @GuardedBy("mDownloadSpeed")
-    // LongSparseLongArray
-    private final LongSparseArray<Long> mDownloadSpeed = new LongSparseArray<>();
+    private final NotificationDisplayer notificationDisplayer;
 
-    private final Resources resources;
+    public static DownloadNotifier newInstance(Context context, NotificationImageRetriever imageRetriever, Resources resources) {
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationDisplayer notificationDisplayer = new NotificationDisplayer(context, notificationManager, imageRetriever, resources);
 
-    public DownloadNotifier(Context context, NotificationImageRetriever imageRetriever, Resources resources) {
-        this.mContext = context;
-        this.resources = resources;
-        this.imageRetriever = imageRetriever;
-        this.mNotifManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        return new DownloadNotifier(context, notificationDisplayer);
+    }
+
+    DownloadNotifier(Context context, NotificationDisplayer notificationDisplayer) {
+        this.context = context;
+        this.notificationDisplayer = notificationDisplayer;
     }
 
     public void cancelAll() {
-        mNotifManager.cancelAll();
+        notificationDisplayer.cancelAll();
     }
 
     /**
@@ -92,13 +77,7 @@ class DownloadNotifier {
      * estimated remaining time.
      */
     public void notifyDownloadSpeed(long id, long bytesPerSecond) {
-        synchronized (mDownloadSpeed) {
-            if (bytesPerSecond != 0) {
-                mDownloadSpeed.put(id, bytesPerSecond);
-            } else {
-                mDownloadSpeed.remove(id);
-            }
-        }
+        notificationDisplayer.notifyDownloadSpeed(id, bytesPerSecond);
     }
 
     /**
@@ -106,13 +85,29 @@ class DownloadNotifier {
      * {@link DownloadInfo}, adding, collapsing, and removing as needed.
      */
     public void updateWith(Collection<DownloadBatch> batches) {
-        synchronized (activeNotifs) {
+        synchronized (activeNotifications) {
             SimpleArrayMap<String, Collection<DownloadBatch>> clusters = getClustersByNotificationTag(batches);
 
-            showNotificationPerCluster(clusters);
+            for (int i = 0, size = clusters.size(); i < size; i++) {
+                String notificationId = clusters.keyAt(i);
+                long firstShown = getFirstShownTime(notificationId);
+                notificationDisplayer.buildAndShowNotification(clusters, notificationId, firstShown);
+            }
 
-            removeStaleTagsThatWereNotRenewed(clusters);
+            List<Integer> staleTagsToBeRemoved = getStaleTagsThatWereNotRenewed(clusters);
+            notificationDisplayer.cancelStaleTags(staleTagsToBeRemoved);
         }
+    }
+
+    private long getFirstShownTime(String notificationId) {
+        final long firstShown;
+        if (activeNotifications.containsKey(notificationId)) {
+            firstShown = activeNotifications.get(notificationId);
+        } else {
+            firstShown = System.currentTimeMillis();
+            activeNotifications.put(notificationId, firstShown);
+        }
+        return firstShown;
     }
 
     @NonNull
@@ -136,9 +131,9 @@ class DownloadNotifier {
         int status = batch.getStatus();
         int visibility = batch.getInfo().getVisibility();
         if (status == Downloads.Impl.STATUS_QUEUED_FOR_WIFI) {
-            return TYPE_WAITING + ":" + mContext.getPackageName();
+            return TYPE_WAITING + ":" + context.getPackageName();
         } else if (status == Downloads.Impl.STATUS_RUNNING && shouldShowActiveItem(visibility)) {
-            return TYPE_ACTIVE + ":" + mContext.getPackageName();
+            return TYPE_ACTIVE + ":" + context.getPackageName();
         } else if (Downloads.Impl.isStatusError(status) && !Downloads.Impl.isStatusCancelled(status)
                 && shouldShowCompletedItem(visibility)) {
             // Failed downloads always have unique notifs
@@ -181,257 +176,21 @@ class DownloadNotifier {
         batches.add(batch);
     }
 
-    private void showNotificationPerCluster(SimpleArrayMap<String, Collection<DownloadBatch>> clusters) {
-        for (int i = 0, size = clusters.size(); i < size; i++) {
-            String notificationId = clusters.keyAt(i);
-            int type = getNotificationTagType(notificationId);
-            Collection<DownloadBatch> cluster = clusters.get(notificationId);
+    private List<Integer> getStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
+        List<Integer> staleTags = new ArrayList<>();
 
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(mContext);
-            useTimeWhenClusterFirstShownToAvoidShuffling(notificationId, builder);
-            buildIcon(type, builder);
-            buildActionIntents(notificationId, type, cluster, builder);
-
-            Notification notification = buildTitlesAndDescription(type, cluster, builder);
-            mNotifManager.notify(notificationId.hashCode(), notification);
-        }
-    }
-
-    /**
-     * Return the cluster type of the given as created by
-     * {@link #buildNotificationTag(DownloadBatch)}.
-     */
-    private static int getNotificationTagType(String tag) {
-        return Integer.parseInt(tag.substring(0, tag.indexOf(':')));
-    }
-
-    private void useTimeWhenClusterFirstShownToAvoidShuffling(String tag, NotificationCompat.Builder builder) {
-        final long firstShown;
-        if (activeNotifs.containsKey(tag)) {
-            firstShown = activeNotifs.get(tag);
-        } else {
-            firstShown = System.currentTimeMillis();
-            activeNotifs.put(tag, firstShown);
-        }
-        builder.setWhen(firstShown);
-    }
-
-    private void buildIcon(int type, NotificationCompat.Builder builder) {
-        switch (type) {
-            case TYPE_ACTIVE:
-                builder.setSmallIcon(android.R.drawable.stat_sys_download);
-                break;
-            case TYPE_WAITING:
-            case TYPE_FAILED:
-                builder.setSmallIcon(android.R.drawable.stat_sys_warning);
-                break;
-            case TYPE_SUCCESS:
-                builder.setSmallIcon(android.R.drawable.stat_sys_download_done);
-                break;
-            default:
-                //don't set an icon if none matches
-                break;
-        }
-    }
-
-    private void buildActionIntents(String tag, int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
-        if (type == TYPE_ACTIVE || type == TYPE_WAITING) {
-            // build a synthetic uri for intent identification purposes
-            Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
-            Intent clickIntent = new Intent(Constants.ACTION_LIST, uri, mContext, DownloadReceiver.class);
-            clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, getDownloadIds(cluster));
-            builder.setContentIntent(PendingIntent.getBroadcast(mContext, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
-            builder.setOngoing(true);
-
-            DownloadBatch batch = cluster.iterator().next();
-            Intent cancelIntent = new Intent(Constants.ACTION_CANCEL, null, mContext, DownloadReceiver.class);
-            cancelIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
-            PendingIntent pendingCancelIntent = PendingIntent.getBroadcast(mContext, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-            builder.addAction(R.drawable.dl__ic_action_cancel, "Cancel", pendingCancelIntent);
-
-        } else if (type == TYPE_SUCCESS) {
-            DownloadBatch batch = cluster.iterator().next();
-            // TODO: Decide how we handle notification clicks
-            DownloadInfo downloadInfo = batch.getDownloads().get(0);
-            Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, downloadInfo.mId);
-            builder.setAutoCancel(true);
-
-            final String action;
-            if (Downloads.Impl.isStatusError(batch.getStatus())) {
-                action = Constants.ACTION_LIST;
-            } else {
-                action = Constants.ACTION_OPEN;
-            }
-
-            final Intent intent = new Intent(action, uri, mContext, DownloadReceiver.class);
-            intent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, getDownloadIds(cluster));
-            intent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
-            builder.setContentIntent(PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT));
-
-            final Intent hideIntent = new Intent(Constants.ACTION_HIDE, uri, mContext, DownloadReceiver.class);
-            hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
-            builder.setDeleteIntent(PendingIntent.getBroadcast(mContext, 0, hideIntent, 0));
-        }
-    }
-
-    private Notification buildTitlesAndDescription(
-            int type,
-            Collection<DownloadBatch> cluster,
-            NotificationCompat.Builder builder) {
-
-        String remainingText = null;
-        String percentText = null;
-        if (type == TYPE_ACTIVE) {
-            long currentBytes = 0;
-            long totalBytes = 0;
-            long totalBytesPerSecond = 0;
-            synchronized (mDownloadSpeed) {
-                for (DownloadBatch batch : cluster) {
-                    for (DownloadInfo info : batch.getDownloads()) {
-                        if (info.hasTotalBytes()) {
-                            currentBytes += info.mCurrentBytes;
-                            totalBytes += info.mTotalBytes;
-                            Long bytesPerSecond = mDownloadSpeed.get(info.mId);
-                            if (bytesPerSecond != null) {
-                                totalBytesPerSecond += bytesPerSecond;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (totalBytes > 0) {
-                int percent = (int) ((currentBytes * 100) / totalBytes);
-                percentText = percent + "%";//res.getString(R.string.download_percent, percent);
-
-                if (totalBytesPerSecond > 0) {
-                    long remainingMillis = ((totalBytes - currentBytes) * 1000) / totalBytesPerSecond;
-                    remainingText = "Duration " + formatDuration(remainingMillis);
-                }
-
-                builder.setProgress(100, percent, false);
-            } else {
-                builder.setProgress(100, 0, true);
-            }
-        }
-
-        List<DownloadBatch> currentBatches = new ArrayList<>();
-        for (DownloadBatch batch : cluster) {
-            currentBatches.add(batch);
-        }
-
-        if (currentBatches.size() == 1) {
-            DownloadBatch batch = currentBatches.iterator().next();
-            return buildSingleNotification(type, builder, batch, remainingText, percentText);
-
-        } else {
-            return buildStackedNotification(type, builder, currentBatches, remainingText, percentText);
-        }
-
-    }
-
-    /**
-     * Return given duration in a human-friendly format. For example, "4
-     * minutes" or "1 second". Returns only largest meaningful unit of time,
-     * from seconds up to hours.
-     */
-    public CharSequence formatDuration(long millis) {
-        if (millis >= DateUtils.HOUR_IN_MILLIS) {
-            int hours = (int) TimeUnit.MILLISECONDS.toHours(millis + TimeUnit.MINUTES.toMillis(30));
-            return resources.getQuantityString(R.plurals.dl__duration_hours, hours, hours);
-        } else if (millis >= DateUtils.MINUTE_IN_MILLIS) {
-            int minutes = (int) TimeUnit.MILLISECONDS.toMinutes(millis + TimeUnit.SECONDS.toMillis(30));
-            return resources.getQuantityString(R.plurals.dl__duration_minutes, minutes, minutes);
-        } else {
-            int seconds = (int) TimeUnit.MILLISECONDS.toSeconds(millis + 500);
-            return resources.getQuantityString(R.plurals.dl__duration_seconds, seconds, seconds);
-        }
-    }
-
-    private Notification buildSingleNotification(int type, NotificationCompat.Builder builder, DownloadBatch batch, String remainingText, String percentText) {
-
-        NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle();
-        String imageUrl = batch.getInfo().getBigPictureUrl();
-        if (!TextUtils.isEmpty(imageUrl)) {
-            Bitmap bitmap = imageRetriever.retrieveImage(imageUrl);
-            style.bigPicture(bitmap);
-        }
-        CharSequence title = getDownloadTitle(batch.getInfo());
-        builder.setContentTitle(title);
-        style.setBigContentTitle(title);
-
-        if (type == TYPE_ACTIVE) {
-            String description = batch.getInfo().getDescription();
-            if (TextUtils.isEmpty(description)) {
-                setSecondaryNotificationText(builder, style, remainingText);
-            } else {
-                setSecondaryNotificationText(builder, style, description);
-            }
-            builder.setContentInfo(percentText);
-
-        } else if (type == TYPE_WAITING) {
-            setSecondaryNotificationText(builder, style, "Download size requires Wi-Fi.");
-
-        } else if (type == TYPE_SUCCESS) {
-            setSecondaryNotificationText(builder, style, "Download complete.");
-        } else if (type == TYPE_FAILED) {
-            setSecondaryNotificationText(builder, style, "Download unsuccessful.");
-        } else if (type == TYPE_CANCELLED) {
-            setSecondaryNotificationText(builder, style, "Download cancelled.");
-        }
-
-        if (!TextUtils.isEmpty(imageUrl)) {
-            builder.setStyle(style);
-        }
-        return builder.build();
-    }
-
-    private void setSecondaryNotificationText(NotificationCompat.Builder builder, NotificationCompat.BigPictureStyle style, String description) {
-        builder.setContentText(description);
-        style.setSummaryText(description);
-    }
-
-    private Notification buildStackedNotification(int type, NotificationCompat.Builder builder, Collection<DownloadBatch> currentBatches, String remainingText, String percentText) {
-        final NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
-
-        for (DownloadBatch batch : currentBatches) {
-            inboxStyle.addLine(getDownloadTitle(batch.getInfo()));
-        }
-
-        if (type == TYPE_ACTIVE) {
-            builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_active, currentBatches.size(), currentBatches.size()));
-            builder.setContentInfo(percentText);
-            setSecondaryNotificationText(builder, inboxStyle, remainingText);
-        } else if (type == TYPE_WAITING) {
-            builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_waiting, currentBatches.size(), currentBatches.size()));
-            setSecondaryNotificationText(builder, inboxStyle, "Download size requires Wi-Fi.");
-        } else if (type == TYPE_SUCCESS) {
-            setSecondaryNotificationText(builder, inboxStyle, "Download complete.");
-        } else if (type == TYPE_FAILED) {
-            setSecondaryNotificationText(builder, inboxStyle, "Download unsuccessful.");
-        } else if (type == TYPE_CANCELLED) {
-            setSecondaryNotificationText(builder, inboxStyle, "Download cancelled.");
-        }
-
-        return inboxStyle.build();
-    }
-
-    private void setSecondaryNotificationText(NotificationCompat.Builder builder, NotificationCompat.InboxStyle style, String description) {
-        builder.setContentText(description);
-        style.setSummaryText(description);
-    }
-
-    private void removeStaleTagsThatWereNotRenewed(SimpleArrayMap<String, Collection<DownloadBatch>> clustered) {
-        for (int i = activeNotifs.size() - 1; i >= 0; i--) {
-            String tag = activeNotifs.keyAt(i);
+        for (int i = activeNotifications.size() - 1; i >= 0; i--) {
+            String tag = activeNotifications.keyAt(i);
             if (!clustered.containsKey(tag)) {
-                mNotifManager.cancel(tag.hashCode());
-                activeNotifs.removeAt(i);
+                staleTags.add(tag.hashCode());
+                activeNotifications.removeAt(i);
             }
         }
+
+        return staleTags;
     }
 
-    private static CharSequence getDownloadTitle(BatchInfo batch) {
+    static CharSequence getDownloadTitle(BatchInfo batch) {
         String title = batch.getTitle();
         if (TextUtils.isEmpty(title)) {
             return "unknown";
@@ -440,24 +199,7 @@ class DownloadNotifier {
         }
     }
 
-    private long[] getDownloadIds(Collection<DownloadBatch> batches) {
-        List<Long> ids = new ArrayList<>();
-        for (DownloadBatch batch : batches) {
-            for (DownloadInfo downloadInfo : batch.getDownloads()) {
-                ids.add(downloadInfo.mId);
-            }
-        }
-
-        long[] idArray = new long[ids.size()];
-
-        for (int i = 0, idsSize = ids.size(); i < idsSize; i++) {
-            idArray[i] = ids.get(i);
-        }
-        return idArray;
-    }
-
     public void dumpSpeeds() {
         Log.e("dump at speed");
     }
-
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -17,6 +17,7 @@
 package com.novoda.downloadmanager.lib;
 
 import android.app.AlarmManager;
+import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.content.ContentValues;
@@ -150,7 +151,14 @@ public class DownloadService extends Service {
 
         downloadClientReadyChecker = getDownloadClientReadyChecker();
 
-        mNotifier = DownloadNotifier.newInstance(this, getNotificationImageRetriever(), getResources());
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationDisplayer notificationDisplayer = new NotificationDisplayer(
+                this,
+                notificationManager,
+                getNotificationImageRetriever(),
+                getResources());
+
+        mNotifier = new DownloadNotifier(this, notificationDisplayer);
         mNotifier.cancelAll();
 
         mObserver = new DownloadManagerContentObserver();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -150,7 +150,7 @@ public class DownloadService extends Service {
 
         downloadClientReadyChecker = getDownloadClientReadyChecker();
 
-        mNotifier = new DownloadNotifier(this, getNotificationImageRetriever(), getResources());
+        mNotifier = DownloadNotifier.newInstance(this, getNotificationImageRetriever(), getResources());
         mNotifier.cancelAll();
 
         mObserver = new DownloadManagerContentObserver();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
@@ -1,0 +1,314 @@
+package com.novoda.downloadmanager.lib;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.ContentUris;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.net.Uri;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.util.LongSparseArray;
+import android.support.v4.util.SimpleArrayMap;
+import android.text.TextUtils;
+import android.text.format.DateUtils;
+
+import com.novoda.downloadmanager.R;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+class NotificationDisplayer {
+    private final Context context;
+    private final NotificationManager notificationManager;
+    private final NotificationImageRetriever imageRetriever;
+    private final Resources resources;
+
+    /**
+     * Current speed of active downloads, mapped from {@link DownloadInfo#batchId}
+     * to speed in bytes per second.
+     */
+    private final LongSparseArray<Long> downloadSpeed = new LongSparseArray<>();
+
+    public NotificationDisplayer(
+            Context context,
+            NotificationManager notificationManager,
+            NotificationImageRetriever imageRetriever,
+            Resources resources) {
+        this.context = context;
+        this.notificationManager = notificationManager;
+        this.imageRetriever = imageRetriever;
+        this.resources = resources;
+    }
+
+    public void buildAndShowNotification(SimpleArrayMap<String, Collection<DownloadBatch>> clusters, String notificationId, long firstShown) {
+        int type = getNotificationTagType(notificationId);
+        Collection<DownloadBatch> cluster = clusters.get(notificationId);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
+        builder.setWhen(firstShown);
+        buildIcon(type, builder);
+        buildActionIntents(notificationId, type, cluster, builder);
+
+        Notification notification = buildTitlesAndDescription(type, cluster, builder);
+        notificationManager.notify(notificationId.hashCode(), notification);
+    }
+
+    /**
+     * Return the cluster type of the given as created by
+     * {@link DownloadNotifier#buildNotificationTag(DownloadBatch)}.
+     */
+    private int getNotificationTagType(String tag) {
+        return Integer.parseInt(tag.substring(0, tag.indexOf(':')));
+    }
+
+    private void buildIcon(int type, NotificationCompat.Builder builder) {
+        switch (type) {
+            case DownloadNotifier.TYPE_ACTIVE:
+                builder.setSmallIcon(android.R.drawable.stat_sys_download);
+                break;
+            case DownloadNotifier.TYPE_WAITING:
+            case DownloadNotifier.TYPE_FAILED:
+                builder.setSmallIcon(android.R.drawable.stat_sys_warning);
+                break;
+            case DownloadNotifier.TYPE_SUCCESS:
+                builder.setSmallIcon(android.R.drawable.stat_sys_download_done);
+                break;
+            default:
+                //don't set an icon if none matches
+                break;
+        }
+    }
+
+    private void buildActionIntents(String tag, int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
+        if (type == DownloadNotifier.TYPE_ACTIVE || type == DownloadNotifier.TYPE_WAITING) {
+            // build a synthetic uri for intent identification purposes
+            Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
+            Intent clickIntent = new Intent(Constants.ACTION_LIST, uri, context, DownloadReceiver.class);
+            clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, getDownloadIds(cluster));
+            builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+            builder.setOngoing(true);
+
+            DownloadBatch batch = cluster.iterator().next();
+            Intent cancelIntent = new Intent(Constants.ACTION_CANCEL, null, context, DownloadReceiver.class);
+            cancelIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
+            PendingIntent pendingCancelIntent = PendingIntent.getBroadcast(context, 0, cancelIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            builder.addAction(R.drawable.dl__ic_action_cancel, "Cancel", pendingCancelIntent);
+
+        } else if (type == DownloadNotifier.TYPE_SUCCESS) {
+            DownloadBatch batch = cluster.iterator().next();
+            // TODO: Decide how we handle notification clicks
+            DownloadInfo downloadInfo = batch.getDownloads().get(0);
+            Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, downloadInfo.mId);
+            builder.setAutoCancel(true);
+
+            final String action;
+            if (Downloads.Impl.isStatusError(batch.getStatus())) {
+                action = Constants.ACTION_LIST;
+            } else {
+                action = Constants.ACTION_OPEN;
+            }
+
+            final Intent intent = new Intent(action, uri, context, DownloadReceiver.class);
+            intent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, getDownloadIds(cluster));
+            intent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
+            builder.setContentIntent(PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT));
+
+            final Intent hideIntent = new Intent(Constants.ACTION_HIDE, uri, context, DownloadReceiver.class);
+            hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batch.getBatchId());
+            builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, hideIntent, 0));
+        }
+    }
+
+    private Notification buildTitlesAndDescription(int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
+        String remainingText = null;
+        String percentText = null;
+        if (type == DownloadNotifier.TYPE_ACTIVE) {
+            long currentBytes = 0;
+            long totalBytes = 0;
+            long totalBytesPerSecond = 0;
+            synchronized (downloadSpeed) {
+                for (DownloadBatch batch : cluster) {
+                    for (DownloadInfo info : batch.getDownloads()) {
+                        if (info.hasTotalBytes()) {
+                            currentBytes += info.mCurrentBytes;
+                            totalBytes += info.mTotalBytes;
+                            Long bytesPerSecond = downloadSpeed.get(info.mId);
+                            if (bytesPerSecond != null) {
+                                totalBytesPerSecond += bytesPerSecond;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (totalBytes > 0) {
+                int percent = (int) ((currentBytes * 100) / totalBytes);
+                percentText = percent + "%";//res.getString(R.string.download_percent, percent);
+
+                if (totalBytesPerSecond > 0) {
+                    long remainingMillis = ((totalBytes - currentBytes) * 1000) / totalBytesPerSecond;
+                    remainingText = "Duration " + formatDuration(remainingMillis);
+                }
+
+                builder.setProgress(100, percent, false);
+            } else {
+                builder.setProgress(100, 0, true);
+            }
+        }
+
+        List<DownloadBatch> currentBatches = new ArrayList<>();
+        for (DownloadBatch batch : cluster) {
+            currentBatches.add(batch);
+        }
+
+        if (currentBatches.size() == 1) {
+            DownloadBatch batch = currentBatches.iterator().next();
+            return buildSingleNotification(type, builder, batch, remainingText, percentText);
+
+        } else {
+            return buildStackedNotification(type, builder, currentBatches, remainingText, percentText);
+        }
+    }
+
+    private Notification buildSingleNotification(
+            int type,
+            NotificationCompat.Builder builder,
+            DownloadBatch batch, String remainingText,
+            String percentText) {
+
+        NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle();
+        String imageUrl = batch.getInfo().getBigPictureUrl();
+        if (!TextUtils.isEmpty(imageUrl)) {
+            Bitmap bitmap = imageRetriever.retrieveImage(imageUrl);
+            style.bigPicture(bitmap);
+        }
+        CharSequence title = DownloadNotifier.getDownloadTitle(batch.getInfo());
+        builder.setContentTitle(title);
+        style.setBigContentTitle(title);
+
+        if (type == DownloadNotifier.TYPE_ACTIVE) {
+            String description = batch.getInfo().getDescription();
+            if (TextUtils.isEmpty(description)) {
+                setSecondaryNotificationText(builder, style, remainingText);
+            } else {
+                setSecondaryNotificationText(builder, style, description);
+            }
+            builder.setContentInfo(percentText);
+
+        } else if (type == DownloadNotifier.TYPE_WAITING) {
+            setSecondaryNotificationText(builder, style, "Download size requires Wi-Fi.");
+
+        } else if (type == DownloadNotifier.TYPE_SUCCESS) {
+            setSecondaryNotificationText(builder, style, "Download complete.");
+        } else if (type == DownloadNotifier.TYPE_FAILED) {
+            setSecondaryNotificationText(builder, style, "Download unsuccessful.");
+        } else if (type == DownloadNotifier.TYPE_CANCELLED) {
+            setSecondaryNotificationText(builder, style, "Download cancelled.");
+        }
+
+        if (!TextUtils.isEmpty(imageUrl)) {
+            builder.setStyle(style);
+        }
+        return builder.build();
+    }
+
+    private void setSecondaryNotificationText(NotificationCompat.Builder builder, NotificationCompat.BigPictureStyle style, String description) {
+        builder.setContentText(description);
+        style.setSummaryText(description);
+    }
+
+    private Notification buildStackedNotification(
+            int type,
+            NotificationCompat.Builder builder,
+            Collection<DownloadBatch> currentBatches,
+            String remainingText,
+            String percentText) {
+
+        final NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
+
+        for (DownloadBatch batch : currentBatches) {
+            inboxStyle.addLine(DownloadNotifier.getDownloadTitle(batch.getInfo()));
+        }
+
+        if (type == DownloadNotifier.TYPE_ACTIVE) {
+            builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_active, currentBatches.size(), currentBatches.size()));
+            builder.setContentInfo(percentText);
+            setSecondaryNotificationText(builder, inboxStyle, remainingText);
+        } else if (type == DownloadNotifier.TYPE_WAITING) {
+            builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_waiting, currentBatches.size(), currentBatches.size()));
+            setSecondaryNotificationText(builder, inboxStyle, "Download size requires Wi-Fi.");
+        } else if (type == DownloadNotifier.TYPE_SUCCESS) {
+            setSecondaryNotificationText(builder, inboxStyle, "Download complete.");
+        } else if (type == DownloadNotifier.TYPE_FAILED) {
+            setSecondaryNotificationText(builder, inboxStyle, "Download unsuccessful.");
+        } else if (type == DownloadNotifier.TYPE_CANCELLED) {
+            setSecondaryNotificationText(builder, inboxStyle, "Download cancelled.");
+        }
+
+        return inboxStyle.build();
+    }
+
+    private void setSecondaryNotificationText(NotificationCompat.Builder builder, NotificationCompat.InboxStyle style, String description) {
+        builder.setContentText(description);
+        style.setSummaryText(description);
+    }
+
+    private long[] getDownloadIds(Collection<DownloadBatch> batches) {
+        List<Long> ids = new ArrayList<>();
+        for (DownloadBatch batch : batches) {
+            for (DownloadInfo downloadInfo : batch.getDownloads()) {
+                ids.add(downloadInfo.mId);
+            }
+        }
+
+        long[] idArray = new long[ids.size()];
+
+        for (int i = 0, idsSize = ids.size(); i < idsSize; i++) {
+            idArray[i] = ids.get(i);
+        }
+        return idArray;
+    }
+
+    public void notifyDownloadSpeed(long id, long bytesPerSecond) {
+        synchronized (downloadSpeed) {
+            if (bytesPerSecond != 0) {
+                downloadSpeed.put(id, bytesPerSecond);
+            } else {
+                downloadSpeed.remove(id);
+            }
+        }
+    }
+
+    /**
+     * Return given duration in a human-friendly format. For example, "4
+     * minutes" or "1 second". Returns only largest meaningful unit of time,
+     * from seconds up to hours.
+     */
+    private CharSequence formatDuration(long millis) {
+        if (millis >= DateUtils.HOUR_IN_MILLIS) {
+            int hours = (int) TimeUnit.MILLISECONDS.toHours(millis + TimeUnit.MINUTES.toMillis(30));
+            return resources.getQuantityString(R.plurals.dl__duration_hours, hours, hours);
+        } else if (millis >= DateUtils.MINUTE_IN_MILLIS) {
+            int minutes = (int) TimeUnit.MILLISECONDS.toMinutes(millis + TimeUnit.SECONDS.toMillis(30));
+            return resources.getQuantityString(R.plurals.dl__duration_minutes, minutes, minutes);
+        } else {
+            int seconds = (int) TimeUnit.MILLISECONDS.toSeconds(millis + 500);
+            return resources.getQuantityString(R.plurals.dl__duration_seconds, seconds, seconds);
+        }
+    }
+
+    public void cancelStaleTags(List<Integer> staleTagsToBeRemoved) {
+        for (Integer tag : staleTagsToBeRemoved) {
+            notificationManager.cancel(tag);
+        }
+    }
+
+    public void cancelAll() {
+        notificationManager.cancelAll();
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
@@ -187,7 +187,7 @@ class NotificationDisplayer {
             Bitmap bitmap = imageRetriever.retrieveImage(imageUrl);
             style.bigPicture(bitmap);
         }
-        CharSequence title = DownloadNotifier.getDownloadTitle(batch.getInfo());
+        CharSequence title = getDownloadTitle(batch.getInfo());
         builder.setContentTitle(title);
         style.setBigContentTitle(title);
 
@@ -217,6 +217,15 @@ class NotificationDisplayer {
         return builder.build();
     }
 
+    private CharSequence getDownloadTitle(BatchInfo batch) {
+        String title = batch.getTitle();
+        if (TextUtils.isEmpty(title)) {
+            return "unknown";
+        } else {
+            return title;
+        }
+    }
+
     private void setSecondaryNotificationText(NotificationCompat.Builder builder, NotificationCompat.BigPictureStyle style, String description) {
         builder.setContentText(description);
         style.setSummaryText(description);
@@ -232,7 +241,7 @@ class NotificationDisplayer {
         final NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
 
         for (DownloadBatch batch : currentBatches) {
-            inboxStyle.addLine(DownloadNotifier.getDownloadTitle(batch.getInfo()));
+            inboxStyle.addLine(getDownloadTitle(batch.getInfo()));
         }
 
         if (type == DownloadNotifier.TYPE_ACTIVE) {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadNotifierTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadNotifierTest.java
@@ -1,0 +1,54 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.Context;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DownloadNotifierTest {
+
+    @Mock
+    private NotificationDisplayer mockNotificationDisplayer;
+    @Mock
+    private Context mockContext;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void whenRemovingStaleNotificationsThenItDoesNotCrash() {
+        Collection<DownloadBatch> batches = new ArrayList<>();
+
+        DownloadBatch batchQueuedForWifi = getDownloadBatchWith(Downloads.Impl.STATUS_QUEUED_FOR_WIFI);
+        DownloadBatch batchRunning = getDownloadBatchWith(Downloads.Impl.STATUS_RUNNING);
+
+        batches.add(batchQueuedForWifi);
+        batches.add(batchRunning);
+
+        Collection<DownloadBatch> updatedBatches = new ArrayList<>();
+        DownloadBatch batchQueuedForWifiUpdated = getDownloadBatchWith(Downloads.Impl.STATUS_QUEUED_FOR_WIFI);
+        updatedBatches.add(batchQueuedForWifiUpdated);
+
+        DownloadNotifier downloadNotifier = new DownloadNotifier(mockContext, mockNotificationDisplayer);
+        downloadNotifier.updateWith(batches);
+        downloadNotifier.updateWith(updatedBatches);
+    }
+
+    private DownloadBatch getDownloadBatchWith(int status) {
+        return new DownloadBatch(
+                1,
+                new BatchInfo("", "", "", NotificationVisibility.ACTIVE_OR_COMPLETE),
+                new ArrayList<DownloadInfo>(),
+                status,
+                1,
+                1);
+    }
+}


### PR DESCRIPTION
## Problem description ##

There is a `NullPointerException` at executing `tag.hashCode()` when `removeStaleTagsThatWereNotRenewed(...)`

## Solution implemented ##

- The deletion of an item through a manual iteration must be done in reverse order
- We have extracted the code related to displaying the notifications
- We have added tests around removing the staled notifications

Paired with @amlcurran 