### PR TITLE
Fix current size for batches

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -360,7 +360,7 @@ public class DownloadService extends Service {
     private void updateTotalBytesFor(Collection<FileDownloadInfo> downloadInfos) {
         ContentValues values = new ContentValues();
         for (FileDownloadInfo downloadInfo : downloadInfos) {
-            if (downloadInfo.getTotalBytes() == -1) {
+            if (downloadInfo.hasUnknownTotalBytes()) {
                 long totalBytes = contentLengthFetcher.fetchContentLengthFor(downloadInfo);
                 values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, totalBytes);
                 getContentResolver().update(downloadInfo.getAllDownloadsUri(), values, null, null);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -365,9 +365,9 @@ public class DownloadService extends Service {
                 values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, totalBytes);
                 getContentResolver().update(downloadInfo.getAllDownloadsUri(), values, null, null);
 
-                batchRepository.updateCurrentSize(downloadInfo.getBatchId());
                 batchRepository.updateTotalSize(downloadInfo.getBatchId());
             }
+            batchRepository.updateCurrentSize(downloadInfo.getBatchId());
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -538,6 +538,10 @@ class FileDownloadInfo {
         return totalBytes != UNKNOWN_BYTES;
     }
 
+    public boolean hasUnknownTotalBytes() {
+        return totalBytes == UNKNOWN_BYTES;
+    }
+
     private void addHeader(String header, String value) {
         requestHeaders.add(Pair.create(header, value));
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -539,7 +539,7 @@ class FileDownloadInfo {
     }
 
     public boolean hasUnknownTotalBytes() {
-        return totalBytes == UNKNOWN_BYTES;
+        return !hasTotalBytes();
     }
 
     private void addHeader(String header, String value) {


### PR DESCRIPTION
We've noticed that the current size for the batches was not computed anymore. This is due to the fact that `batchRepository.updateCurrentSize(downloadInfo.getBatchId())` was executed only when there are no total bytes on the batch (notice the `if`) which was wrong - the current size should always be computed. 

Pulls updating the current size out of the check and replaces the hardcoded check with a method on `downloadInfo`. 