### PR TITLE
Incorrect batch id passed to the rule checker

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -127,7 +127,14 @@ class BatchRepository {
     public DownloadBatch retrieveBatchFor(DownloadInfo download) {
         Collection<DownloadInfo> downloads = Collections.singletonList(download);
         List<DownloadBatch> batches = retrieveBatchesFor(downloads);
-        return batches.isEmpty() ? DownloadBatch.DELETED : batches.get(0);
+
+        for (DownloadBatch batch : batches) {
+            if (batch.getBatchId() == download.batchId) {
+                return batch;
+            }
+        }
+
+        return DownloadBatch.DELETED;
     }
 
     public List<DownloadBatch> retrieveBatchesFor(Collection<DownloadInfo> downloads) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -44,7 +44,6 @@ class BatchRepository {
 
     public static BatchRepository newInstance(ContentResolver resolver, DownloadDeleter downloadDeleter) {
         return new BatchRepository(resolver, downloadDeleter, BATCH_CONTENT_URI, ALL_DOWNLOADS_CONTENT_URI);
-
     }
 
     BatchRepository(ContentResolver resolver, DownloadDeleter downloadDeleter, Uri batchContentUri, Uri allDownloadsContentUri) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager.lib;
 import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.SparseIntArray;
 
@@ -38,22 +39,31 @@ class BatchRepository {
 
     private final ContentResolver resolver;
     private final DownloadDeleter downloadDeleter;
+    private final Uri batchContentUri;
+    private final Uri allDownloadsContentUri;
 
-    public BatchRepository(ContentResolver resolver, DownloadDeleter downloadDeleter) {
+    public static BatchRepository newInstance(ContentResolver resolver, DownloadDeleter downloadDeleter) {
+        return new BatchRepository(resolver, downloadDeleter, BATCH_CONTENT_URI, ALL_DOWNLOADS_CONTENT_URI);
+
+    }
+
+    BatchRepository(ContentResolver resolver, DownloadDeleter downloadDeleter, Uri batchContentUri, Uri allDownloadsContentUri) {
         this.resolver = resolver;
         this.downloadDeleter = downloadDeleter;
+        this.batchContentUri = batchContentUri;
+        this.allDownloadsContentUri = allDownloadsContentUri;
     }
 
     void updateTotalSize(long batchId) {
         ContentValues updateValues = new ContentValues();
         updateValues.put(Batches.COLUMN_TOTAL_BYTES, getSummedBatchSizeInBytes(batchId, COLUMN_TOTAL_BYTES));
-        resolver.update(BATCH_CONTENT_URI, updateValues, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
+        resolver.update(batchContentUri, updateValues, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
     }
 
     void updateCurrentSize(long batchId) {
         ContentValues updateValues = new ContentValues();
         updateValues.put(Batches.COLUMN_CURRENT_BYTES, getSummedBatchSizeInBytes(batchId, COLUMN_CURRENT_BYTES));
-        resolver.update(BATCH_CONTENT_URI, updateValues, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
+        resolver.update(batchContentUri, updateValues, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
     }
 
     private long getSummedBatchSizeInBytes(long batchId, String columnName) {
@@ -62,7 +72,7 @@ class BatchRepository {
         try {
             String[] selectionArgs = {String.valueOf(batchId)};
             cursor = resolver.query(
-                    ALL_DOWNLOADS_CONTENT_URI,
+                    allDownloadsContentUri,
                     new String[]{"sum(" + columnName + ")"},
                     COLUMN_BATCH_ID + " = ?",
                     selectionArgs,
@@ -82,7 +92,7 @@ class BatchRepository {
     void updateBatchStatus(long batchId, int status) {
         ContentValues values = new ContentValues();
         values.put(Batches.COLUMN_STATUS, status);
-        resolver.update(BATCH_CONTENT_URI, values, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
+        resolver.update(batchContentUri, values, Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
     }
 
     int getBatchStatus(long batchId) {
@@ -91,7 +101,7 @@ class BatchRepository {
         try {
             String[] selectionArgs = {String.valueOf(batchId)};
             cursor = resolver.query(
-                    ALL_DOWNLOADS_CONTENT_URI,
+                    allDownloadsContentUri,
                     null,
                     COLUMN_BATCH_ID + " = ?",
                     selectionArgs,
@@ -129,7 +139,7 @@ class BatchRepository {
         List<DownloadBatch> batches = retrieveBatchesFor(downloads);
 
         for (DownloadBatch batch : batches) {
-            if (batch.getBatchId() == download.batchId) {
+            if (batch.getBatchId() == download.getBatchId()) {
                 return batch;
             }
         }
@@ -138,7 +148,7 @@ class BatchRepository {
     }
 
     public List<DownloadBatch> retrieveBatchesFor(Collection<DownloadInfo> downloads) {
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, null, null, null, null);
+        Cursor batchesCursor = resolver.query(batchContentUri, null, null, null, null);
         List<DownloadBatch> batches = new ArrayList<>(batchesCursor.getCount());
         try {
             int idColumn = batchesCursor.getColumnIndexOrThrow(Downloads.Impl.Batches._ID);
@@ -163,7 +173,7 @@ class BatchRepository {
 
                 List<DownloadInfo> batchDownloads = new ArrayList<>(1);
                 for (DownloadInfo downloadInfo : downloads) {
-                    if (downloadInfo.batchId == id) {
+                    if (downloadInfo.getBatchId() == id) {
                         batchDownloads.add(downloadInfo);
                     }
                 }
@@ -177,7 +187,7 @@ class BatchRepository {
     }
 
     public void deleteMarkedBatchesFor(Collection<DownloadInfo> downloads) {
-        Cursor batchesCursor = resolver.query(Downloads.Impl.BATCH_CONTENT_URI, PROJECT_BATCH_ID, WHERE_DELETED_VALUE_IS, MARKED_FOR_DELETION, null);
+        Cursor batchesCursor = resolver.query(batchContentUri, PROJECT_BATCH_ID, WHERE_DELETED_VALUE_IS, MARKED_FOR_DELETION, null);
         List<Long> batchIdsToDelete = new ArrayList<>();
         try {
             while (batchesCursor.moveToNext()) {
@@ -197,13 +207,13 @@ class BatchRepository {
         }
 
         for (DownloadInfo download : downloads) {
-            if (batchIdsToDelete.contains(download.batchId)) {
+            if (batchIdsToDelete.contains(download.getBatchId())) {
                 downloadDeleter.deleteFileAndDatabaseRow(download);
             }
         }
 
         String selection = TextUtils.join(", ", batchIdsToDelete);
         String[] selectionArgs = {selection};
-        resolver.delete(Downloads.Impl.BATCH_CONTENT_URI, Downloads.Impl.Batches._ID + " IN (?)", selectionArgs);
+        resolver.delete(batchContentUri, Downloads.Impl.Batches._ID + " IN (?)", selectionArgs);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Future;
  * Stores information about an individual download.
  */
 class DownloadInfo {
+
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
     private static final int UNKNOWN_BYTES = -1;
 
@@ -226,7 +227,7 @@ class DownloadInfo {
     public boolean mAllowRoaming;
     public boolean mAllowMetered;
     public int mBypassRecommendedSizeLimit;
-    public long batchId;
+    private long batchId;
 
     private List<Pair<String, String>> mRequestHeaders = new ArrayList<Pair<String, String>>();
 
@@ -259,6 +260,10 @@ class DownloadInfo {
         this.randomNumberGenerator = randomNumberGenerator;
         this.downloadClientReadyChecker = downloadClientReadyChecker;
         this.downloadStatusContentValues = downloadStatusContentValues;
+    }
+
+    public long getBatchId() {
+        return batchId;
     }
 
     public Collection<Pair<String, String>> getHeaders() {
@@ -456,7 +461,7 @@ class DownloadInfo {
             if (mSubmittedTask == null || mSubmittedTask.isDone()) {
                 BatchCompletionBroadcaster batchCompletionBroadcaster = BatchCompletionBroadcaster.newInstance(mContext);
                 ContentResolver contentResolver = mContext.getContentResolver();
-                BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver));
+                BatchRepository batchRepository = BatchRepository.newInstance(contentResolver, new DownloadDeleter(contentResolver));
                 DownloadThread downloadThread = new DownloadThread(mContext, mSystemFacade, this, mStorageManager, mNotifier,
                         batchCompletionBroadcaster, batchRepository);
                 mSubmittedTask = executor.submit(downloadThread);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -134,7 +134,7 @@ public class DownloadService extends Service {
         Log.v("Service onCreate");
 
         this.downloadDeleter = new DownloadDeleter(getContentResolver());
-        this.batchRepository = new BatchRepository(getContentResolver(), downloadDeleter);
+        this.batchRepository = BatchRepository.newInstance(getContentResolver(), downloadDeleter);
 
         if (mSystemFacade == null) {
             mSystemFacade = new RealSystemFacade(this);
@@ -338,8 +338,8 @@ public class DownloadService extends Service {
                     }
 
                     updateTotalBytesFor(info);
-                    batchRepository.updateCurrentSize(info.batchId);
-                    batchRepository.updateTotalSize(info.batchId);
+                    batchRepository.updateCurrentSize(info.getBatchId());
+                    batchRepository.updateTotalSize(info.getBatchId());
 
                     isActive = kickOffDownloadTaskIfReady(isActive, info, downloadBatch);
                     isActive = kickOffMediaScanIfCompleted(isActive, info);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -201,7 +201,7 @@ class DownloadThread implements Runnable {
 
         if (downloadStatus != Downloads.Impl.STATUS_RUNNING) {
             mInfo.updateStatus(Downloads.Impl.STATUS_RUNNING);
-            updateBatchStatus(mInfo.batchId, mInfo.mId);
+            updateBatchStatus(mInfo.getBatchId(), mInfo.mId);
         }
 
         State state = new State(mInfo);
@@ -852,7 +852,7 @@ class DownloadThread implements Runnable {
         }
         getContentResolver().update(mInfo.getAllDownloadsUri(), values, null, null);
 
-        updateBatchStatus(mInfo.batchId, mInfo.mId);
+        updateBatchStatus(mInfo.getBatchId(), mInfo.mId);
     }
 
     private ContentResolver getContentResolver() {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class BatchRepositoryTest {
+
+    BatchRepository batchRepository;
+
+    @Mock
+    ContentResolver contentResolver;
+
+    @Mock
+    DownloadDeleter downloadDeleter;
+
+    @Mock
+    DownloadInfo downloadInfo;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        this.batchRepository = new BatchRepository(contentResolver, downloadDeleter, mock(Uri.class), mock(Uri.class));
+    }
+
+    @Test
+    public void givenADownloadInfoWhenRetrievingTheBatchThenTheBatchIdsMatch() {
+        long expectedBatchId = 100L;
+        when(downloadInfo.getBatchId()).thenReturn(expectedBatchId);
+        Cursor batchCursor = singleBatchCursor(expectedBatchId);
+        when(contentResolver.query(any(Uri.class), any(String[].class), anyString(), any(String[].class), anyString())).thenReturn(batchCursor);
+
+        DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(downloadInfo);
+
+        assertThat(downloadBatch.getBatchId()).isEqualTo(expectedBatchId);
+    }
+
+    private Cursor singleBatchCursor(final long batchId) {
+        final int batchSize = 1;
+        int idColumn = 1337;
+        Cursor cursor = mock(Cursor.class);
+        when(cursor.getColumnIndexOrThrow(Downloads.Impl.Batches._ID)).thenReturn(idColumn);
+        when(cursor.moveToNext()).thenAnswer(new Answer<Boolean>() {
+            int count = 0;
+
+            @Override
+            public Boolean answer(InvocationOnMock invocation) throws Throwable {
+                boolean batchSizeNotReached = count < batchSize;
+                count++;
+                return batchSizeNotReached;
+            }
+        });
+
+        when(cursor.getLong(idColumn)).thenReturn(batchId);
+
+        return cursor;
+    }
+
+    @Test
+    public void givenADownloadInfoAndNoLinkedBatchesWhenRetrievingTheBatchThenTheBatchIsDeleted() {
+        long batchIdToMatch = 100L;
+        when(downloadInfo.getBatchId()).thenReturn(batchIdToMatch);
+        Cursor emptyBatchCursor = mock(Cursor.class);
+        when(contentResolver.query(any(Uri.class), any(String[].class), anyString(), any(String[].class), anyString())).thenReturn(emptyBatchCursor);
+
+        DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(downloadInfo);
+
+        assertThat(downloadBatch).isEqualTo(DownloadBatch.DELETED);
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
@@ -71,8 +71,8 @@ public class BatchRepositoryTest {
 
     @Test
     public void givenADownloadInfoAndNoLinkedBatchesWhenRetrievingTheBatchThenTheBatchIsDeleted() {
-        long batchIdToMatch = 100L;
-        when(downloadInfo.getBatchId()).thenReturn(batchIdToMatch);
+        long batchIdToBeMissing = 100L;
+        when(downloadInfo.getBatchId()).thenReturn(batchIdToBeMissing);
         Cursor emptyBatchCursor = mock(Cursor.class);
         when(contentResolver.query(any(Uri.class), any(String[].class), anyString(), any(String[].class), anyString())).thenReturn(emptyBatchCursor);
 


### PR DESCRIPTION
We weren't checking that the first batch in the retrieved list matched the dowload info batch id, this caused the `isAllowedToDownload` to always be called with the first downloaded batch!

Fixed by enforcing the batch ids to be matched instead of just using the first list entry