### PR TITLE
Less isAllowToDownload callbacks

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -369,10 +369,9 @@ public class DownloadService extends Service {
     }
 
     private boolean kickOffDownloadTaskIfReady(FileDownloadInfo info, DownloadBatch downloadBatch) {
-        boolean isReadyToDownload = info.isReadyToDownload(downloadBatch);
         boolean downloadIsSubmittedOrActive = info.isSubmittedOrRunning();
 
-        if (isReadyToDownload && !downloadIsSubmittedOrActive) {
+        if (!downloadIsSubmittedOrActive && info.isReadyToDownload(downloadBatch)) {
             info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository);
             return true;
         }


### PR DESCRIPTION
We found that isAllowedToDownload was being called for all queued and running downloads, on EVERY download table change. It kind of made sense for running downloads but wasn't really necessary...

This PR forces the check to only occur if a download hasn't been set to submitted or in progress before checking if that download is "ready to download"