### PR TITLE
Fix error when no batch ID is provided for the Query filter

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -715,7 +715,7 @@ public class DownloadManager {
     /**
      * Get the DownloadProvider URI for the download with the given ID.
      */
-    Uri getDownloadUri(long id) {
+    private Uri getDownloadUri(long id) {
         return ContentUris.withAppendedId(mBaseUri, id);
     }
 
@@ -739,7 +739,7 @@ public class DownloadManager {
     /**
      * Get the selection args for a clause returned by {@link #getWhereClauseForIds(long[])}.
      */
-    static String[] longArrayToStringArray(long[] ids) {
+    private static String[] longArrayToStringArray(long[] ids) {
         String[] whereArgs = new String[ids.length];
         for (int i = 0; i < ids.length; i++) {
             whereArgs[i] = Long.toString(ids[i]);

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -1,0 +1,51 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class QueryTest {
+
+    @Mock
+    private Uri uri;
+
+    @Mock
+    private ContentResolver resolver;
+
+    @Captor
+    ArgumentCaptor<String> stringArgumentCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    @Test
+    public void givenBatchIdsWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
+        new Query().setFilterByBatchId(1, 2, 3).runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertThat(stringArgumentCaptor.getValue()).contains(Downloads.Impl.COLUMN_BATCH_ID + " IN (1,2,3)");
+    }
+
+    @Test
+    public void givenNoBatchIdsWhenTheQueryIsCreatedThenTheWhereStatementContainsNoBatchIdPredicate() {
+        new Query().runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertThat(stringArgumentCaptor.getValue()).doesNotContain(Downloads.Impl.COLUMN_BATCH_ID + " IN ");
+    }
+}


### PR DESCRIPTION
Fixes the error:
```
E/SQLiteLog﹕ (1) near ")": syntax error
```
when no batch IDs have been provided to a `Query`.

Also simplifies the SQL generation and adds test around this functionality.