### PR TITLE
Calculate entire batch size in one go

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadInfo.java
@@ -106,10 +106,8 @@ class DownloadInfo {
             Uri headerUri = Uri.withAppendedPath(info.getAllDownloadsUri(), Downloads.Impl.RequestHeaders.URI_SEGMENT);
             Cursor cursor = mResolver.query(headerUri, null, null, null, null);
             try {
-                int headerIndex =
-                        cursor.getColumnIndexOrThrow(Downloads.Impl.RequestHeaders.COLUMN_HEADER);
-                int valueIndex =
-                        cursor.getColumnIndexOrThrow(Downloads.Impl.RequestHeaders.COLUMN_VALUE);
+                int headerIndex = cursor.getColumnIndexOrThrow(Downloads.Impl.RequestHeaders.COLUMN_HEADER);
+                int valueIndex = cursor.getColumnIndexOrThrow(Downloads.Impl.RequestHeaders.COLUMN_VALUE);
                 for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
                     addHeader(info, cursor.getString(headerIndex), cursor.getString(valueIndex));
                 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -113,9 +113,6 @@ public class DownloadService extends Service {
         throw new UnsupportedOperationException("Cannot bind to Download Manager Service");
     }
 
-    /**
-     * Initializes the service when it is first created
-     */
     @Override
     public void onCreate() {
         super.onCreate();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -331,6 +331,7 @@ public class DownloadService extends Service {
                     if (downloadBatch.isDeleted()) {
                         break;
                     }
+
                     isActive = kickOffDownloadTaskIfReady(isActive, info, downloadBatch);
                     isActive = kickOffMediaScanIfCompleted(isActive, info);
                 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -309,13 +309,13 @@ public class DownloadService extends Service {
                     downloadDeleter.deleteFileAndMediaReference(info);
                 } else {
                     updateTotalBytesFor(allDownloads);
+                    batchRepository.updateCurrentSize(info.getBatchId());
+                    batchRepository.updateTotalSize(info.getBatchId());
+
                     DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(info);
                     if (downloadBatch.isDeleted()) {
                         continue;
                     }
-
-                    batchRepository.updateCurrentSize(info.getBatchId());
-                    batchRepository.updateTotalSize(info.getBatchId());
 
                     isActive = kickOffDownloadTaskIfReady(isActive, info, downloadBatch);
                     isActive = kickOffMediaScanIfCompleted(isActive, info);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -249,10 +249,7 @@ public class DownloadService extends Service {
             // TODO: switch to asking real tasks to derive active state
             // TODO: handle media scanner timeouts
 
-            final boolean isActive;
-            synchronized (DownloadService.this) {
-                isActive = updateLocked();
-            }
+            boolean isActive = updateLocked();
 
             if (msg.what == MSG_FINAL_UPDATE) {
                 // Dump thread stacks belonging to pool

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -254,7 +254,9 @@ public class DownloadService extends Service {
             // TODO: handle media scanner timeouts
 
             final boolean isActive;
-            isActive = updateLocked();
+            synchronized (DownloadService.this) {
+                isActive = updateLocked();
+            }
 
             if (msg.what == MSG_FINAL_UPDATE) {
                 // Dump thread stacks belonging to pool

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -401,14 +401,6 @@ public class DownloadService extends Service {
         return info;
     }
 
-    /**
-     * Updates the local copy of the info about a download.
-     */
-    private void updateDownloadFromDatabase(DownloadInfo.Reader reader, DownloadInfo info) {
-        reader.updateFromDatabase(info);
-        Log.v("processing updated download " + info.mId + ", status: " + info.mStatus);
-    }
-
     @Override
     protected void dump(FileDescriptor fd, PrintWriter writer, String[] args) {
         Log.e("I want to dump but nothing to dump into");

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -337,7 +337,7 @@ public class DownloadService extends Service {
                         continue;
                     }
 
-                    updateTotalBytesFor(info);
+                    updateTotalBytesFor(downloadBatch);
                     batchRepository.updateCurrentSize(info.getBatchId());
                     batchRepository.updateTotalSize(info.getBatchId());
 
@@ -373,12 +373,14 @@ public class DownloadService extends Service {
         return isActive;
     }
 
-    private void updateTotalBytesFor(DownloadInfo info) {
-        if (info.mTotalBytes == -1) {
+    private void updateTotalBytesFor(DownloadBatch batch) {
+        if (batch.getTotalSize() == -1) {
             ContentValues values = new ContentValues();
-            info.mTotalBytes = contentLengthFetcher.fetchContentLengthFor(info);
-            values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, info.mTotalBytes);
-            getContentResolver().update(info.getAllDownloadsUri(), values, null, null);
+            for (DownloadInfo downloadInfo : batch.getDownloads()) {
+                downloadInfo.mTotalBytes = contentLengthFetcher.fetchContentLengthFor(downloadInfo);
+                values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, downloadInfo.mTotalBytes);
+                getContentResolver().update(downloadInfo.getAllDownloadsUri(), values, null, null);
+            }
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -317,13 +317,13 @@ public class DownloadService extends Service {
         long now = mSystemFacade.currentTimeMillis();
 
         Collection<DownloadInfo> allDownloads = downloadsRepository.getAllDownloads();
+        updateTotalBytesFor(allDownloads);
         for (DownloadInfo info : allDownloads) {
             if (info.mDeleted) {
                 downloadDeleter.deleteFileAndDatabaseRow(info);
             } else if (Downloads.Impl.isStatusCancelled(info.mStatus) || Downloads.Impl.isStatusError(info.mStatus)) {
                 downloadDeleter.deleteFileAndMediaReference(info);
             } else {
-                updateTotalBytesFor(allDownloads);
                 batchRepository.updateCurrentSize(info.getBatchId());
                 batchRepository.updateTotalSize(info.getBatchId());
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -1,0 +1,39 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class DownloadsRepository {
+
+    private final ContentResolver contentResolver;
+    private final DownloadInfoCreator downloadInfoCreator;
+
+    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator) {
+        this.contentResolver = contentResolver;
+        this.downloadInfoCreator = downloadInfoCreator;
+    }
+
+    public List<DownloadInfo> getAllDownloads() {
+        Cursor downloadsCursor = contentResolver.query(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, null, null, null, null);
+        try {
+            List<DownloadInfo> downloads = new ArrayList<>();
+            DownloadInfo.Reader reader = new DownloadInfo.Reader(contentResolver, downloadsCursor);
+
+            while (downloadsCursor.moveToNext()) {
+                downloads.add(downloadInfoCreator.create(reader));
+            }
+
+            return downloads;
+        } finally {
+            downloadsCursor.close();
+        }
+    }
+
+    interface DownloadInfoCreator {
+        DownloadInfo create(DownloadInfo.Reader reader);
+    }
+
+}


### PR DESCRIPTION
Forces the download batch to be fully sized up before hitting the `isAllowedToDownload()` rules and download thread

Fixes `isAllowedToDownload` being called with -1 total size

Removes the cached `mDownloads`, they were being used as a back up to when the content provider failed(?!) **BUT** if the content provider failed we wouldn't be able to read from the map anyways because we were calling `contentResolver.query().getLong(id)`... ! Removing them super simplified the download flow and due to the reuse of the download batches and download infos, we no longer have to query on each iteration of the loop, performance increased!

Logs taken at the start and end of `updateLocked()` in the `DownloadService`

Before 119, 118, 87, 91, 113, 139, 63, 61, 62, 65 average = **91.8ms**
After 75, 6, 4, 5, 4, 3, 4, 3, 4, 3 average = **11.1ms**

almost 10x increase....