### PR TITLE
Add deleting status

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/Download.java
@@ -39,6 +39,8 @@ public class Download {
                 return "Queued";
             case DownloadManager.STATUS_PAUSED:
                 return "Paused";
+            case DownloadManager.STATUS_DELETING:
+                return "Deleting";
             default:
                 return "WTH";
         }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/Batch.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/Batch.java
@@ -51,6 +51,8 @@ public class Batch {
                 return "Queued";
             case DownloadManager.STATUS_PAUSED:
                 return "Paused";
+            case DownloadManager.STATUS_DELETING:
+                return "Deleting";
             default:
                 return "WTH";
         }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/ShowBatchesActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/ShowBatchesActivity.java
@@ -67,6 +67,7 @@ public class ShowBatchesActivity extends AppCompatActivity implements QueryForBa
                         break;
                     case R.id.show_batches_query_deleting:
                         query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_DELETING).build();
+                        break;
                     default:
                         break;
                 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/ShowBatchesActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/ShowBatchesActivity.java
@@ -64,6 +64,9 @@ public class ShowBatchesActivity extends AppCompatActivity implements QueryForBa
                         break;
                     case R.id.show_batches_query_live:
                         query = new BatchQuery.Builder().withSortByLiveness().build();
+                        break;
+                    case R.id.show_batches_query_deleting:
+                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_DELETING).build();
                     default:
                         break;
                 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
@@ -96,11 +96,7 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
 
         @Override
         public void onChange(boolean selfChange) {
-            if (lastQueryTimestamp.updatedRecently()) {
-                return;
-            }
             queryForDownloads();
-            lastQueryTimestamp.setJustUpdated();
         }
 
     };

--- a/demo-extended/src/main/res/layout/activity_show_batches.xml
+++ b/demo-extended/src/main/res/layout/activity_show_batches.xml
@@ -44,6 +44,11 @@
       android:layout_height="wrap_content"
       android:text="@string/downloading" />
 
+    <RadioButton
+      android:id="@+id/show_batches_query_deleting"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/deleting" />
 
     <RadioButton
       android:id="@+id/show_batches_query_failed"

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
   <string name="successful">Successful</string>
   <string name="pending">Pending</string>
   <string name="downloading">Downloading</string>
+  <string name="deleting">Deleting</string>
   <string name="failed">Failed</string>
   <string name="failed_or_pending">Failed or pending</string>
   <string name="live">Live</string>

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/Download.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/Download.java
@@ -32,6 +32,8 @@ class Download {
             return "Queued";
         } else if (downloadStatus == DownloadManager.STATUS_PAUSED) {
             return "Paused";
+        } else if (downloadStatus == DownloadManager.STATUS_DELETING) {
+            return "Deleting";
         } else {
             return "WTH";
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -114,6 +114,7 @@ public class BatchQuery {
          *                    {@link DownloadManager#STATUS_PENDING},
          *                    {@link DownloadManager#STATUS_SUCCESSFUL},
          *                    {@link DownloadManager#STATUS_RUNNING}
+         *                    {@link DownloadManager#STATUS_DELETING}
          *                    <p/>
          *                    e.g. withStatusFilter(DownloadManager.STATUS_FAILED | DownloadManager.STATUS_PENDING)
          * @return {@link BatchQuery.Builder}
@@ -210,7 +211,8 @@ public class BatchQuery {
                     DownloadManager.STATUS_RUNNING,
                     DownloadManager.STATUS_PAUSED,
                     DownloadManager.STATUS_SUCCESSFUL,
-                    DownloadManager.STATUS_FAILED})
+                    DownloadManager.STATUS_FAILED,
+                    DownloadManager.STATUS_DELETING})
     public @interface Status {
         //marker interface that ensures the annotated fields are in within the above values
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -164,7 +164,7 @@ public class BatchQuery {
             if ((statusFlags & DownloadManager.STATUS_DELETING) != 0) {
                 Criteria deletingCriteria = new Criteria.Builder()
                         .withSelection(DownloadContract.Batches.COLUMN_STATUS, Criteria.Wildcard.EQUALS)
-                        .withArgument(String.valueOf(DownloadManager.STATUS_DELETING))
+                        .withArgument(String.valueOf(DownloadStatus.DELETING))
                         .build();
                 criteriaList.add(deletingCriteria);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -161,6 +161,14 @@ public class BatchQuery {
                 criteriaList.add(pausedCriteria);
             }
 
+            if ((statusFlags & DownloadManager.STATUS_DELETING) != 0) {
+                Criteria deletingCriteria = new Criteria.Builder()
+                        .withSelection(DownloadContract.Batches.COLUMN_STATUS, Criteria.Wildcard.EQUALS)
+                        .withArgument(String.valueOf(DownloadManager.STATUS_DELETING))
+                        .build();
+                criteriaList.add(deletingCriteria);
+            }
+
             if ((statusFlags & DownloadManager.STATUS_SUCCESSFUL) != 0) {
                 Criteria successfulCriteria = new Criteria.Builder()
                         .withSelection(DownloadContract.Batches.COLUMN_STATUS, Criteria.Wildcard.EQUALS)

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -18,6 +18,7 @@ class BatchRepository {
     private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
             DownloadStatus.CANCELED,
             DownloadStatus.RUNNING,
+            DownloadStatus.DELETING,
 
             // Paused statuses
             DownloadStatus.PAUSED_BY_APP,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -499,9 +499,9 @@ public class DownloadManager {
 
         if (batchesIds.length == 1) {
             contentResolver.update(downloadsUriProvider.getContentUri(), values, COLUMN_BATCH_ID + "=?", new String[]{String.valueOf(batchesIds[0])});
+        } else {
+            contentResolver.update(downloadsUriProvider.getContentUri(), values, getWhereClauseFor(batchesIds, COLUMN_BATCH_ID), longArrayToStringArray(batchesIds));
         }
-
-        contentResolver.update(downloadsUriProvider.getContentUri(), values, getWhereClauseFor(batchesIds, COLUMN_BATCH_ID), longArrayToStringArray(batchesIds));
     }
 
     private int markBatchesBeDeleted(long[] batchesIds) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -473,7 +473,7 @@ public class DownloadManager {
         if (ids.length == 1) {
             return contentResolver.update(ContentUris.withAppendedId(baseUri, ids[0]), values, null, null);
         }
-        return contentResolver.update(baseUri, values, getWhereClauseForIds(ids), longArrayToStringArray(ids));
+        return contentResolver.update(baseUri, values, getWhereClauseFor(ids, DownloadContract.Downloads._ID), longArrayToStringArray(ids));
     }
 
     /**
@@ -512,7 +512,11 @@ public class DownloadManager {
             return contentResolver.update(ContentUris.withAppendedId(downloadsUriProvider.getBatchesUri(), batchesIds[0]), valuesDelete, null, null);
         }
 
-        return contentResolver.update(downloadsUriProvider.getBatchesUri(), valuesDelete, getWhereClauseForIds(batchesIds), longArrayToStringArray(batchesIds));
+        return contentResolver.update(
+                downloadsUriProvider.getBatchesUri(),
+                valuesDelete,
+                getWhereClauseFor(batchesIds, DownloadContract.Downloads._ID),
+                longArrayToStringArray(batchesIds));
     }
 
     /**
@@ -669,7 +673,7 @@ public class DownloadManager {
         values.putNull(DownloadContract.Downloads.COLUMN_DATA);
         values.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.PENDING);
         values.put(DownloadContract.Downloads.COLUMN_FAILED_CONNECTIONS, 0);
-        contentResolver.update(baseUri, values, getWhereClauseForIds(ids), longArrayToStringArray(ids));
+        contentResolver.update(baseUri, values, getWhereClauseFor(ids, DownloadContract.Downloads._ID), longArrayToStringArray(ids));
     }
 
     /**
@@ -795,14 +799,7 @@ public class DownloadManager {
         return downloadsUriProvider.getBatchesUri();
     }
 
-    /**
-     * Get a parameterized SQL WHERE clause to select a bunch of IDs.
-     */
-    static String getWhereClauseForIds(long[] ids) {
-        return getWhereClauseFor(ids, DownloadContract.Downloads._ID);
-    }
-
-    private static String getWhereClauseFor(long[] ids, String column) {
+    static String getWhereClauseFor(long[] ids, String column) {
         StringBuilder whereClause = new StringBuilder();
         whereClause.append("(");
         for (int i = 0; i < ids.length; i++) {
@@ -816,9 +813,6 @@ public class DownloadManager {
         return whereClause.toString();
     }
 
-    /**
-     * Get the selection args for a clause returned by {@link #getWhereClauseForIds(long[])}.
-     */
     private static String[] longArrayToStringArray(long[] ids) {
         String[] whereArgs = new String[ids.length];
         for (int i = 0; i < ids.length; i++) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -481,16 +481,16 @@ public class DownloadManager {
      * it was running, and it will no longer be accessible through the download manager.
      * If there are any downloaded files, partial or complete, they will be deleted.
      *
-     * @param batchesIds the IDs of the batches to remove
+     * @param batchIds the IDs of the batches to remove
      * @return the number of batches actually removed
      */
-    public int removeBatches(long... batchesIds) {
-        if (batchesIds == null || batchesIds.length == 0) {
-            throw new IllegalArgumentException("called with nothing to remove. input param 'batchesIds' can't be null");
+    public int removeBatches(long... batchIds) {
+        if (batchIds == null || batchIds.length == 0) {
+            throw new IllegalArgumentException("called with nothing to remove. input param 'batchIds' can't be null");
         }
 
-        setDeletingStatusFor(batchesIds);
-        return markBatchesToBeDeleted(batchesIds);
+        setDeletingStatusFor(batchIds);
+        return markBatchesToBeDeleted(batchIds);
     }
 
     private void setDeletingStatusFor(long[] batchesIds) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -490,7 +490,7 @@ public class DownloadManager {
         }
 
         setDeletingStatusFor(batchesIds);
-        return markBatchesBeDeleted(batchesIds);
+        return markBatchesToBeDeleted(batchesIds);
     }
 
     private void setDeletingStatusFor(long[] batchesIds) {
@@ -504,7 +504,7 @@ public class DownloadManager {
         }
     }
 
-    private int markBatchesBeDeleted(long[] batchesIds) {
+    private int markBatchesToBeDeleted(long[] batchesIds) {
         ContentValues valuesDelete = new ContentValues(1);
         valuesDelete.put(DownloadContract.Batches.COLUMN_DELETED, 1);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -13,6 +13,10 @@ package com.novoda.downloadmanager.lib;
 final class DownloadStatus {
 
     /**
+     * This download has been marked for deletion and it will be deleted in the future
+     */
+    public static final int DELETING = 188;
+    /**
      * This download has been submitted to the download executor but not yet started
      */
     public static final int SUBMITTED = 189;
@@ -212,6 +216,10 @@ final class DownloadStatus {
 
     public static boolean isRunning(int status) {
         return status == RUNNING;
+    }
+
+    public static boolean isDeleting(int status) {
+        return status == DELETING;
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -202,6 +202,10 @@ class DownloadThread implements Runnable {
             Log.d("Download " + originalDownloadInfo.getId() + " already failed: status = " + downloadStatus + "; skipping");
             return;
         }
+        if (DownloadStatus.isDeleting(downloadStatus)) {
+            Log.d("Download " + originalDownloadInfo.getId() + " is deleting: status = " + downloadStatus + "; skipping");
+            return;
+        }
 
         DownloadBatch currentBatch = batchRepository.retrieveBatchFor(originalDownloadInfo);
         if (!originalDownloadInfo.isReadyToDownload(currentBatch)) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -238,6 +238,9 @@ public class Query {
         if ((statusFlags & DownloadManager.STATUS_SUCCESSFUL) != 0) {
             parts.add(statusClause("=", DownloadStatus.SUCCESS));
         }
+        if ((statusFlags & DownloadManager.STATUS_DELETING) != 0) {
+            parts.add(statusClause("=", DownloadStatus.DELETING));
+        }
         if ((statusFlags & DownloadManager.STATUS_FAILED) != 0) {
             parts.add("(" + statusClause(">=", 400) + " AND " + statusClause("<", 600) + ")");
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -188,7 +188,7 @@ public class Query {
         if (downloadIds == null) {
             return;
         }
-        selectionParts.add(DownloadManager.getWhereClauseForIds(downloadIds));
+        selectionParts.add(DownloadManager.getWhereClauseFor(downloadIds, DownloadContract.Downloads._ID));
     }
 
     private void filterByBatchIds(List<String> selectionParts) {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchQueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchQueryTest.java
@@ -42,6 +42,14 @@ public class BatchQueryTest {
     }
 
     @Test
+    public void givenTheQueryIsWithDeletingStatusFilterWhenItIsBuiltThenTheSelectionAndArgumentsAreCorrect() {
+        BatchQuery query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_DELETING).build();
+
+        assertThat(query.getSelection()).isEqualTo("(" + DownloadContract.Batches.COLUMN_STATUS + "=?)");
+        assertThatSelectionArgumentAreEqualTo(query.getSelectionArguments(), new Integer[]{DownloadStatus.DELETING});
+    }
+
+    @Test
     public void givenTheQueryIsWithPausedStatusFilterWhenItIsBuiltThenTheSelectionAndArgumentsAreCorrect() {
         BatchQuery query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_PAUSED).build();
 
@@ -162,11 +170,13 @@ public class BatchQueryTest {
                                 | DownloadManager.STATUS_SUCCESSFUL
                                 | DownloadManager.STATUS_RUNNING
                                 | DownloadManager.STATUS_PENDING
-                                | DownloadManager.STATUS_PAUSED)
+                                | DownloadManager.STATUS_PAUSED
+                                | DownloadManager.STATUS_DELETING)
                 .build();
 
         assertThat(query.getSelection()).isEqualTo(
                 "(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
@@ -183,6 +193,7 @@ public class BatchQueryTest {
                 DownloadStatus.WAITING_TO_RETRY,
                 DownloadStatus.WAITING_FOR_NETWORK,
                 DownloadStatus.QUEUED_FOR_WIFI,
+                DownloadStatus.DELETING,
                 DownloadStatus.SUCCESS,
                 400,
                 600,
@@ -199,13 +210,15 @@ public class BatchQueryTest {
                                 | DownloadManager.STATUS_SUCCESSFUL
                                 | DownloadManager.STATUS_RUNNING
                                 | DownloadManager.STATUS_PENDING
-                                | DownloadManager.STATUS_PAUSED)
+                                | DownloadManager.STATUS_PAUSED
+                                | DownloadManager.STATUS_DELETING)
                 .withId(id)
                 .build();
 
         assertThat(query.getSelection()).isEqualTo(
                 "(" + DownloadContract.Batches._ID + "=?) AND "
                         + "(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
@@ -223,6 +236,7 @@ public class BatchQueryTest {
                 DownloadStatus.WAITING_TO_RETRY,
                 DownloadStatus.WAITING_FOR_NETWORK,
                 DownloadStatus.QUEUED_FOR_WIFI,
+                DownloadStatus.DELETING,
                 DownloadStatus.SUCCESS,
                 400,
                 600

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadStatusTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadStatusTest.java
@@ -124,4 +124,10 @@ public class DownloadStatusTest {
         assertThat(isStatusRunning).isTrue();
     }
 
+    @Test
+    public void whenStatusIs188ThenStatusIsDeleting() {
+        boolean isStatusDeleting = DownloadStatus.isDeleting(188);
+        assertThat(isStatusDeleting).isTrue();
+    }
+
 }


### PR DESCRIPTION
## Feature needed ##

We need to bubble up immediately when a batch is marked for deletion.

The current implementation marks a flag in a table that doesn't affect the current status of a downloads

## Solution implemented ##

As soon as a batch is marked for deletion, the batch status immediately changes to a new status `deleting`. This status happens in the same table that any other statuses and so all listeners monitoring the status of a download will be immediately notified.

Previous | Now
--- | ---
![after](https://cloud.githubusercontent.com/assets/2845931/8621127/cfe7d044-271b-11e5-8f18-f492f9f27d76.gif) | ![after-new](https://cloud.githubusercontent.com/assets/2845931/8621132/d4f5e10c-271b-11e5-9e54-1052df1b82dc.gif)

Notice that the demo `DeleteActivity` has changed the way that listens for updates in the database. The previous implementation failed to refresh a second event if that one is faster than the `lastQueryTimestamp`, here's an example of the previous implementation (the gif old has this fixed in order to show updates):

![after](https://cloud.githubusercontent.com/assets/2845931/8621406/3fbcf0d8-271d-11e5-9afd-caf384abb75d.gif)
