### PR TITLE
Fix download info state

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -115,7 +115,7 @@ class BatchRepository {
                     return statusCode;
                 }
 
-                Integer currentStatusCount = statusCounts.get(statusCode);
+                int currentStatusCount = statusCounts.get(statusCode);
                 statusCounts.put(statusCode, currentStatusCount + 1);
             }
         } finally {
@@ -124,7 +124,7 @@ class BatchRepository {
             }
         }
 
-        for (Integer status : PRIORITISED_STATUSES) {
+        for (int status : PRIORITISED_STATUSES) {
             if (statusCounts.get(status) > 0) {
                 return status;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -370,7 +370,7 @@ public class DownloadService extends Service {
         boolean downloadIsActive = info.isActive();
 
         if (isReadyToDownload || downloadIsActive) {
-            isActive |= info.startDownloadIfNotActive(executor, storageManager, downloadNotifier);
+            isActive |= info.startDownloadIfNotActive(executor, storageManager, downloadNotifier, downloadsRepository);
         }
         return isActive;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -374,6 +374,7 @@ public class DownloadService extends Service {
 
         if (isReadyToDownload && !downloadIsSubmittedOrActive) {
             info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository);
+            return true;
         }
         return downloadIsSubmittedOrActive;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -325,8 +325,11 @@ public class DownloadService extends Service {
                         break;
                     }
 
-                    isActive = kickOffDownloadTaskIfReady(isActive, info, downloadBatch);
-                    isActive = kickOffMediaScanIfCompleted(isActive, info);
+                    if (!isActive) {
+                        isActive = kickOffDownloadTaskIfReady(info, downloadBatch);
+                        isActive = kickOffMediaScanIfCompleted(isActive, info);
+                    }
+
                 }
 
                 // Keep track of nearest next action
@@ -365,14 +368,14 @@ public class DownloadService extends Service {
         }
     }
 
-    private boolean kickOffDownloadTaskIfReady(boolean isActive, FileDownloadInfo info, DownloadBatch downloadBatch) {
+    private boolean kickOffDownloadTaskIfReady(FileDownloadInfo info, DownloadBatch downloadBatch) {
         boolean isReadyToDownload = info.isReadyToDownload(downloadBatch);
-        boolean downloadIsActive = info.isActive();
+        boolean downloadIsSubmittedOrActive = info.isSubmittedOrRunning();
 
-        if (isReadyToDownload && !downloadIsActive) {
+        if (isReadyToDownload && !downloadIsSubmittedOrActive) {
             info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository);
         }
-        return isActive;
+        return downloadIsSubmittedOrActive;
     }
 
     private boolean kickOffMediaScanIfCompleted(boolean isActive, FileDownloadInfo info) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -369,8 +369,8 @@ public class DownloadService extends Service {
         boolean isReadyToDownload = info.isReadyToDownload(downloadBatch);
         boolean downloadIsActive = info.isActive();
 
-        if (isReadyToDownload || downloadIsActive) {
-            isActive |= info.startDownloadIfNotActive(executor, storageManager, downloadNotifier, downloadsRepository);
+        if (isReadyToDownload && !downloadIsActive) {
+            info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository);
         }
         return isActive;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -46,8 +46,8 @@ import java.net.UnknownHostException;
 import java.util.Locale;
 
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
-import static com.novoda.downloadmanager.lib.FileDownloadInfo.NetworkState;
 import static com.novoda.downloadmanager.lib.Downloads.Impl.*;
+import static com.novoda.downloadmanager.lib.FileDownloadInfo.NetworkState;
 import static java.net.HttpURLConnection.*;
 
 /**
@@ -73,19 +73,22 @@ class DownloadThread implements Runnable {
     private final DownloadNotifier downloadNotifier;
     private final BatchCompletionBroadcaster batchCompletionBroadcaster;
     private final BatchRepository batchRepository;
+    private final DownloadsRepository downloadsRepository;
 
     private volatile boolean policyDirty;
 
-    public DownloadThread(Context context, SystemFacade systemFacade, FileDownloadInfo fileDownloadInfo,
+    public DownloadThread(Context context, SystemFacade systemFacade, FileDownloadInfo originalDownloadInfo,
                           StorageManager storageManager, DownloadNotifier downloadNotifier,
-                          BatchCompletionBroadcaster batchCompletionBroadcaster, BatchRepository batchRepository) {
+                          BatchCompletionBroadcaster batchCompletionBroadcaster, BatchRepository batchRepository,
+                          DownloadsRepository downloadsRepository) {
         this.context = context;
         this.systemFacade = systemFacade;
-        this.fileDownloadInfo = fileDownloadInfo;
+        this.fileDownloadInfo = originalDownloadInfo;
         this.storageManager = storageManager;
         this.downloadNotifier = downloadNotifier;
         this.batchCompletionBroadcaster = batchCompletionBroadcaster;
         this.batchRepository = batchRepository;
+        this.downloadsRepository = downloadsRepository;
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -67,7 +67,7 @@ class DownloadThread implements Runnable {
     private static final int DEFAULT_TIMEOUT = (int) (20 * SECOND_IN_MILLIS);
 
     private final Context context;
-    private final FileDownloadInfo fileDownloadInfo;
+    private final FileDownloadInfo originalDownloadInfo;
     private final SystemFacade systemFacade;
     private final StorageManager storageManager;
     private final DownloadNotifier downloadNotifier;
@@ -83,7 +83,7 @@ class DownloadThread implements Runnable {
                           DownloadsRepository downloadsRepository) {
         this.context = context;
         this.systemFacade = systemFacade;
-        this.fileDownloadInfo = originalDownloadInfo;
+        this.originalDownloadInfo = originalDownloadInfo;
         this.storageManager = storageManager;
         this.downloadNotifier = downloadNotifier;
         this.batchCompletionBroadcaster = batchCompletionBroadcaster;
@@ -95,7 +95,7 @@ class DownloadThread implements Runnable {
      * Returns the user agent provided by the initiating app, or use the default one
      */
     private String userAgent() {
-        String userAgent = fileDownloadInfo.getUserAgent();
+        String userAgent = originalDownloadInfo.getUserAgent();
         if (userAgent == null) {
             userAgent = Constants.DEFAULT_USER_AGENT;
         }
@@ -176,41 +176,41 @@ class DownloadThread implements Runnable {
         try {
             runInternal();
         } finally {
-            downloadNotifier.notifyDownloadSpeed(fileDownloadInfo.getId(), 0);
+            downloadNotifier.notifyDownloadSpeed(originalDownloadInfo.getId(), 0);
         }
     }
 
     private void runInternal() {
         // Skip when download already marked as finished; this download was probably started again while racing with UpdateThread.
-        int downloadStatus = FileDownloadInfo.queryDownloadStatus(getContentResolver(), fileDownloadInfo.getId());
+        int downloadStatus = FileDownloadInfo.queryDownloadStatus(getContentResolver(), originalDownloadInfo.getId());
         if (downloadStatus == Downloads.Impl.STATUS_SUCCESS) {
-            Log.d("Download " + fileDownloadInfo.getId() + " already finished; skipping");
+            Log.d("Download " + originalDownloadInfo.getId() + " already finished; skipping");
             return;
         }
         if (Downloads.Impl.isStatusCancelled(downloadStatus)) {
-            Log.d("Download " + fileDownloadInfo.getId() + " already cancelled; skipping");
+            Log.d("Download " + originalDownloadInfo.getId() + " already cancelled; skipping");
             return;
         }
         if (Downloads.Impl.isStatusError(downloadStatus)) {
-            Log.d("Download " + fileDownloadInfo.getId() + " already failed: status = " + downloadStatus + "; skipping");
+            Log.d("Download " + originalDownloadInfo.getId() + " already failed: status = " + downloadStatus + "; skipping");
             return;
         }
 
-        DownloadBatch currentBatch = batchRepository.retrieveBatchFor(fileDownloadInfo);
-        if (!fileDownloadInfo.isReadyToDownload(currentBatch)) {
-            Log.d("Download " + fileDownloadInfo.getId() + " is not ready to download: skipping");
+        DownloadBatch currentBatch = batchRepository.retrieveBatchFor(originalDownloadInfo);
+        if (!originalDownloadInfo.isReadyToDownload(currentBatch)) {
+            Log.d("Download " + originalDownloadInfo.getId() + " is not ready to download: skipping");
             return;
         }
 
         if (downloadStatus != Downloads.Impl.STATUS_RUNNING) {
-            fileDownloadInfo.updateStatus(Downloads.Impl.STATUS_RUNNING);
-            updateBatchStatus(fileDownloadInfo.getBatchId(), fileDownloadInfo.getId());
+            originalDownloadInfo.updateStatus(Downloads.Impl.STATUS_RUNNING);
+            updateBatchStatus(originalDownloadInfo.getBatchId(), originalDownloadInfo.getId());
         }
 
-        State state = new State(fileDownloadInfo);
+        State state = new State(originalDownloadInfo);
         PowerManager.WakeLock wakeLock = null;
         int finalStatus = STATUS_UNKNOWN_ERROR;
-        int numFailed = fileDownloadInfo.getNumFailed();
+        int numFailed = originalDownloadInfo.getNumFailed();
         String errorMsg = null;
 
 //        final NetworkPolicyManager netPolicy = NetworkPolicyManager.from(context);
@@ -223,7 +223,7 @@ class DownloadThread implements Runnable {
             // while performing download, register for rules updates
 //            netPolicy.registerListener(mPolicyListener);
 
-            Log.i("Download " + fileDownloadInfo.getId() + " starting");
+            Log.i("Download " + originalDownloadInfo.getId() + " starting");
 
             // Remember which network this download started on; used to
             // determine if errors were due to network changes.
@@ -251,7 +251,7 @@ class DownloadThread implements Runnable {
         } catch (StopRequestException error) {
             // remove the cause before printing, in case it contains PII
             errorMsg = error.getMessage();
-            String msg = "Aborting request for download " + fileDownloadInfo.getId() + ": " + errorMsg;
+            String msg = "Aborting request for download " + originalDownloadInfo.getId() + ": " + errorMsg;
             Log.w(msg, error);
             finalStatus = error.getFinalStatus();
 
@@ -284,7 +284,7 @@ class DownloadThread implements Runnable {
             // fall through to finally block
         } catch (Throwable ex) {
             errorMsg = ex.getMessage();
-            String msg = "Exception for id " + fileDownloadInfo.getId() + ": " + errorMsg;
+            String msg = "Exception for id " + originalDownloadInfo.getId() + ": " + errorMsg;
             Log.w(msg, ex);
             finalStatus = STATUS_UNKNOWN_ERROR;
             // falls through to the code that reports an error
@@ -295,7 +295,7 @@ class DownloadThread implements Runnable {
             cleanupDestination(state, finalStatus);
             notifyDownloadCompleted(state, finalStatus, errorMsg, numFailed);
 
-            Log.i("Download " + fileDownloadInfo.getId() + " finished with status " + Downloads.Impl.statusToString(finalStatus));
+            Log.i("Download " + originalDownloadInfo.getId() + " finished with status " + Downloads.Impl.statusToString(finalStatus));
 
 //            netPolicy.unregisterListener(mPolicyListener);
 
@@ -317,7 +317,7 @@ class DownloadThread implements Runnable {
         // skip when already finished; remove after fixing race in 5217390
         if (state.currentBytes == state.totalBytes) {
             Log.i("Skipping initiating request for download " +
-                    fileDownloadInfo.getId() + "; already completed");
+                    originalDownloadInfo.getId() + "; already completed");
             return;
         }
 
@@ -466,15 +466,15 @@ class DownloadThread implements Runnable {
         // checking connectivity will apply current policy
         policyDirty = false;
 
-        final NetworkState networkUsable = fileDownloadInfo.checkCanUseNetwork();
+        final NetworkState networkUsable = originalDownloadInfo.checkCanUseNetwork();
         if (networkUsable != NetworkState.OK) {
             int status = STATUS_WAITING_FOR_NETWORK;
             if (networkUsable == NetworkState.UNUSABLE_DUE_TO_SIZE) {
                 status = Downloads.Impl.STATUS_QUEUED_FOR_WIFI;
-                fileDownloadInfo.notifyPauseDueToSize(true);
+                originalDownloadInfo.notifyPauseDueToSize(true);
             } else if (networkUsable == NetworkState.RECOMMENDED_UNUSABLE_DUE_TO_SIZE) {
                 status = Downloads.Impl.STATUS_QUEUED_FOR_WIFI;
-                fileDownloadInfo.notifyPauseDueToSize(false);
+                originalDownloadInfo.notifyPauseDueToSize(false);
             }
             throw new StopRequestException(status, networkUsable.name());
         }
@@ -536,13 +536,13 @@ class DownloadThread implements Runnable {
      * has been.
      */
     private void checkPausedOrCanceled() throws StopRequestException {
-        synchronized (fileDownloadInfo) {
-            if (fileDownloadInfo.getControl() == Downloads.Impl.CONTROL_PAUSED) {
-                throw new StopRequestException(Downloads.Impl.STATUS_PAUSED_BY_APP, "download paused by owner");
-            }
-            if (fileDownloadInfo.getStatus() == Downloads.Impl.STATUS_CANCELED) {
-                throw new StopRequestException(Downloads.Impl.STATUS_CANCELED, "download canceled");
-            }
+        FileDownloadInfo currentDownloadInfo = downloadsRepository.getDownloadsFor(originalDownloadInfo.getId());
+
+        if (currentDownloadInfo.getControl() == Downloads.Impl.CONTROL_PAUSED) {
+            throw new StopRequestException(Downloads.Impl.STATUS_PAUSED_BY_APP, "download paused by owner");
+        }
+        if (currentDownloadInfo.getStatus() == Downloads.Impl.STATUS_CANCELED) {
+            throw new StopRequestException(Downloads.Impl.STATUS_CANCELED, "download canceled");
         }
 
         // if policy has been changed, trigger connectivity check
@@ -569,7 +569,7 @@ class DownloadThread implements Runnable {
 
             // Only notify once we have a full sample window
             if (state.speedSampleStart != 0) {
-                downloadNotifier.notifyDownloadSpeed(fileDownloadInfo.getId(), state.speed);
+                downloadNotifier.notifyDownloadSpeed(originalDownloadInfo.getId(), state.speed);
             }
 
             state.speedSampleStart = now;
@@ -580,7 +580,7 @@ class DownloadThread implements Runnable {
                 now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
             ContentValues values = new ContentValues();
             values.put(Downloads.Impl.COLUMN_CURRENT_BYTES, state.currentBytes);
-            getContentResolver().update(fileDownloadInfo.getAllDownloadsUri(), values, null, null);
+            getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
             state.bytesNotified = state.currentBytes;
             state.timeLastNotification = now;
         }
@@ -593,7 +593,7 @@ class DownloadThread implements Runnable {
      * @param bytesRead how many bytes to write from the buffer
      */
     private void writeDataToDestination(State state, byte[] data, int bytesRead, OutputStream out) throws StopRequestException {
-        storageManager.verifySpaceBeforeWritingToFile(fileDownloadInfo.getDestination(), state.filename, bytesRead);
+        storageManager.verifySpaceBeforeWritingToFile(originalDownloadInfo.getDestination(), state.filename, bytesRead);
 
         boolean forceVerified = false;
         while (true) {
@@ -604,7 +604,7 @@ class DownloadThread implements Runnable {
                 // TODO: better differentiate between DRM and disk failures
                 if (!forceVerified) {
                     // couldn't write to file. are we out of space? check.
-                    storageManager.verifySpace(fileDownloadInfo.getDestination(), state.filename, bytesRead);
+                    storageManager.verifySpace(originalDownloadInfo.getDestination(), state.filename, bytesRead);
                     forceVerified = true;
                 } else {
                     throw new StopRequestException(STATUS_FILE_ERROR,
@@ -624,7 +624,7 @@ class DownloadThread implements Runnable {
         if (state.contentLength == -1) {
             values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, state.currentBytes);
         }
-        getContentResolver().update(fileDownloadInfo.getAllDownloadsUri(), values, null, null);
+        getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
 
         final boolean lengthMismatched = (state.contentLength != -1)
                 && (state.currentBytes != state.contentLength);
@@ -638,7 +638,7 @@ class DownloadThread implements Runnable {
     }
 
     private boolean cannotResume(State state) {
-        return (state.currentBytes > 0 && !fileDownloadInfo.isNoIntegrity() && state.headerETag == null) || DownloadDrmHelper.isDrmConvertNeeded(state.mimeType);
+        return (state.currentBytes > 0 && !originalDownloadInfo.isNoIntegrity() && state.headerETag == null) || DownloadDrmHelper.isDrmConvertNeeded(state.mimeType);
     }
 
     /**
@@ -660,7 +660,7 @@ class DownloadThread implements Runnable {
 
             ContentValues values = new ContentValues(1);
             values.put(Downloads.Impl.COLUMN_CURRENT_BYTES, state.currentBytes);
-            getContentResolver().update(fileDownloadInfo.getAllDownloadsUri(), values, null, null);
+            getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
             if (cannotResume(state)) {
                 throw new StopRequestException(STATUS_CANNOT_RESUME, "Failed reading response: " + ex + "; unable to resume", ex);
             } else {
@@ -679,12 +679,12 @@ class DownloadThread implements Runnable {
         readResponseHeaders(state, conn);
 
         state.filename = Helpers.generateSaveFile(
-                fileDownloadInfo.getUri(),
-                fileDownloadInfo.getHint(),
+                originalDownloadInfo.getUri(),
+                originalDownloadInfo.getHint(),
                 state.contentDisposition,
                 state.contentLocation,
                 state.mimeType,
-                fileDownloadInfo.getDestination(),
+                originalDownloadInfo.getDestination(),
                 state.contentLength,
                 storageManager);
 
@@ -706,8 +706,8 @@ class DownloadThread implements Runnable {
         if (state.mimeType != null) {
             values.put(Downloads.Impl.COLUMN_MIME_TYPE, state.mimeType);
         }
-        values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, fileDownloadInfo.getTotalBytes());
-        getContentResolver().update(fileDownloadInfo.getAllDownloadsUri(), values, null, null);
+        values.put(Downloads.Impl.COLUMN_TOTAL_BYTES, originalDownloadInfo.getTotalBytes());
+        getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
     }
 
     /**
@@ -732,10 +732,10 @@ class DownloadThread implements Runnable {
         }
 
         state.totalBytes = state.contentLength;
-        fileDownloadInfo.setTotalBytes(state.contentLength);
+        originalDownloadInfo.setTotalBytes(state.contentLength);
 
         final boolean noSizeInfo = state.contentLength == -1 && (transferEncoding == null || !transferEncoding.equalsIgnoreCase("chunked"));
-        if (!fileDownloadInfo.isNoIntegrity() && noSizeInfo) {
+        if (!originalDownloadInfo.isNoIntegrity() && noSizeInfo) {
             throw new StopRequestException(STATUS_CANNOT_RESUME, "can't know size of download, giving up");
         }
     }
@@ -764,7 +764,7 @@ class DownloadThread implements Runnable {
             // only true if we've already run a thread for this download
             return;
         }
-        Log.i("have run thread before for id: " + fileDownloadInfo.getId() + ", and state.filename: " + state.filename);
+        Log.i("have run thread before for id: " + originalDownloadInfo.getId() + ", and state.filename: " + state.filename);
         if (!Helpers.isFilenameValid(state.filename, storageManager.getDownloadDataDirectory())) {
             Log.d("Yeah we know we are bad for downloading to internal storage");
 //                throw new StopRequestException(Downloads.Impl.STATUS_FILE_ERROR, "found invalid internal destination filename");
@@ -772,29 +772,29 @@ class DownloadThread implements Runnable {
         // We're resuming a download that got interrupted
         File destinationFile = new File(state.filename);
         if (destinationFile.exists()) {
-            Log.i("resuming download for id: " + fileDownloadInfo.getId() + ", and state.filename: " + state.filename);
+            Log.i("resuming download for id: " + originalDownloadInfo.getId() + ", and state.filename: " + state.filename);
             long fileLength = destinationFile.length();
             if (fileLength == 0) {
                 // The download hadn't actually started, we can restart from scratch
                 Log.d("setupDestinationFile() found fileLength=0, deleting " + state.filename);
                 destinationFile.delete();
                 state.filename = null;
-                Log.i("resuming download for id: " + fileDownloadInfo.getId() + ", BUT starting from scratch again: ");
-            } else if (fileDownloadInfo.getETag() == null && !fileDownloadInfo.isNoIntegrity()) {
+                Log.i("resuming download for id: " + originalDownloadInfo.getId() + ", BUT starting from scratch again: ");
+            } else if (originalDownloadInfo.getETag() == null && !originalDownloadInfo.isNoIntegrity()) {
                 // This should've been caught upon failure
                 Log.d("setupDestinationFile() unable to resume download, deleting " + state.filename);
                 destinationFile.delete();
                 throw new StopRequestException(STATUS_CANNOT_RESUME, "Trying to resume a download that can't be resumed");
             } else {
                 // All right, we'll be able to resume this download
-                Log.i("resuming download for id: " + fileDownloadInfo.getId() + ", and starting with file of length: " + fileLength);
+                Log.i("resuming download for id: " + originalDownloadInfo.getId() + ", and starting with file of length: " + fileLength);
                 state.currentBytes = (int) fileLength;
-                if (fileDownloadInfo.getTotalBytes() != -1) {
-                    state.contentLength = fileDownloadInfo.getTotalBytes();
+                if (originalDownloadInfo.getTotalBytes() != -1) {
+                    state.contentLength = originalDownloadInfo.getTotalBytes();
                 }
-                state.headerETag = fileDownloadInfo.getETag();
+                state.headerETag = originalDownloadInfo.getETag();
                 state.continuingDownload = true;
-                Log.i("resuming download for id: " + fileDownloadInfo.getId() + ", state.currentBytes: " + state.currentBytes + ", and setting continuingDownload to true: ");
+                Log.i("resuming download for id: " + originalDownloadInfo.getId() + ", state.currentBytes: " + state.currentBytes + ", and setting continuingDownload to true: ");
             }
         }
     }
@@ -803,7 +803,7 @@ class DownloadThread implements Runnable {
      * Add custom headers for this download to the HTTP request.
      */
     private void addRequestHeaders(State state, HttpURLConnection conn) {
-        for (Pair<String, String> header : fileDownloadInfo.getHeaders()) {
+        for (Pair<String, String> header : originalDownloadInfo.getHeaders()) {
             conn.addRequestProperty(header.first, header.second);
         }
 
@@ -830,14 +830,14 @@ class DownloadThread implements Runnable {
     private void notifyDownloadCompleted(State state, int finalStatus, String errorMsg, int numFailed) {
         notifyThroughDatabase(state, finalStatus, errorMsg, numFailed);
         if (Downloads.Impl.isStatusCompleted(finalStatus)) {
-            fileDownloadInfo.broadcastIntentDownloadComplete(finalStatus);
+            originalDownloadInfo.broadcastIntentDownloadComplete(finalStatus);
         } else if (Downloads.Impl.isStatusInsufficientSpace(finalStatus)) {
-            fileDownloadInfo.broadcastIntentDownloadFailedInsufficientSpace();
+            originalDownloadInfo.broadcastIntentDownloadFailedInsufficientSpace();
         }
     }
 
     private void notifyThroughDatabase(State state, int finalStatus, String errorMsg, int numFailed) {
-        fileDownloadInfo.setStatus(finalStatus);
+        originalDownloadInfo.setStatus(finalStatus);
         ContentValues values = new ContentValues(8);
         values.put(Downloads.Impl.COLUMN_STATUS, finalStatus);
         values.put(Downloads.Impl._DATA, state.filename);
@@ -846,7 +846,7 @@ class DownloadThread implements Runnable {
         values.put(Downloads.Impl.COLUMN_FAILED_CONNECTIONS, numFailed);
         values.put(Constants.RETRY_AFTER_X_REDIRECT_COUNT, state.retryAfter);
 
-        if (!TextUtils.equals(fileDownloadInfo.getUri(), state.requestUri)) {
+        if (!TextUtils.equals(originalDownloadInfo.getUri(), state.requestUri)) {
             values.put(Downloads.Impl.COLUMN_URI, state.requestUri);
         }
 
@@ -854,9 +854,9 @@ class DownloadThread implements Runnable {
         if (!TextUtils.isEmpty(errorMsg)) {
             values.put(Downloads.Impl.COLUMN_ERROR_MSG, errorMsg);
         }
-        getContentResolver().update(fileDownloadInfo.getAllDownloadsUri(), values, null, null);
+        getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
 
-        updateBatchStatus(fileDownloadInfo.getBatchId(), fileDownloadInfo.getId());
+        updateBatchStatus(originalDownloadInfo.getBatchId(), originalDownloadInfo.getId());
     }
 
     private ContentResolver getContentResolver() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -865,6 +865,7 @@ class DownloadThread implements Runnable {
 
     private void updateBatchStatus(long batchId, long downloadId) {
         int batchStatus = batchRepository.getBatchStatus(batchId);
+
         batchRepository.updateBatchStatus(batchId, batchStatus);
 
         if (Downloads.Impl.isStatusCancelled(batchStatus)) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -536,7 +536,7 @@ class DownloadThread implements Runnable {
      * has been.
      */
     private void checkPausedOrCanceled() throws StopRequestException {
-        FileDownloadInfo currentDownloadInfo = downloadsRepository.getDownloadsFor(originalDownloadInfo.getId());
+        FileDownloadInfo currentDownloadInfo = downloadsRepository.getDownloadFor(originalDownloadInfo.getId());
 
         if (currentDownloadInfo.getControl() == Downloads.Impl.CONTROL_PAUSED) {
             throw new StopRequestException(Downloads.Impl.STATUS_PAUSED_BY_APP, "download paused by owner");

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -544,6 +544,11 @@ final class Downloads {
         }
 
         /**
+         * This download has been submitted to the download executor but not yet started
+         */
+        public static final int STATUS_SUBMITTED = 189;
+
+        /**
          * This download hasn't stated yet
          */
         public static final int STATUS_PENDING = 190;
@@ -594,11 +599,7 @@ final class Downloads {
          * Use isSucccess() to capture the entire category.
          */
         public static final int STATUS_SUCCESS = 200;
-
-        /**
-         * This download has been submitted to the download executor but not yet started
-         */
-        public static final int STATUS_SUBMITTED = 201;
+        ;
 
         /**
          * This request couldn't be parsed. This is also used when processing

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -599,7 +599,6 @@ final class Downloads {
          * Use isSucccess() to capture the entire category.
          */
         public static final int STATUS_SUCCESS = 200;
-        ;
 
         /**
          * This request couldn't be parsed. This is also used when processing

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Downloads.java
@@ -528,6 +528,14 @@ final class Downloads {
             return status == STATUS_CANCELED;
         }
 
+        public static boolean isStatusSubmitted(int status) {
+            return status == STATUS_SUBMITTED;
+        }
+
+        public static boolean isStatusRunning(int status) {
+            return status == STATUS_RUNNING;
+        }
+
         /**
          * Returns whether the download did not start due to insufficient space
          */
@@ -586,6 +594,11 @@ final class Downloads {
          * Use isSucccess() to capture the entire category.
          */
         public static final int STATUS_SUCCESS = 200;
+
+        /**
+         * This download has been submitted to the download executor but not yet started
+         */
+        public static final int STATUS_SUBMITTED = 201;
 
         /**
          * This request couldn't be parsed. This is also used when processing

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -34,7 +34,7 @@ class DownloadsRepository {
         }
     }
 
-    public FileDownloadInfo getDownloadsFor(long id) {
+    public FileDownloadInfo getDownloadFor(long id) {
         Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, id);
         Cursor downloadsCursor = contentResolver.query(uri, null, null, null, null);
         try {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -38,6 +38,7 @@ class DownloadsRepository {
         Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, id);
         Cursor downloadsCursor = contentResolver.query(uri, null, null, null, null);
         try {
+            downloadsCursor.moveToFirst();
             FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
             return downloadInfoCreator.create(reader);
         } finally {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -1,7 +1,9 @@
 package com.novoda.downloadmanager.lib;
 
 import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.database.Cursor;
+import android.net.Uri;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +29,17 @@ class DownloadsRepository {
             }
 
             return downloads;
+        } finally {
+            downloadsCursor.close();
+        }
+    }
+
+    public FileDownloadInfo getDownloadsFor(long id) {
+        Uri uri = ContentUris.withAppendedId(Downloads.Impl.ALL_DOWNLOADS_CONTENT_URI, id);
+        Cursor downloadsCursor = contentResolver.query(uri, null, null, null, null);
+        try {
+            FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
+            return downloadInfoCreator.create(reader);
         } finally {
             downloadsCursor.close();
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -424,7 +424,7 @@ class FileDownloadInfo {
         submittedThread = executor.submit(downloadThread);
     }
 
-    public boolean isActive() {
+    public boolean isSubmittedOrRunning() {
         return Downloads.Impl.isStatusSubmitted(status) || Downloads.Impl.isStatusRunning(status);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -434,7 +434,7 @@ class FileDownloadInfo {
     }
 
     public boolean isActive() {
-        return submittedThread != null && !submittedThread.isDone();
+        return Downloads.Impl.isStatusSubmitted(status) || Downloads.Impl.isStatusRunning(status);
     }
 
     public void updateStatus(int status) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -413,7 +413,8 @@ class FileDownloadInfo {
         }
     }
 
-    public boolean startDownloadIfNotActive(ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier) {
+    public boolean startDownloadIfNotActive(ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier
+            , DownloadsRepository downloadsRepository) {
         synchronized (this) {
             boolean isActive;
             if (submittedThread == null || submittedThread.isDone()) {
@@ -422,7 +423,7 @@ class FileDownloadInfo {
                 ContentResolver contentResolver = context.getContentResolver();
                 BatchRepository batchRepository = BatchRepository.newInstance(contentResolver, new DownloadDeleter(contentResolver));
                 DownloadThread downloadThread = new DownloadThread(context, systemFacade, this, storageManager, downloadNotifier,
-                        batchCompletionBroadcaster, batchRepository);
+                        batchCompletionBroadcaster, batchRepository, downloadsRepository);
                 submittedThread = executor.submit(downloadThread);
                 isActive = true;
             } else {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -174,6 +174,7 @@ class FileDownloadInfo {
     }
 
     public void setStatus(int status) {
+        // TODO remove me!
         this.status = status;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 
 /**
  * Stores information about an individual download.
@@ -111,12 +110,6 @@ class FileDownloadInfo {
     private boolean allowMetered;
     private int bypassRecommendedSizeLimit;
     private long batchId;
-
-    /**
-     * Result of last {DownloadThread} started by
-     * {@link #isReadyToDownload(DownloadBatch)}  && {@link #startDownloadIfNotActive(ExecutorService, StorageManager, DownloadNotifier)}.
-     */
-    private Future<?> submittedThread;
 
     private final List<Pair<String, String>> requestHeaders = new ArrayList<>();
     private final Context context;
@@ -421,7 +414,7 @@ class FileDownloadInfo {
         BatchRepository batchRepository = BatchRepository.newInstance(contentResolver, new DownloadDeleter(contentResolver));
         DownloadThread downloadThread = new DownloadThread(context, systemFacade, this, storageManager, downloadNotifier,
                 batchCompletionBroadcaster, batchRepository, downloadsRepository);
-        submittedThread = executor.submit(downloadThread);
+        executor.submit(downloadThread);
     }
 
     public boolean isSubmittedOrRunning() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -413,24 +413,15 @@ class FileDownloadInfo {
         }
     }
 
-    public boolean startDownloadIfNotActive(ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier
+    public void startDownload(ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier
             , DownloadsRepository downloadsRepository) {
-        synchronized (this) {
-            boolean isActive;
-            if (submittedThread == null || submittedThread.isDone()) {
-                String applicationPackageName = context.getApplicationContext().getPackageName();
-                BatchCompletionBroadcaster batchCompletionBroadcaster = new BatchCompletionBroadcaster(context, applicationPackageName);
-                ContentResolver contentResolver = context.getContentResolver();
-                BatchRepository batchRepository = BatchRepository.newInstance(contentResolver, new DownloadDeleter(contentResolver));
-                DownloadThread downloadThread = new DownloadThread(context, systemFacade, this, storageManager, downloadNotifier,
-                        batchCompletionBroadcaster, batchRepository, downloadsRepository);
-                submittedThread = executor.submit(downloadThread);
-                isActive = true;
-            } else {
-                isActive = !submittedThread.isDone();
-            }
-            return isActive;
-        }
+        String applicationPackageName = context.getApplicationContext().getPackageName();
+        BatchCompletionBroadcaster batchCompletionBroadcaster = new BatchCompletionBroadcaster(context, applicationPackageName);
+        ContentResolver contentResolver = context.getContentResolver();
+        BatchRepository batchRepository = BatchRepository.newInstance(contentResolver, new DownloadDeleter(contentResolver));
+        DownloadThread downloadThread = new DownloadThread(context, systemFacade, this, storageManager, downloadNotifier,
+                batchCompletionBroadcaster, batchRepository, downloadsRepository);
+        submittedThread = executor.submit(downloadThread);
     }
 
     public boolean isActive() {


### PR DESCRIPTION
#75 removed the in memory maps of downloads but also had the side effect of no longer using the mutable `DownloadInfos` contained within.

The `DownloadThread` was making use of this mutable state via the `control status` which was being updated via the `DownloadService`, this was no longer the case.

The `DownloadInfo` also retained the thread instance to be able to tell if it was complete, this has been replaced with a column status `SUBMITTED`. THE DB IS THE TRUTH

This PR adds download querying within the main download loop to check for control changes.

- Also simplifying the `isActive` logic by returning less booleans from methods which do more than one thing (looking at you `startDownloadIfReady`)  