### PR TITLE
Reduce number of db update callbacks

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -384,7 +384,7 @@ public class DownloadService extends Service {
         executor.submit(downloadThread);
     }
 
-    private long lastUpdate = 0;
+    private long lastUpdate;
 
     private void updateTotalBytesFor(Collection<FileDownloadInfo> downloadInfos) {
         if (SystemClock.elapsedRealtime() - lastUpdate < TimeUnit.SECONDS.toMillis(1)) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -63,6 +63,8 @@ public class DownloadService extends Service {
     // DownloadReceiver to protect our entire workflow.
 
     private static final boolean DEBUG_LIFECYCLE = false;
+    private static final long ONE_SECOND = TimeUnit.SECONDS.toMillis(1);
+
     private final ContentLengthFetcher contentLengthFetcher = new ContentLengthFetcher();
 
     private SystemFacade systemFacade;
@@ -387,7 +389,7 @@ public class DownloadService extends Service {
     private long lastUpdate;
 
     private void updateTotalBytesIfNecessaryFor(Collection<FileDownloadInfo> downloadInfos) {
-        if (SystemClock.elapsedRealtime() - lastUpdate < TimeUnit.SECONDS.toMillis(1)) {
+        if (SystemClock.elapsedRealtime() - lastUpdate < ONE_SECOND) {
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -322,7 +322,7 @@ public class DownloadService extends Service {
         long now = systemFacade.currentTimeMillis();
 
         Collection<FileDownloadInfo> allDownloads = downloadsRepository.getAllDownloads();
-        updateTotalBytesFor(allDownloads);
+        updateTotalBytesIfNecessaryFor(allDownloads);
 
         List<DownloadBatch> downloadBatches = batchRepository.retrieveBatchesFor(allDownloads);
         for (DownloadBatch downloadBatch : downloadBatches) {
@@ -386,7 +386,7 @@ public class DownloadService extends Service {
 
     private long lastUpdate;
 
-    private void updateTotalBytesFor(Collection<FileDownloadInfo> downloadInfos) {
+    private void updateTotalBytesIfNecessaryFor(Collection<FileDownloadInfo> downloadInfos) {
         if (SystemClock.elapsedRealtime() - lastUpdate < TimeUnit.SECONDS.toMillis(1)) {
             return;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -261,7 +261,6 @@ public class DownloadService extends Service {
             // TODO: switch to asking real tasks to derive active state
             // TODO: handle media scanner timeouts
 
-            Log.d("Ferran, updateCallback");
             boolean isActive = updateLocked();
 
             if (msg.what == MSG_FINAL_UPDATE) {
@@ -380,8 +379,6 @@ public class DownloadService extends Service {
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.SUBMITTED);
-
-        Log.d("Ferran, download");
         getContentResolver().update(info.getAllDownloadsUri(), contentValues, null, null);
 
         executor.submit(downloadThread);
@@ -402,7 +399,6 @@ public class DownloadService extends Service {
                 long totalBytes = contentLengthFetcher.fetchContentLengthFor(downloadInfo);
                 values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, totalBytes);
                 getContentResolver().update(downloadInfo.getAllDownloadsUri(), values, null, null);
-                Log.d("Ferran, updateTotalBytesFor: " + downloadInfo.getFileName() + ", size: " + (totalBytes/1048576) + "MB");
 
                 batchRepository.updateTotalSize(downloadInfo.getBatchId());
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -613,9 +613,6 @@ class DownloadThread implements Runnable {
 
         if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
                 now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
-
-            Log.d("Ferran, report progress with: " + (state.currentBytes / 1048576f));
-
             ContentValues values = new ContentValues();
             values.put(DownloadContract.Downloads.COLUMN_CURRENT_BYTES, state.currentBytes);
             getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -613,6 +613,9 @@ class DownloadThread implements Runnable {
 
         if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
                 now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
+
+            Log.d("Ferran, report progress with: " + (state.currentBytes / 1048576f));
+
             ContentValues values = new ContentValues();
             values.put(DownloadContract.Downloads.COLUMN_CURRENT_BYTES, state.currentBytes);
             getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);


### PR DESCRIPTION
## Description of the problem ##

Downloads are taking a really long time when the wifi connection is strong and good enough

## Causes of the problem ##

After some investigation, we have find out that there was a kind of recursive calls going from the download thread to the database and back to the download thread.

Here's the cycle:
- In the DownloadService, the download thread is triggered by a `Handler` that is listening to the database. When there is a change in the database, the handler is triggered.
- In the Handler method, there is a call to `updateTotalBytesFor(allDownloads)`. This method triggers a database update calling `batchRepository.updateCurrentSize(batchId)`
- The previous database update triggers a change in the database and so a news handler is immediately triggered

This causes an overload on the system that leads to a slowdown on the downloads

## Solution implemented ##

The size update for the batch doesn't need to happen immediately as there are other mechanisms that triggers updates if a download has finished completely.

We have put in place a security for too many unnecessary calls preventing the system to call this method more than once per second.

**Time to download 100MB**

Before | Now
--- | ---
10m | 5m10s