### PR TITLE
Adds back in-memory cache of objects

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -4,12 +4,15 @@ import android.content.ContentResolver;
 import android.database.Cursor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 class DownloadsRepository {
 
     private final ContentResolver contentResolver;
     private final DownloadInfoCreator downloadInfoCreator;
+    private final Map<Long, FileDownloadInfo> currentFileInfos = new HashMap<>();
 
     public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator) {
         this.contentResolver = contentResolver;
@@ -19,14 +22,21 @@ class DownloadsRepository {
     public List<FileDownloadInfo> getAllDownloads() {
         Cursor downloadsCursor = contentResolver.query(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, null, null, null, null);
         try {
-            List<FileDownloadInfo> downloads = new ArrayList<>();
             FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
 
             while (downloadsCursor.moveToNext()) {
-                downloads.add(downloadInfoCreator.create(reader));
+                FileDownloadInfo downloadInfo = downloadInfoCreator.create(reader);
+                if (currentFileInfos.containsKey(downloadInfo.getId())) {
+                    // We have to do an in-place update whilst the DownloadFileInfo
+                    // object contains the download thread - creating new objects prevents pause/resume working
+                    FileDownloadInfo currentInfo = currentFileInfos.get(downloadInfo.getId());
+                    reader.updateFromDatabase(currentInfo);
+                } else {
+                    currentFileInfos.put(downloadInfo.getId(), downloadInfo);
+                }
             }
 
-            return downloads;
+            return new ArrayList<>(currentFileInfos.values());
         } finally {
             downloadsCursor.close();
         }


### PR DESCRIPTION
This broke pause and resume because each FileDownloadInfo contains the thread that is running for that download :cry: So for now we don't create a new FileDownloadInfo if we already have an in-memory representation of it.

Ideally we'll move the threading out of this object, but at a later date