### PR TITLE
Sort queries

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
@@ -47,7 +47,4 @@ public class Download {
         return downloadStatus == DownloadManager.STATUS_PAUSED;
     }
 
-    public int getDownloadStatus() {
-        return downloadStatus;
-    }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
@@ -46,4 +46,8 @@ public class Download {
     public boolean isPaused() {
         return downloadStatus == DownloadManager.STATUS_PAUSED;
     }
+
+    public int getDownloadStatus() {
+        return downloadStatus;
+    }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
@@ -8,8 +8,6 @@ import com.novoda.downloadmanager.lib.Query;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 public class QueryForDownloadsAsyncTask extends AsyncTask<Query, Void, List<Download>> {
@@ -41,17 +39,7 @@ public class QueryForDownloadsAsyncTask extends AsyncTask<Query, Void, List<Down
         } finally {
             cursor.close();
         }
-        sortByBatchId(downloads);
         return downloads;
-    }
-
-    private void sortByBatchId(List<Download> downloads) {
-        Collections.sort(downloads, new Comparator<Download>() {
-            @Override
-            public int compare(Download lhs, Download rhs) {
-                return (int) (lhs.getBatchId() - rhs.getBatchId());
-            }
-        });
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -125,11 +125,6 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
 
     @Override
     public void onQueryResult(List<Download> downloads) {
-        String statuses = "";
-        for (Download download : downloads) {
-            statuses += download.getDownloadStatus() + "|";
-        }
-        Log.d(statuses);
         downloadAdapter.updateDownloads(downloads);
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -81,7 +81,8 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
     }
 
     private void queryForDownloads() {
-        QueryForDownloadsAsyncTask.newInstance(downloadManager, this).execute(new Query());
+        Query orderedQuery = new Query().orderByLiveness();
+        QueryForDownloadsAsyncTask.newInstance(downloadManager, this).execute(orderedQuery);
     }
 
     private void enqueueSingleDownload() {
@@ -124,6 +125,11 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
 
     @Override
     public void onQueryResult(List<Download> downloads) {
+        String statuses = "";
+        for (Download download : downloads) {
+            statuses += download.getDownloadStatus() + "|";
+        }
+        Log.d(statuses);
         downloadAdapter.updateDownloads(downloads);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -399,14 +399,14 @@ public class DownloadManager {
     public void pauseBatch(long id) {
         ContentValues values = new ContentValues();
         values.put(Downloads.Impl.COLUMN_CONTROL, Downloads.Impl.CONTROL_PAUSED);
-        mResolver.update(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, values, COLUMN_BATCH_ID + "=?", new String[] { String.valueOf(id) });
+        mResolver.update(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, values, COLUMN_BATCH_ID + "=?", new String[]{String.valueOf(id)});
     }
 
     public void resumeBatch(long id) {
         ContentValues values = new ContentValues();
         values.put(Downloads.Impl.COLUMN_CONTROL, Downloads.Impl.CONTROL_RUN);
         values.put(Downloads.Impl.COLUMN_STATUS, Downloads.Impl.STATUS_PENDING);
-        mResolver.update(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, values, COLUMN_BATCH_ID + "=?", new String[] { String.valueOf(id) });
+        mResolver.update(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, values, COLUMN_BATCH_ID + "=?", new String[]{String.valueOf(id)});
     }
 
     public void removeDownload(URI uri) {
@@ -826,7 +826,7 @@ public class DownloadManager {
             return ContentUris.withAppendedId(mBaseUri, downloadId).toString();
         }
 
-            private long getReason(int status) {
+        private long getReason(int status) {
             switch (translateStatus(status)) {
                 case STATUS_FAILED:
                     return getErrorCode(status);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -826,7 +826,7 @@ public class DownloadManager {
             return ContentUris.withAppendedId(mBaseUri, downloadId).toString();
         }
 
-        private long getReason(int status) {
+            private long getReason(int status) {
             switch (translateStatus(status)) {
                 case STATUS_FAILED:
                     return getErrorCode(status);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -3,7 +3,10 @@ package com.novoda.downloadmanager.lib;
 import android.content.ContentResolver;
 import android.database.Cursor;
 import android.net.Uri;
+import android.support.annotation.IntDef;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +15,12 @@ import java.util.List;
  * This class may be used to filter download manager queries.
  */
 public class Query {
+
+    @Retention(RetentionPolicy.SOURCE)
+    @IntDef({ORDER_ASCENDING, ORDER_DESCENDING})
+    public @interface Order {
+    }
+
     /**
      * Constant for use with {@link #orderBy}
      */
@@ -106,7 +115,7 @@ public class Query {
      * @param direction either {@link #ORDER_ASCENDING} or {@link #ORDER_DESCENDING}
      * @return this object
      */
-    public Query orderBy(String column, int direction) {
+    public Query orderBy(String column, @Order int direction) {
         if (direction != ORDER_ASCENDING && direction != ORDER_DESCENDING) {
             throw new IllegalArgumentException("Invalid direction: " + direction);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -37,7 +37,8 @@ public class Query {
                     + "WHEN %3$d THEN 3 "
                     + "WHEN %4$d THEN 4 "
                     + "WHEN %5$d THEN 5 "
-                    + "ELSE 2 END",
+                    + "ELSE 2 "
+                    + "END",
             Downloads.Impl.STATUS_RUNNING,
             Downloads.Impl.STATUS_PENDING,
             Downloads.Impl.STATUS_PAUSED_BY_APP,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -49,8 +49,6 @@ public class Query {
     private long[] downloadIds = null;
     private long[] batchIds = null;
     private Integer statusFlags = null;
-    private String orderByColumn = Downloads.Impl.COLUMN_LAST_MODIFICATION;
-    private int orderDirection = ORDER_DESCENDING;
     private boolean onlyIncludeVisibleInDownloadsUi = false;
     private String[] filterExtras;
     private String orderString = Downloads.Impl.COLUMN_LAST_MODIFICATION + " DESC";

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -22,6 +22,20 @@ public class Query {
      */
     public static final int ORDER_DESCENDING = 2;
 
+    private static final String ORDER_BY_LIVENESS = String.format("CASE batch_status "
+                    + "WHEN %1$d THEN 1 "
+                    + "WHEN %2$d THEN 2 "
+                    + "WHEN %3$d THEN 3 "
+                    + "WHEN %4$d THEN 4 "
+                    + "WHEN %5$d THEN 5 "
+                    + "ELSE 2 END",
+            Downloads.Impl.STATUS_RUNNING,
+            Downloads.Impl.STATUS_PENDING,
+            Downloads.Impl.STATUS_PAUSED_BY_APP,
+            Downloads.Impl.STATUS_BATCH_FAILED,
+            Downloads.Impl.STATUS_SUCCESS
+    );
+
     private long[] downloadIds = null;
     private long[] batchIds = null;
     private Integer mStatusFlags = null;
@@ -114,21 +128,11 @@ public class Query {
     /**
      * Sorts downloads according to the 'liveness' of the download, i.e. in the order:
      * Downloading, queued, other, paused, failed, completed
+     *
      * @return this {@link Query}
      */
     public Query orderByLiveness() {
-        orderString = String.format("CASE batch_status " +
-                        "WHEN %1$d THEN 1 " +
-                        "WHEN %2$d THEN 2 " +
-                        "WHEN %3$d THEN 3 " +
-                        "WHEN %4$d THEN 4 " +
-                        "WHEN %5$d THEN 5 " +
-                        "ELSE 2 END",
-                Downloads.Impl.STATUS_RUNNING,
-                Downloads.Impl.STATUS_PENDING,
-                Downloads.Impl.STATUS_PAUSED_BY_APP,
-                Downloads.Impl.STATUS_BATCH_FAILED,
-                Downloads.Impl.STATUS_SUCCESS);
+        orderString = ORDER_BY_LIVENESS;
         return this;
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -72,11 +72,10 @@ public class QueryTest {
         verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
     }
 
-    @Test(expected = IllegalArgumentException.class )
+    @Test(expected = IllegalArgumentException.class)
     public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
         new Query().orderBy(DownloadManager.COLUMN_STATUS, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
-
-        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("batch_status ASC"));
+        // Expecting an exception
     }
 
 }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -48,4 +49,34 @@ public class QueryTest {
 
         assertThat(stringArgumentCaptor.getValue()).doesNotContain(Downloads.Impl.COLUMN_BATCH_ID + " IN ");
     }
+
+    @Test
+    public void whenWeSetABatchStatusOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
+        new Query().orderBy(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
+
+        // Actually resolves to Downloads.Impl.COLUMN_LAST_MODIFIED
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod ASC"));
+    }
+
+    @Test
+    public void whenWeSetNoOrderByOnAQueryThenTheResolverIsQueriedWithTheLastModifiedSortOrder() {
+        new Query().runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
+    }
+
+    @Test
+    public void whenOrderingByLivenessThenTheResolverIsQueriedWithTheExpectedSort() {
+        new Query().runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
+    }
+
+    @Test(expected = IllegalArgumentException.class )
+    public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
+        new Query().orderBy(DownloadManager.COLUMN_STATUS, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("batch_status ASC"));
+    }
+
 }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -67,9 +67,15 @@ public class QueryTest {
 
     @Test
     public void whenOrderingByLivenessThenTheResolverIsQueriedWithTheExpectedSort() {
-        new Query().runQuery(resolver, null, uri);
+        new Query().orderByLiveness().runQuery(resolver, null, uri);
 
-        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("CASE batch_status " +
+                        "WHEN 192 THEN 1 " +
+                        "WHEN 190 THEN 2 " +
+                        "WHEN 193 THEN 3 " +
+                        "WHEN 498 THEN 4 " +
+                        "WHEN 200 THEN 5 " +
+                        "ELSE 2 END"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -80,7 +80,8 @@ public class QueryTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
-        new Query().orderBy(DownloadManager.COLUMN_STATUS, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
+        int anyOrder = Query.ORDER_ASCENDING;
+        new Query().orderBy(DownloadManager.COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
         // Expecting an exception
     }
 


### PR DESCRIPTION
This PR adds the ability to sort downloads by a couple of previously-unexposed sorts, and also by a new one. The new one is sort by "liveness" (better naming welcome) which basically sorts the downloads by their status in this order: _running, queued, other statuses, paused, failed, complete_. 

| Before | After |
| --- | --- |
| ![not-sorted](https://cloud.githubusercontent.com/assets/666285/8550592/612a62c4-24c9-11e5-9b60-83cad73bd4dd.gif) | ![sort-queries](https://cloud.githubusercontent.com/assets/666285/8550597/67488b86-24c9-11e5-812e-b647dffb2072.gif) |