### PR TITLE
98/Fix processDebugAndroidTest

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,6 +34,10 @@ android {
         }
     }
 
+    testVariants.all {
+        it.mergedFlavor.manifestPlaceholders = [downloadAuthority: "com.novoda.download-manager.android-test"]
+    }
+
     lintOptions {
         abortOnError false
     }


### PR DESCRIPTION
This PR adds a value for downloadAuthority to be used in integration test.

Currently, there are no test in `androidTest` but the missing value can make `gradle sync` fail in Android Studio when the test artifact is set to Android instrumentation test.