### PR TITLE
Fix log warning about no icon being set

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
@@ -82,7 +82,7 @@ class NotificationDisplayer {
                 builder.setSmallIcon(android.R.drawable.stat_sys_download_done);
                 break;
             default:
-                //don't set an icon if none matches
+                builder.setSmallIcon(android.R.drawable.stat_sys_warning);
                 break;
         }
     }


### PR DESCRIPTION
we should always set a notification icon

https://github.com/shorelinedev/aosp_frameworks_base/blob/master/services/java/com/android/server/NotificationManagerService.java#L1842

```kotlin
07-13 12:03:25.501     470-2496/system_process E/NotificationService﹕ WARNING: In a future release this will crash the app: com.novoda.demo
07-13 12:03:25.533      470-470/system_process E/NotificationService﹕ Not posting notification with icon==0: Notification(pri=0 contentView=com.novoda.demo/0x1090082 vibrate=null sound=null defaults=0x0 flags=0x0 kind=[null])
```