### PR TITLE
Simplifying download info

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -55,6 +55,8 @@ import java.net.URI;
  */
 public class DownloadManager {
 
+    public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
+
     /**
      * An identifier for a particular download, unique across the system.  Clients use this ID to
      * make subsequent calls related to the download.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -55,6 +55,10 @@ import java.net.URI;
  */
 public class DownloadManager {
 
+    /**
+     * Extra information available when you register for notications of download status changes
+     * see {@link Request#setNotificationExtra(String extra)`
+     */
     public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -81,6 +81,7 @@ public class DownloadService extends Service {
     private DownloadReadyChecker downloadReadyChecker;
     private DownloadsUriProvider downloadsUriProvider;
     private BatchCompletionBroadcaster batchCompletionBroadcaster;
+    private NetworkChecker networkChecker;
 
     /**
      * Receives notifications when the data in the content provider changes
@@ -121,7 +122,8 @@ public class DownloadService extends Service {
         this.batchRepository = new BatchRepository(getContentResolver(), downloadDeleter, downloadsUriProvider);
         PublicFacingDownloadMarshaller downloadMarshaller = new PublicFacingDownloadMarshaller();
         DownloadClientReadyChecker downloadClientReadyChecker = getDownloadClientReadyChecker();
-        this.downloadReadyChecker = new DownloadReadyChecker(systemFacade, new NetworkChecker(systemFacade), downloadClientReadyChecker, downloadMarshaller);
+        this.networkChecker = new NetworkChecker(systemFacade);
+        this.downloadReadyChecker = new DownloadReadyChecker(systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
 
         String applicationPackageName = getApplicationContext().getPackageName();
         this.batchCompletionBroadcaster = new BatchCompletionBroadcaster(this, applicationPackageName);
@@ -370,7 +372,7 @@ public class DownloadService extends Service {
 
     private void download(FileDownloadInfo info) {
         DownloadThread downloadThread = new DownloadThread(this, systemFacade, info, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker);
+                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, networkChecker, downloadReadyChecker);
         executor.submit(downloadThread);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -359,7 +359,7 @@ public class DownloadService extends Service {
     private void downloadOrContinueBatch(List<FileDownloadInfo> downloads) {
         for (FileDownloadInfo info : downloads) {
             if (!info.isSubmittedOrRunning()) {
-                info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository, downloadReadyChecker);
+                info.startDownload(this, executor, storageManager, downloadNotifier, downloadsRepository, downloadReadyChecker);
             }
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -172,7 +172,7 @@ public class DownloadService extends Service {
      * download if appropriate.
      */
     private FileDownloadInfo createNewDownloadInfo(FileDownloadInfo.Reader reader) {
-        FileDownloadInfo info = reader.newDownloadInfo(this, systemFacade, downloadReadyChecker, downloadsUriProvider);
+        FileDownloadInfo info = reader.newDownloadInfo(this, systemFacade, downloadsUriProvider);
         Log.v("processing inserted download " + info.getId());
         return info;
     }
@@ -359,7 +359,7 @@ public class DownloadService extends Service {
     private void downloadOrContinueBatch(List<FileDownloadInfo> downloads) {
         for (FileDownloadInfo info : downloads) {
             if (!info.isSubmittedOrRunning()) {
-                info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository);
+                info.startDownload(executor, storageManager, downloadNotifier, downloadsRepository, downloadReadyChecker);
             }
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -239,7 +239,9 @@ class DownloadThread implements Runnable {
         }
 
         if (downloadStatus != DownloadStatus.RUNNING) {
-            originalDownloadInfo.updateStatus(DownloadStatus.RUNNING);
+            ContentValues contentValues = new ContentValues();
+            contentValues.put(DownloadContract.Downloads.COLUMN_STATUS, downloadStatus);
+            context.getContentResolver().update(allDownloadsUri, contentValues, null, null);
             updateBatchStatus(batchId, id);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -910,7 +910,6 @@ class DownloadThread implements Runnable {
     }
 
     private void notifyThroughDatabase(State state, int finalStatus, String errorMsg, int numFailed) {
-        originalDownloadInfo.setStatus(finalStatus);
         ContentValues values = new ContentValues(8);
         values.put(DownloadContract.Downloads.COLUMN_STATUS, finalStatus);
         values.put(DownloadContract.Downloads.COLUMN_DATA, state.filename);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -62,7 +62,6 @@ class DownloadThread implements Runnable {
      * is true, WiFi is required for this download size; otherwise, it is only recommended.
      */
     public static final String EXTRA_IS_WIFI_REQUIRED = "isWifiRequired";
-    public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
 
     private static final String TAG = "DownloadManager-DownloadThread";
 
@@ -876,7 +875,7 @@ class DownloadThread implements Runnable {
         intent.putExtra(DownloadManager.EXTRA_DOWNLOAD_STATUS, finalStatus);
         intent.setData(originalDownloadInfo.getMyDownloadsUri());
         if (originalDownloadInfo.getExtras() != null) {
-            intent.putExtra(EXTRA_EXTRA, originalDownloadInfo.getExtras());
+            intent.putExtra(DownloadManager.EXTRA_EXTRA, originalDownloadInfo.getExtras());
         }
         context.sendBroadcast(intent);
     }
@@ -887,7 +886,7 @@ class DownloadThread implements Runnable {
         intent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, originalDownloadInfo.getId());
         intent.setData(originalDownloadInfo.getMyDownloadsUri());
         if (originalDownloadInfo.getExtras() != null) {
-            intent.putExtra(EXTRA_EXTRA, originalDownloadInfo.getExtras());
+            intent.putExtra(DownloadManager.EXTRA_EXTRA, originalDownloadInfo.getExtras());
         }
         context.sendBroadcast(intent);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -101,17 +101,11 @@ class FileDownloadInfo {
     private long batchId;
 
     private final List<Pair<String, String>> requestHeaders = new ArrayList<>();
-    private final Context context;
     private final SystemFacade systemFacade;
     private final RandomNumberGenerator randomNumberGenerator;
     private final DownloadsUriProvider downloadsUriProvider;
 
-    FileDownloadInfo(
-            Context context,
-            SystemFacade systemFacade,
-            RandomNumberGenerator randomNumberGenerator,
-            DownloadsUriProvider downloadsUriProvider) {
-        this.context = context;
+    FileDownloadInfo(SystemFacade systemFacade, RandomNumberGenerator randomNumberGenerator, DownloadsUriProvider downloadsUriProvider) {
         this.systemFacade = systemFacade;
         this.randomNumberGenerator = randomNumberGenerator;
         this.downloadsUriProvider = downloadsUriProvider;
@@ -281,12 +275,7 @@ class FileDownloadInfo {
         return NetworkState.OK;
     }
 
-    public void startDownload(
-            ExecutorService executor,
-            StorageManager storageManager,
-            DownloadNotifier downloadNotifier,
-            DownloadsRepository downloadsRepository,
-            DownloadReadyChecker downloadReadyChecker) {
+    public void startDownload(Context context, ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier, DownloadsRepository downloadsRepository, DownloadReadyChecker downloadReadyChecker) {
         String applicationPackageName = context.getApplicationContext().getPackageName();
         BatchCompletionBroadcaster batchCompletionBroadcaster = new BatchCompletionBroadcaster(context, applicationPackageName);
         ContentResolver contentResolver = context.getContentResolver();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -72,12 +72,6 @@ class FileDownloadInfo {
         BLOCKED
     }
 
-    /**
-     * For intents used to notify the user that a download exceeds a size threshold, if this extra
-     * is true, WiFi is required for this download size; otherwise, it is only recommended.
-     */
-    public static final String EXTRA_IS_WIFI_REQUIRED = "isWifiRequired";
-
     private long id;
     private String uri;
     private boolean scannable;
@@ -387,15 +381,6 @@ class FileDownloadInfo {
                 getDestination() == DownloadsDestination.DESTINATION_NON_DOWNLOADMANAGER_DOWNLOAD)
                 && DownloadStatus.isSuccess(getStatus())
                 && scannable;
-    }
-
-    void notifyPauseDueToSize(boolean isWifiRequired) {
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setData(getAllDownloadsUri());
-        intent.setClassName(SizeLimitActivity.class.getPackage().getName(), SizeLimitActivity.class.getName());
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.putExtra(EXTRA_IS_WIFI_REQUIRED, isWifiRequired);
-        context.startActivity(intent);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -304,13 +304,6 @@ class FileDownloadInfo {
         return DownloadStatus.isSubmitted(status) || DownloadStatus.isRunning(status);
     }
 
-    public void updateStatus(int status) {
-        setStatus(status);
-        downloadStatusContentValues.clear();
-        downloadStatusContentValues.put(DownloadContract.Downloads.COLUMN_STATUS, status);
-        context.getContentResolver().update(getAllDownloadsUri(), downloadStatusContentValues, null, null);
-    }
-
     /**
      * If download is ready to be scanned, enqueue it into the given
      * {@link DownloadScanner}.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -4,7 +4,6 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
-import android.content.Intent;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.Uri;
@@ -22,7 +21,6 @@ import java.util.concurrent.ExecutorService;
  */
 class FileDownloadInfo {
 
-    public static final String EXTRA_EXTRA = "com.novoda.download.lib.KEY_INTENT_EXTRA";
     private static final int UNKNOWN_BYTES = -1;
 
     // TODO: move towards these in-memory objects being sources of truth, and periodically pushing to provider.
@@ -228,33 +226,6 @@ class FileDownloadInfo {
         return Collections.unmodifiableList(requestHeaders);
     }
 
-    public void broadcastIntentDownloadComplete(int finalStatus) {
-        Intent intent = new Intent(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
-        intent.setPackage(getPackageName());
-        intent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, id);
-        intent.putExtra(DownloadManager.EXTRA_DOWNLOAD_STATUS, finalStatus);
-        intent.setData(getMyDownloadsUri());
-        if (extras != null) {
-            intent.putExtra(EXTRA_EXTRA, extras);
-        }
-        context.sendBroadcast(intent);
-    }
-
-    private String getPackageName() {
-        return context.getApplicationContext().getPackageName();
-    }
-
-    public void broadcastIntentDownloadFailedInsufficientSpace() {
-        Intent intent = new Intent(DownloadManager.ACTION_DOWNLOAD_INSUFFICIENT_SPACE);
-        intent.setPackage(getPackageName());
-        intent.putExtra(DownloadManager.EXTRA_DOWNLOAD_ID, id);
-        intent.setData(getMyDownloadsUri());
-        if (extras != null) {
-            intent.putExtra(EXTRA_EXTRA, extras);
-        }
-        context.sendBroadcast(intent);
-    }
-
     /**
      * Returns the time when a download should be restarted.
      */
@@ -325,7 +296,7 @@ class FileDownloadInfo {
         BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
         DownloadThread downloadThread = new DownloadThread(
                 context, systemFacade, this, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker, id, batchId);
+                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker, id, batchId, extras);
         executor.submit(downloadThread);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -2,7 +2,6 @@ package com.novoda.downloadmanager.lib;
 
 import android.content.ContentResolver;
 import android.content.ContentUris;
-import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
@@ -105,23 +104,16 @@ class FileDownloadInfo {
     private final Context context;
     private final SystemFacade systemFacade;
     private final RandomNumberGenerator randomNumberGenerator;
-    private final ContentValues downloadStatusContentValues;
-    private final DownloadReadyChecker downloadReadyChecker;
     private final DownloadsUriProvider downloadsUriProvider;
 
     FileDownloadInfo(
             Context context,
             SystemFacade systemFacade,
             RandomNumberGenerator randomNumberGenerator,
-            ContentValues downloadStatusContentValues,
-            PublicFacingDownloadMarshaller downloadMarshaller,
-            DownloadReadyChecker downloadReadyChecker,
             DownloadsUriProvider downloadsUriProvider) {
         this.context = context;
         this.systemFacade = systemFacade;
         this.randomNumberGenerator = randomNumberGenerator;
-        this.downloadStatusContentValues = downloadStatusContentValues;
-        this.downloadReadyChecker = downloadReadyChecker;
         this.downloadsUriProvider = downloadsUriProvider;
     }
 
@@ -293,7 +285,8 @@ class FileDownloadInfo {
             ExecutorService executor,
             StorageManager storageManager,
             DownloadNotifier downloadNotifier,
-            DownloadsRepository downloadsRepository) {
+            DownloadsRepository downloadsRepository,
+            DownloadReadyChecker downloadReadyChecker) {
         String applicationPackageName = context.getApplicationContext().getPackageName();
         BatchCompletionBroadcaster batchCompletionBroadcaster = new BatchCompletionBroadcaster(context, applicationPackageName);
         ContentResolver contentResolver = context.getContentResolver();
@@ -396,22 +389,9 @@ class FileDownloadInfo {
             this.cursor = cursor;
         }
 
-        public FileDownloadInfo newDownloadInfo(
-                Context context,
-                SystemFacade systemFacade,
-                DownloadReadyChecker downloadReadyChecker,
-                DownloadsUriProvider downloadsUriProvider) {
+        public FileDownloadInfo newDownloadInfo(Context context, SystemFacade systemFacade, DownloadsUriProvider downloadsUriProvider) {
             RandomNumberGenerator randomNumberGenerator = new RandomNumberGenerator();
-            ContentValues contentValues = new ContentValues();
-            PublicFacingDownloadMarshaller downloadMarshaller = new PublicFacingDownloadMarshaller();
-            FileDownloadInfo info = new FileDownloadInfo(
-                    context,
-                    systemFacade,
-                    randomNumberGenerator,
-                    contentValues,
-                    downloadMarshaller,
-                    downloadReadyChecker,
-                    downloadsUriProvider);
+            FileDownloadInfo info = new FileDownloadInfo(context, systemFacade, randomNumberGenerator, downloadsUriProvider);
             updateFromDatabase(info);
             readRequestHeaders(info);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -331,7 +331,7 @@ class FileDownloadInfo {
         BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
         DownloadThread downloadThread = new DownloadThread(
                 context, systemFacade, this, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker);
+                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker, id, batchId);
         executor.submit(downloadThread);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -222,6 +222,10 @@ class FileDownloadInfo {
         return bypassRecommendedSizeLimit == 0;
     }
 
+    public String getExtras() {
+        return extras;
+    }
+
     public Collection<Pair<String, String>> getHeaders() {
         return Collections.unmodifiableList(requestHeaders);
     }
@@ -296,7 +300,7 @@ class FileDownloadInfo {
         BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
         DownloadThread downloadThread = new DownloadThread(
                 context, systemFacade, this, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker, id, batchId, extras);
+                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker);
         executor.submit(downloadThread);
     }
 
@@ -327,7 +331,7 @@ class FileDownloadInfo {
                 || destination == DownloadsDestination.DESTINATION_CACHE_PARTITION_PURGEABLE);
     }
 
-    private Uri getMyDownloadsUri() {
+    public Uri getMyDownloadsUri() {
         return ContentUris.withAppendedId(downloadsUriProvider.getContentUri(), id);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -2,7 +2,6 @@ package com.novoda.downloadmanager.lib;
 
 import android.content.ContentResolver;
 import android.content.ContentUris;
-import android.content.Context;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.Uri;
@@ -13,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Stores information about an individual download.
@@ -275,17 +273,6 @@ class FileDownloadInfo {
         return NetworkState.OK;
     }
 
-    public void startDownload(Context context, ExecutorService executor, StorageManager storageManager, DownloadNotifier downloadNotifier, DownloadsRepository downloadsRepository, DownloadReadyChecker downloadReadyChecker) {
-        String applicationPackageName = context.getApplicationContext().getPackageName();
-        BatchCompletionBroadcaster batchCompletionBroadcaster = new BatchCompletionBroadcaster(context, applicationPackageName);
-        ContentResolver contentResolver = context.getContentResolver();
-        BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
-        DownloadThread downloadThread = new DownloadThread(
-                context, systemFacade, this, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, new NetworkChecker(systemFacade), downloadReadyChecker);
-        executor.submit(downloadThread);
-    }
-
     public boolean isSubmittedOrRunning() {
         return DownloadStatus.isSubmitted(status) || DownloadStatus.isRunning(status);
     }
@@ -378,9 +365,9 @@ class FileDownloadInfo {
             this.cursor = cursor;
         }
 
-        public FileDownloadInfo newDownloadInfo(Context context, SystemFacade systemFacade, DownloadsUriProvider downloadsUriProvider) {
+        public FileDownloadInfo newDownloadInfo(SystemFacade systemFacade, DownloadsUriProvider downloadsUriProvider) {
             RandomNumberGenerator randomNumberGenerator = new RandomNumberGenerator();
-            FileDownloadInfo info = new FileDownloadInfo(context, systemFacade, randomNumberGenerator, downloadsUriProvider);
+            FileDownloadInfo info = new FileDownloadInfo(systemFacade, randomNumberGenerator, downloadsUriProvider);
             updateFromDatabase(info);
             readRequestHeaders(info);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
@@ -78,7 +78,7 @@ public class SizeLimitActivity extends Activity implements DialogInterface.OnCan
         int size = cursor.getInt(cursor.getColumnIndexOrThrow(DownloadContract.Downloads.COLUMN_TOTAL_BYTES));
         String sizeString = Formatter.formatFileSize(this, size);
         String queueText = "Queue";//getString(R.string.button_queue_for_wifi);
-        boolean isWifiRequired = currentIntent.getExtras().getBoolean(FileDownloadInfo.EXTRA_IS_WIFI_REQUIRED);
+        boolean isWifiRequired = currentIntent.getExtras().getBoolean(DownloadThread.EXTRA_IS_WIFI_REQUIRED);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(this, AlertDialog.THEME_HOLO_DARK);
         if (isWifiRequired) {
@@ -113,7 +113,7 @@ public class SizeLimitActivity extends Activity implements DialogInterface.OnCan
 
     @Override
     public void onClick(@NonNull DialogInterface dialog, int which) {
-        boolean isRequired = currentIntent.getExtras().getBoolean(FileDownloadInfo.EXTRA_IS_WIFI_REQUIRED);
+        boolean isRequired = currentIntent.getExtras().getBoolean(DownloadThread.EXTRA_IS_WIFI_REQUIRED);
         if (isRequired && which == AlertDialog.BUTTON_NEGATIVE) {
             getContentResolver().delete(currentUri, null, null);
         } else if (!isRequired && which == AlertDialog.BUTTON_POSITIVE) {


### PR DESCRIPTION
refactoring based around #89 only check against the current download (this PR is raised against it, and could be merged in)

simplifies the `FileDownloadInfo`, removes lots of unused dependencies and inlines a few of the methods into their only usage, the `DownloadThread`, ready to be extracted into their own classes!

**API CHANGE!** moves the `FileDownloadInfo.EXTRA_EXTRA` to `DownloadManager.EXTRA_EXTRA`