### PR TITLE
Less isAllowToDownload callbacks

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -366,10 +366,9 @@ public class DownloadService extends Service {
     }
 
     private boolean kickOffDownloadTaskIfReady(boolean isActive, FileDownloadInfo info, DownloadBatch downloadBatch) {
-        boolean isReadyToDownload = info.isReadyToDownload(downloadBatch);
         boolean downloadIsActive = info.isActive();
 
-        if (isReadyToDownload || downloadIsActive) {
+        if (!downloadIsActive || info.isReadyToDownload(downloadBatch)) {
             isActive |= info.startDownloadIfNotActive(executor, storageManager, downloadNotifier);
         }
         return isActive;


### PR DESCRIPTION
We found that `isAllowedToDownload` was being called for all queued and running downloads, on **EVERY** download table change. It kind of made sense for running downloads but wasn't really necessary...

This PR forces the check to only occur if a download is ready and hasn't been submitted to the downloads exectutor