### PR TITLE
Revert constant for query selection and project only the column needed

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -32,9 +32,9 @@ class BatchRepository {
 
     private static final int PRIORITISED_STATUSES_SIZE = PRIORITISED_STATUSES.size();
 
-    private static final String[] PROJECT_BATCH_ID = {Downloads.Impl.Batches._ID};
-    private static final String SELECT_DELETED = Downloads.Impl.Batches.COLUMN_DELETED;
-    private static final String[] WHERE_MARKED_FOR_DELETION = {"1"};
+    private static final String[] PROJECT_BATCH_ID = {Batches._ID};
+    private static final String WHERE_DELETED_VALUE_IS = Batches.COLUMN_DELETED + " = ?";
+    private static final String[] MARKED_FOR_DELETION = {"1"};
 
     private final ContentResolver resolver;
     private final DownloadDeleter downloadDeleter;
@@ -170,7 +170,7 @@ class BatchRepository {
     }
 
     public void deleteMarkedBatchesFor(Collection<DownloadInfo> downloads) {
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECT_BATCH_ID, SELECT_DELETED, WHERE_MARKED_FOR_DELETION, null);
+        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECT_BATCH_ID, WHERE_DELETED_VALUE_IS, MARKED_FOR_DELETION, null);
         List<Long> batchIdsToDelete = new ArrayList<>();
         try {
             while (batchesCursor.moveToNext()) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -32,7 +32,7 @@ class BatchRepository {
 
     private static final int PRIORITISED_STATUSES_SIZE = PRIORITISED_STATUSES.size();
 
-    private static final String[] PROJECTION_BATCH_ID = {Downloads.Impl.Batches._ID};
+    private static final String[] PROJECT_BATCH_ID = {Downloads.Impl.Batches._ID};
     private static final String SELECT_DELETED = Downloads.Impl.Batches.COLUMN_DELETED;
     private static final String[] WHERE_MARKED_FOR_DELETION = {"1"};
 
@@ -170,7 +170,7 @@ class BatchRepository {
     }
 
     public void deleteMarkedBatchesFor(Collection<DownloadInfo> downloads) {
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECTION_BATCH_ID, SELECT_DELETED, WHERE_MARKED_FOR_DELETION, null);
+        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECT_BATCH_ID, SELECT_DELETED, WHERE_MARKED_FOR_DELETION, null);
         List<Long> batchIdsToDelete = new ArrayList<>();
         try {
             while (batchesCursor.moveToNext()) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -31,7 +31,7 @@ class BatchRepository {
     );
 
     private static final int PRIORITISED_STATUSES_SIZE = PRIORITISED_STATUSES.size();
-    private static final String SELECT_MARKED_FOR_DELETION = Batches.COLUMN_DELETED + " = 1";
+    private static final String MARKED_FOR_DELETION = "1";
 
     private final ContentResolver resolver;
     private final DownloadDeleter downloadDeleter;
@@ -167,13 +167,15 @@ class BatchRepository {
     }
 
     public void deleteMarkedBatchesFor(Collection<DownloadInfo> downloads) {
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, null, SELECT_MARKED_FOR_DELETION, null, null);
+        String[] projection = {Downloads.Impl.Batches._ID};
+        String selection = Batches.COLUMN_DELETED + " = ?";
+        String[] selectionArgs = {MARKED_FOR_DELETION};
+
+        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, projection, selection, selectionArgs, null);
         List<Long> batchIdsToDelete = new ArrayList<>();
         try {
-            int idColumn = batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches._ID);
-
             while (batchesCursor.moveToNext()) {
-                long id = batchesCursor.getLong(idColumn);
+                long id = batchesCursor.getLong(0);
                 batchIdsToDelete.add(id);
             }
         } finally {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -31,7 +31,10 @@ class BatchRepository {
     );
 
     private static final int PRIORITISED_STATUSES_SIZE = PRIORITISED_STATUSES.size();
-    private static final String MARKED_FOR_DELETION = "1";
+
+    private static final String[] PROJECTION_BATCH_ID = {Downloads.Impl.Batches._ID};
+    private static final String SELECT_DELETED = Downloads.Impl.Batches.COLUMN_DELETED;
+    private static final String[] WHERE_MARKED_FOR_DELETION = {"1"};
 
     private final ContentResolver resolver;
     private final DownloadDeleter downloadDeleter;
@@ -167,11 +170,7 @@ class BatchRepository {
     }
 
     public void deleteMarkedBatchesFor(Collection<DownloadInfo> downloads) {
-        String[] projection = {Downloads.Impl.Batches._ID};
-        String selection = Batches.COLUMN_DELETED + " = ?";
-        String[] selectionArgs = {MARKED_FOR_DELETION};
-
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, projection, selection, selectionArgs, null);
+        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECTION_BATCH_ID, SELECT_DELETED, WHERE_MARKED_FOR_DELETION, null);
         List<Long> batchIdsToDelete = new ArrayList<>();
         try {
             while (batchesCursor.moveToNext()) {


### PR DESCRIPTION
## Task description ##

This PR amends the comments at https://github.com/novoda/download-manager/pull/62#discussion_r33934601

- Use `selection` and `selectionArgs` instead of a constant value
- Project only the column that we need