### PR TITLE
Update query ability - can now query on Extra Data

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -52,6 +52,7 @@ public class Query {
     private Integer statusFlags = null;
     private boolean onlyIncludeVisibleInDownloadsUi = false;
     private String[] filterNotificiationExtras;
+    private String[] filterExtraData;
     private String orderString = DownloadContract.Downloads.COLUMN_LAST_MODIFICATION + " DESC";
 
     /**
@@ -81,6 +82,16 @@ public class Query {
      */
     public Query setFilterByNotificationExtras(String... extras) {
         filterNotificiationExtras = extras;
+        return this;
+    }
+
+    /**
+     * Include only the downloads with the given extra data.
+     *
+     * @return this object
+     */
+    public Query setFilterByExtraData(String... extraData) {
+        filterExtraData = extraData;
         return this;
     }
 
@@ -163,6 +174,7 @@ public class Query {
         filterByDownloadIds(selectionParts);
         filterByBatchIds(selectionParts);
         filterByNotificationExtras(selectionParts);
+        filterByExtraData(selectionParts);
         filterByStatus(selectionParts);
 
         if (onlyIncludeVisibleInDownloadsUi) {
@@ -217,6 +229,13 @@ public class Query {
         selectionParts.add(joinStrings(" OR ", parts));
     }
 
+    private void filterByExtraData(List<String> selectionParts) {
+        if (filterExtraData == null) {
+            return;
+        }
+        List<String> parts = new ArrayList<>();
+        for (String filterExtra : filterExtraData) {
+            parts.add(extraDataClause(filterExtra));
         }
         selectionParts.add(joinStrings(" OR ", parts));
     }
@@ -275,6 +294,10 @@ public class Query {
 
     private String notificationExtrasClause(String extra) {
         return DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = '" + extra + "'";
+    }
+
+    private String extraDataClause(String extra) {
+        return DownloadContract.Downloads.COLUMN_EXTRA_DATA + " = '" + extra + "'";
     }
 
     private String statusClause(String operator, int value) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -51,7 +51,7 @@ public class Query {
     private long[] batchIds = null;
     private Integer statusFlags = null;
     private boolean onlyIncludeVisibleInDownloadsUi = false;
-    private String[] filterExtras;
+    private String[] filterNotificiationExtras;
     private String orderString = DownloadContract.Downloads.COLUMN_LAST_MODIFICATION + " DESC";
 
     /**
@@ -75,12 +75,12 @@ public class Query {
     }
 
     /**
-     * Include only the downloads with the given extras.
+     * Include only the downloads with the given notification extras.
      *
      * @return this object
      */
-    public Query setFilterByExtras(String... extras) {
-        filterExtras = extras;
+    public Query setFilterByNotificationExtras(String... extras) {
+        filterNotificiationExtras = extras;
         return this;
     }
 
@@ -207,11 +207,11 @@ public class Query {
     }
 
     private void filterByExtras(List<String> selectionParts) {
-        if (filterExtras == null) {
+        if (filterNotificiationExtras == null) {
             return;
         }
         List<String> parts = new ArrayList<>();
-        for (String filterExtra : filterExtras) {
+        for (String filterExtra : filterNotificiationExtras) {
             parts.add(extrasClause(filterExtra));
         }
         selectionParts.add(joinStrings(" OR ", parts));

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -212,7 +212,11 @@ public class Query {
         }
         List<String> parts = new ArrayList<>();
         for (String filterExtra : filterNotificiationExtras) {
-            parts.add(extrasClause(filterExtra));
+            parts.add(notificationExtrasClause(filterExtra));
+        }
+        selectionParts.add(joinStrings(" OR ", parts));
+    }
+
         }
         selectionParts.add(joinStrings(" OR ", parts));
     }
@@ -269,7 +273,7 @@ public class Query {
         return strings;
     }
 
-    private String extrasClause(String extra) {
+    private String notificationExtrasClause(String extra) {
         return DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = '" + extra + "'";
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -162,7 +162,7 @@ public class Query {
 
         filterByDownloadIds(selectionParts);
         filterByBatchIds(selectionParts);
-        filterByExtras(selectionParts);
+        filterByNotificationExtras(selectionParts);
         filterByStatus(selectionParts);
 
         if (onlyIncludeVisibleInDownloadsUi) {
@@ -206,7 +206,7 @@ public class Query {
         return DownloadContract.Downloads.COLUMN_BATCH_ID + " IN (" + joinStrings(",", Arrays.asList(idStrings)) + ")";
     }
 
-    private void filterByExtras(List<String> selectionParts) {
+    private void filterByNotificationExtras(List<String> selectionParts) {
         if (filterNotificiationExtras == null) {
             return;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -31,7 +31,8 @@ public class Query {
      */
     public static final int ORDER_DESCENDING = 2;
 
-    private static final String ORDER_BY_LIVENESS = String.format("CASE %1$s "
+    private static final String ORDER_BY_LIVENESS = String.format(
+            "CASE %1$s "
                     + "WHEN %2$d THEN 1 "
                     + "WHEN %3$d THEN 2 "
                     + "WHEN %4$d THEN 3 "

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -39,7 +39,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).contains(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN (1,2,3)");
+        assertSelectionContains(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN (1,2,3)");
     }
 
     @Test
@@ -48,7 +48,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).doesNotContain(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN ");
+        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN ");
     }
 
     @Test
@@ -84,7 +84,9 @@ public class QueryTest {
     @Test(expected = IllegalArgumentException.class)
     public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
         int anyOrder = Query.ORDER_ASCENDING;
+
         query.orderBy(DownloadManager.COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
+
         // Expecting an exception
     }
 
@@ -94,7 +96,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).contains(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = 'something extra'");
+        assertSelectionContains(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = 'something extra'");
     }
 
     @Test
@@ -103,7 +105,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).doesNotContain(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " IN ");
+        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " IN ");
     }
 
     @Test
@@ -112,7 +114,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).contains(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " = 'something extra'");
+        assertSelectionContains(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " = 'something extra'");
     }
 
     @Test
@@ -121,6 +123,14 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertThat(stringArgumentCaptor.getValue()).doesNotContain(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " IN ");
+        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " IN ");
+    }
+
+    private void assertSelectionContains(String sequence) {
+        assertThat(stringArgumentCaptor.getValue()).contains(sequence);
+    }
+
+    private void assertSelectionDoesNotContain(String sequence) {
+        assertThat(stringArgumentCaptor.getValue()).doesNotContain(sequence);
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -25,14 +25,17 @@ public class QueryTest {
     @Captor
     ArgumentCaptor<String> stringArgumentCaptor;
 
+    private Query query;
+
     @Before
     public void setUp() throws Exception {
         initMocks(this);
+        query = new Query();
     }
 
     @Test
     public void givenBatchIdsWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
-        new Query().setFilterByBatchId(1, 2, 3).runQuery(resolver, null, uri);
+        query.setFilterByBatchId(1, 2, 3).runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
@@ -41,7 +44,7 @@ public class QueryTest {
 
     @Test
     public void givenNoBatchIdsWhenTheQueryIsCreatedThenTheWhereStatementContainsNoBatchIdPredicate() {
-        new Query().runQuery(resolver, null, uri);
+        query.runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
@@ -50,7 +53,7 @@ public class QueryTest {
 
     @Test
     public void whenWeSetABatchStatusOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
-        new Query().orderBy(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
+        query.orderBy(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
 
         // Actually resolves to Downloads.Impl.COLUMN_LAST_MODIFIED
         verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod ASC"));
@@ -58,14 +61,14 @@ public class QueryTest {
 
     @Test
     public void whenWeSetNoOrderByOnAQueryThenTheResolverIsQueriedWithTheLastModifiedSortOrder() {
-        new Query().runQuery(resolver, null, uri);
+        query.runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
     }
 
     @Test
     public void whenOrderingByLivenessThenTheResolverIsQueriedWithTheExpectedSort() {
-        new Query().orderByLiveness().runQuery(resolver, null, uri);
+        query.orderByLiveness().runQuery(resolver, null, uri);
 
         verify(resolver).query(
                 any(Uri.class), any(String[].class), anyString(), any(String[].class), eq(
@@ -81,13 +84,13 @@ public class QueryTest {
     @Test(expected = IllegalArgumentException.class)
     public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
         int anyOrder = Query.ORDER_ASCENDING;
-        new Query().orderBy(DownloadManager.COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
+        query.orderBy(DownloadManager.COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
         // Expecting an exception
     }
 
     @Test
     public void givenNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
-        new Query().setFilterByNotificationExtras("something extra").runQuery(resolver, null, uri);
+        query.setFilterByNotificationExtras("something extra").runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
@@ -96,7 +99,7 @@ public class QueryTest {
 
     @Test
     public void givenNoNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementContainsNoBatchIdPredicate() {
-        new Query().runQuery(resolver, null, uri);
+        query.runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
@@ -105,7 +108,7 @@ public class QueryTest {
 
     @Test
     public void givenExtraDataWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
-        new Query().setFilterByExtraData("something extra").runQuery(resolver, null, uri);
+        query.setFilterByExtraData("something extra").runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
@@ -114,7 +117,7 @@ public class QueryTest {
 
     @Test
     public void givenNoExtraDataWhenTheQueryIsCreatedThenTheWhereStatementContainsNoBatchIdPredicate() {
-        new Query().runQuery(resolver, null, uri);
+        query.runQuery(resolver, null, uri);
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -9,6 +9,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
+import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
+import static com.novoda.downloadmanager.lib.DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP;
+import static com.novoda.downloadmanager.lib.DownloadManager.COLUMN_STATUS;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.verify;
@@ -39,7 +42,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionContains(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN (1,2,3)");
+        assertSelectionContains(COLUMN_BATCH_ID + " IN (1,2,3)");
     }
 
     @Test
@@ -48,12 +51,12 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_BATCH_ID + " IN ");
+        assertSelectionDoesNotContain(COLUMN_BATCH_ID + " IN ");
     }
 
     @Test
     public void whenWeSetABatchStatusOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
-        query.orderBy(DownloadManager.COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
+        query.orderBy(COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
 
         // Actually resolves to Downloads.Impl.COLUMN_LAST_MODIFIED
         verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod ASC"));
@@ -85,7 +88,7 @@ public class QueryTest {
     public void whenWeSetAnUnsupportedOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
         int anyOrder = Query.ORDER_ASCENDING;
 
-        query.orderBy(DownloadManager.COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
+        query.orderBy(COLUMN_STATUS, anyOrder).runQuery(resolver, null, uri);
 
         // Expecting an exception
     }
@@ -96,7 +99,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionContains(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = 'something extra'");
+        assertSelectionContains(COLUMN_NOTIFICATION_EXTRAS + " = 'something extra'");
     }
 
     @Test
@@ -105,7 +108,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " IN ");
+        assertSelectionDoesNotContain(COLUMN_NOTIFICATION_EXTRAS + " IN ");
     }
 
     @Test
@@ -114,7 +117,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionContains(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " = 'something extra'");
+        assertSelectionContains(COLUMN_EXTRA_DATA + " = 'something extra'");
     }
 
     @Test
@@ -123,7 +126,7 @@ public class QueryTest {
 
         verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
 
-        assertSelectionDoesNotContain(DownloadContract.Downloads.COLUMN_EXTRA_DATA + " IN ");
+        assertSelectionDoesNotContain(COLUMN_EXTRA_DATA + " IN ");
     }
 
     private void assertSelectionContains(String sequence) {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -86,6 +86,24 @@ public class QueryTest {
     }
 
     @Test
+    public void givenNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
+        new Query().setFilterByNotificationExtras("something extra").runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertThat(stringArgumentCaptor.getValue()).contains(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " = 'something extra'");
+    }
+
+    @Test
+    public void givenNoNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementContainsNoBatchIdPredicate() {
+        new Query().runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertThat(stringArgumentCaptor.getValue()).doesNotContain(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS + " IN ");
+    }
+
+    @Test
     public void givenExtraDataWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
         new Query().setFilterByExtraData("something extra").runQuery(resolver, null, uri);
 


### PR DESCRIPTION
**breaking API change** need to remember this when we write the changelog & release

Fixes https://github.com/novoda/download-manager/pull/88#issuecomment-120435573

Now that we have an extra data column where clients can pass whatever they want through the download manager. It is right to also add the ability to query on this field.

Did some boyscouting and added 2 more tests and some clean up.