### PR TITLE
Batch sizes view

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -46,41 +46,6 @@ class BatchRepository {
         this.downloadsUriProvider = downloadsUriProvider;
     }
 
-    void updateTotalSize(long batchId) {
-        ContentValues updateValues = new ContentValues();
-        updateValues.put(DownloadContract.Batches.COLUMN_TOTAL_BYTES, getSummedBatchSizeInBytes(batchId, DownloadContract.Downloads.COLUMN_TOTAL_BYTES));
-        resolver.update(downloadsUriProvider.getBatchesUri(), updateValues, DownloadContract.Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
-    }
-
-    void updateCurrentSize(long batchId) {
-        ContentValues updateValues = new ContentValues();
-        updateValues.put(DownloadContract.Batches.COLUMN_CURRENT_BYTES, getSummedBatchSizeInBytes(batchId, DownloadContract.Downloads.COLUMN_CURRENT_BYTES));
-        resolver.update(downloadsUriProvider.getBatchesUri(), updateValues, DownloadContract.Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
-    }
-
-    private long getSummedBatchSizeInBytes(long batchId, String columnName) {
-        Cursor cursor = null;
-        long totalSize = 0;
-        try {
-            String[] selectionArgs = {String.valueOf(batchId)};
-            cursor = resolver.query(
-                    downloadsUriProvider.getAllDownloadsUri(),
-                    new String[]{"sum(" + columnName + ")"},
-                    DownloadContract.Downloads.COLUMN_BATCH_ID + " = ?",
-                    selectionArgs,
-                    null);
-
-            cursor.moveToFirst();
-            totalSize = cursor.getLong(0);
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
-        }
-
-        return totalSize;
-    }
-
     void updateBatchStatus(long batchId, int status) {
         ContentValues values = new ContentValues();
         values.put(DownloadContract.Batches.COLUMN_STATUS, status);
@@ -149,8 +114,8 @@ class BatchRepository {
             int bigPictureUrlIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.Batches.COLUMN_BIG_PICTURE);
             int statusIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.Batches.COLUMN_STATUS);
             int visibilityColumn = batchesCursor.getColumnIndexOrThrow(DownloadContract.Batches.COLUMN_VISIBILITY);
-            int totalBatchSizeIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.Batches.COLUMN_TOTAL_BYTES);
-            int currentBatchSizeIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.Batches.COLUMN_CURRENT_BYTES);
+            int totalBatchSizeIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES);
+            int currentBatchSizeIndex = batchesCursor.getColumnIndexOrThrow(DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES);
 
             while (batchesCursor.moveToNext()) {
                 long id = batchesCursor.getLong(idColumn);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -46,9 +46,9 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             DownloadContract.Batches.COLUMN_BIG_PICTURE,
             DownloadContract.Batches.COLUMN_VISIBILITY,
             DownloadContract.Batches.COLUMN_STATUS,
-            DownloadContract.Batches.BATCHES_TABLE_NAME + "." + DownloadContract.Batches.COLUMN_DELETED,
-            DownloadContract.Batches.COLUMN_TOTAL_BYTES,
-            DownloadContract.Batches.COLUMN_CURRENT_BYTES
+            DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES + "." + DownloadContract.Batches.COLUMN_DELETED,
+            DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES,
+            DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES
     };
 
     public static final String[] DOWNLOADS_WITHOUT_PROGRESS_VIEW_COLUMNS = new String[]{
@@ -250,34 +250,6 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         + ";"
         );
     }
-    /**
-     * columns to request from DownloadProvider.
-     */
-    public static final String[] DOWNLOAD_BY_BATCH_VIEW_COLUMNS = new String[]{
-            DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads._ID + " AS _id ",
-            DownloadContract.Downloads.COLUMN_DATA,
-            DownloadContract.Downloads.COLUMN_MEDIAPROVIDER_URI,
-            DownloadContract.Downloads.COLUMN_DESTINATION,
-            DownloadContract.Downloads.COLUMN_URI,
-            DownloadContract.Downloads.COLUMN_STATUS,
-            DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads.COLUMN_DELETED,
-            DownloadContract.Downloads.COLUMN_FILE_NAME_HINT,
-            DownloadContract.Downloads.COLUMN_MIME_TYPE,
-            DownloadContract.Downloads.COLUMN_TOTAL_BYTES,
-            DownloadContract.Downloads.COLUMN_LAST_MODIFICATION,
-            DownloadContract.Downloads.COLUMN_CURRENT_BYTES,
-            DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS,
-            DownloadContract.Downloads.COLUMN_EXTRA_DATA,
-            DownloadContract.Downloads.COLUMN_BATCH_ID,
-            DownloadContract.Batches.COLUMN_TITLE,
-            DownloadContract.Batches.COLUMN_DESCRIPTION,
-            DownloadContract.Batches.COLUMN_BIG_PICTURE,
-            DownloadContract.Batches.COLUMN_VISIBILITY,
-            DownloadContract.Batches.COLUMN_STATUS,
-            DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES + "." + DownloadContract.Batches.COLUMN_DELETED,
-            DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES,
-            DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES
-    };
 
     private String projectionFrom(String[] array) {
         if (array == null) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -210,15 +210,15 @@ final class DatabaseHelper extends SQLiteOpenHelper {
         db.execSQL(
                 "CREATE VIEW " + DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES
                         + " AS SELECT DISTINCT "
-                        + DownloadContract.Batches.BATCHES_TABLE_NAME + ".*"
-                        + ", " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES
-                        + ", " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
+                        + DownloadContract.Batches.BATCHES_TABLE_NAME + ".*, "
+                        + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES + ", "
+                        + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
                         + " FROM " + DownloadContract.Batches.BATCHES_TABLE_NAME
                         + " INNER JOIN "
                         + "  (SELECT "
                         + "    " + DownloadContract.Downloads.COLUMN_BATCH_ID + ","
-                        + "    SUM(" + DownloadContract.Downloads.COLUMN_CURRENT_BYTES + ") " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES + ","
-                        + "    SUM(" + DownloadContract.Downloads.COLUMN_TOTAL_BYTES + ") " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
+                        + "    SUM(" + DownloadContract.Downloads.COLUMN_CURRENT_BYTES + ") AS " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES + ","
+                        + "    SUM(" + DownloadContract.Downloads.COLUMN_TOTAL_BYTES + ") AS " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
                         + "    FROM " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME
                         + "    GROUP BY " + DownloadContract.Downloads.COLUMN_BATCH_ID
                         + "  ) " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -35,6 +35,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
         createDownloadsTable(db);
         createHeadersTable(db);
         createBatchesTable(db);
+        createBatchesWithSizesView(db);
         createDownloadsByBatchView(db);
         makeCacheDownloadsInvisible(db);
     }
@@ -131,9 +132,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         DownloadContract.Batches.COLUMN_BIG_PICTURE + " TEXT," +
                         DownloadContract.Batches.COLUMN_STATUS + " INTEGER," +
                         DownloadContract.Batches.COLUMN_VISIBILITY + " INTEGER," +
-                        DownloadContract.Batches.COLUMN_DELETED + " BOOLEAN NOT NULL DEFAULT 0, " +
-                        DownloadContract.Batches.COLUMN_TOTAL_BYTES + " INTEGER NOT NULL DEFAULT -1, " +
-                        DownloadContract.Batches.COLUMN_CURRENT_BYTES + " INTEGER NOT NULL DEFAULT 0 " +
+                        DownloadContract.Batches.COLUMN_DELETED + " BOOLEAN NOT NULL DEFAULT 0" +
                         ");");
     }
 
@@ -144,7 +143,29 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         + " AS SELECT DISTINCT "
                         + projectionFrom(DOWNLOAD_BY_BATCH_VIEW_COLUMNS)
                         + " FROM " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME
-                        + " INNER JOIN " + DownloadContract.Batches.BATCHES_TABLE_NAME
+                        + " INNER JOIN " + DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES
+                        + " ON " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads.COLUMN_BATCH_ID
+                        + " = " + DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES + "." + DownloadContract.Batches._ID + ";"
+        );
+    }
+
+    private void createBatchesWithSizesView(SQLiteDatabase db) {
+        db.execSQL("DROP VIEW IF EXISTS " + DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES);
+        db.execSQL(
+                "CREATE VIEW " + DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES
+                        + " AS SELECT DISTINCT "
+                        + DownloadContract.Batches.BATCHES_TABLE_NAME + ".*"
+                        + ", " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES
+                        + ", " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
+                        + " FROM " + DownloadContract.Batches.BATCHES_TABLE_NAME
+                        + " INNER JOIN "
+                        + "  (SELECT "
+                        + "    " + DownloadContract.Downloads.COLUMN_BATCH_ID + ","
+                        + "    SUM(" + DownloadContract.Downloads.COLUMN_CURRENT_BYTES + ") " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES + ","
+                        + "    SUM(" + DownloadContract.Downloads.COLUMN_TOTAL_BYTES + ") " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
+                        + "    FROM " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME
+                        + "    GROUP BY " + DownloadContract.Downloads.COLUMN_BATCH_ID
+                        + "  ) " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME
                         + " ON " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads.COLUMN_BATCH_ID
                         + " = " + DownloadContract.Batches.BATCHES_TABLE_NAME + "." + DownloadContract.Batches._ID + ";"
         );
@@ -174,9 +195,9 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             DownloadContract.Batches.COLUMN_BIG_PICTURE,
             DownloadContract.Batches.COLUMN_VISIBILITY,
             DownloadContract.Batches.COLUMN_STATUS,
-            DownloadContract.Batches.BATCHES_TABLE_NAME + "." + DownloadContract.Batches.COLUMN_DELETED,
-            DownloadContract.Batches.COLUMN_TOTAL_BYTES,
-            DownloadContract.Batches.COLUMN_CURRENT_BYTES
+            DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES + "." + DownloadContract.Batches.COLUMN_DELETED,
+            DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES,
+            DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES
     };
 
     private String projectionFrom(String[] array) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -218,7 +218,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         + "  (SELECT "
                         + "    " + DownloadContract.Downloads.COLUMN_BATCH_ID + ","
                         + "    SUM(" + DownloadContract.Downloads.COLUMN_CURRENT_BYTES + ") AS " + DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES + ","
-                        + "    SUM(" + DownloadContract.Downloads.COLUMN_TOTAL_BYTES + ") AS " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
+                        + "    MAX(SUM(" + DownloadContract.Downloads.COLUMN_TOTAL_BYTES + "), -1) AS " + DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES
                         + "    FROM " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME
                         + "    GROUP BY " + DownloadContract.Downloads.COLUMN_BATCH_ID
                         + "  ) " + DownloadContract.Downloads.DOWNLOADS_TABLE_NAME

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -308,18 +308,6 @@ final class DownloadContract {
          */
         public static final String COLUMN_DELETED = "deleted";
 
-        /**
-         * The total size of the batch in bytes.
-         * <P>Type: INTEGER</P>
-         */
-        public static final String COLUMN_TOTAL_BYTES = "batch_total_bytes";
-
-        /**
-         * The current size of the batch in bytes (on device).
-         * <P>Type: INTEGER</P>
-         */
-        public static final String COLUMN_CURRENT_BYTES = "batch_current_bytes";
-
         private Batches() {
             // non-instantiable class
         }
@@ -332,6 +320,27 @@ final class DownloadContract {
         private DownloadsByBatch() {
             // non-instantiable class
         }
+
+    }
+    static final class BatchesWithSizes {
+
+        public static final String VIEW_NAME_BATCHES_WITH_SIZES = "BatchesWithSizes";
+
+        private BatchesWithSizes() {
+            // non-instantiable class
+        }
+
+        /**
+         * The total size of the batch in bytes.
+         * <P>Type: INTEGER</P>
+         */
+        public static final String COLUMN_TOTAL_BYTES = "batch_total_bytes";
+
+        /**
+         * The current size of the batch in bytes (on device).
+         * <P>Type: INTEGER</P>
+         */
+        public static final String COLUMN_CURRENT_BYTES = "batch_current_bytes";
 
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -87,12 +87,12 @@ public class DownloadManager {
     /**
      * The total size in bytes of the batch.
      */
-    public static final String COLUMN_BATCH_TOTAL_SIZE_BYTES = DownloadContract.Batches.COLUMN_TOTAL_BYTES;
+    public static final String COLUMN_BATCH_TOTAL_SIZE_BYTES = DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES;
 
     /**
      * The current size in bytes of the batch.
      */
-    public static final String COLUMN_BATCH_CURRENT_SIZE_BYTES = DownloadContract.Batches.COLUMN_CURRENT_BYTES;
+    public static final String COLUMN_BATCH_CURRENT_SIZE_BYTES = DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES;
 
     /**
      * The extra supplied information available to completion notifications for this download.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Allows application to interact with the download manager.
@@ -133,23 +134,6 @@ public final class DownloadProvider extends ContentProvider {
      */
     private static final int DOWNLOADS_BY_BATCH = 9;
 
-    static {
-        URI_MATCHER.addURI(AUTHORITY, "my_downloads", MY_DOWNLOADS);
-        URI_MATCHER.addURI(AUTHORITY, "my_downloads/#", MY_DOWNLOADS_ID);
-        URI_MATCHER.addURI(AUTHORITY, "all_downloads", ALL_DOWNLOADS);
-        URI_MATCHER.addURI(AUTHORITY, "all_downloads/#", ALL_DOWNLOADS_ID);
-        URI_MATCHER.addURI(AUTHORITY, "batches", BATCHES);
-        URI_MATCHER.addURI(AUTHORITY, "batches/#", BATCHES_ID);
-        URI_MATCHER.addURI(AUTHORITY, "downloads_by_batch", DOWNLOADS_BY_BATCH);
-        URI_MATCHER.addURI(AUTHORITY, "my_downloads/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
-        URI_MATCHER.addURI(AUTHORITY, "all_downloads/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
-        // temporary, for backwards compatibility
-        URI_MATCHER.addURI(AUTHORITY, "download", MY_DOWNLOADS);
-        URI_MATCHER.addURI(AUTHORITY, "download/#", MY_DOWNLOADS_ID);
-        URI_MATCHER.addURI(AUTHORITY, "download/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
-        URI_MATCHER.addURI(AUTHORITY, DownloadsDestination.PUBLICLY_ACCESSIBLE_DOWNLOADS_URI_SEGMENT + "/#", PUBLIC_DOWNLOAD_ID);
-    }
-
     private static final String[] APP_READABLE_COLUMNS_ARRAY = new String[]{
             DownloadContract.Downloads._ID,
             DownloadContract.Downloads.COLUMN_APP_DATA,
@@ -181,10 +165,51 @@ public final class DownloadProvider extends ContentProvider {
             OpenableColumns.SIZE,
     };
 
-    private static final HashSet<String> APP_READABLE_COLUMNS_SET;
-    private static final HashMap<String, String> COLUMNS_MAP;
+    private static final Set<String> APP_READABLE_COLUMNS_SET;
+
+    private static final Map<String, String> COLUMNS_MAP;
+
+    private static final List<String> DOWNLOAD_MANAGER_COLUMNS_LIST = Arrays.asList(DownloadManager.UNDERLYING_COLUMNS);
+
+    private final DownloadsUriProvider downloadsUriProvider;
+
+    /**
+     * Different base URIs that could be used to access an individual download
+     */
+    private final Uri[] baseUris;
+
+
+    /**
+     * The database that lies underneath this content provider
+     */
+    private SQLiteOpenHelper openHelper;
+
+    /**
+     * List of uids that can access the downloads
+     */
+    private int systemUid = -1;
+
+    private int defcontaineruid = -1;
+    private File downloadsDataDir;
+    //    @VisibleForTesting
+    SystemFacade systemFacade;
 
     static {
+        URI_MATCHER.addURI(AUTHORITY, "my_downloads", MY_DOWNLOADS);
+        URI_MATCHER.addURI(AUTHORITY, "my_downloads/#", MY_DOWNLOADS_ID);
+        URI_MATCHER.addURI(AUTHORITY, "all_downloads", ALL_DOWNLOADS);
+        URI_MATCHER.addURI(AUTHORITY, "all_downloads/#", ALL_DOWNLOADS_ID);
+        URI_MATCHER.addURI(AUTHORITY, "batches", BATCHES);
+        URI_MATCHER.addURI(AUTHORITY, "batches/#", BATCHES_ID);
+        URI_MATCHER.addURI(AUTHORITY, "downloads_by_batch", DOWNLOADS_BY_BATCH);
+        URI_MATCHER.addURI(AUTHORITY, "my_downloads/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
+        URI_MATCHER.addURI(AUTHORITY, "all_downloads/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
+        // temporary, for backwards compatibility
+        URI_MATCHER.addURI(AUTHORITY, "download", MY_DOWNLOADS);
+        URI_MATCHER.addURI(AUTHORITY, "download/#", MY_DOWNLOADS_ID);
+        URI_MATCHER.addURI(AUTHORITY, "download/#/" + DownloadContract.RequestHeaders.URI_SEGMENT, REQUEST_HEADERS_URI);
+        URI_MATCHER.addURI(AUTHORITY, DownloadsDestination.PUBLICLY_ACCESSIBLE_DOWNLOADS_URI_SEGMENT + "/#", PUBLIC_DOWNLOAD_ID);
+
         APP_READABLE_COLUMNS_SET = new HashSet<>();
         Collections.addAll(APP_READABLE_COLUMNS_SET, APP_READABLE_COLUMNS_ARRAY);
 
@@ -192,30 +217,6 @@ public final class DownloadProvider extends ContentProvider {
         COLUMNS_MAP.put(OpenableColumns.DISPLAY_NAME, DownloadContract.Batches.COLUMN_TITLE + " AS " + OpenableColumns.DISPLAY_NAME);
         COLUMNS_MAP.put(OpenableColumns.SIZE, DownloadContract.Downloads.COLUMN_TOTAL_BYTES + " AS " + OpenableColumns.SIZE);
     }
-
-    private static final List<String> DOWNLOAD_MANAGER_COLUMNS_LIST = Arrays.asList(DownloadManager.UNDERLYING_COLUMNS);
-
-    /**
-     * Different base URIs that could be used to access an individual download
-     */
-    private final Uri[] baseUris;
-
-    /**
-     * The database that lies underneath this content provider
-     */
-    private SQLiteOpenHelper openHelper = null;
-
-    /**
-     * List of uids that can access the downloads
-     */
-    private int systemUid = -1;
-    private int defcontaineruid = -1;
-    private File downloadsDataDir;
-
-    //    @VisibleForTesting
-    SystemFacade systemFacade;
-
-    private DownloadsUriProvider downloadsUriProvider;
 
     public DownloadProvider() {
         downloadsUriProvider = DownloadsUriProvider.getInstance();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -175,8 +175,8 @@ public final class DownloadProvider extends ContentProvider {
             DownloadContract.Batches.COLUMN_DESCRIPTION,
             DownloadContract.Batches.COLUMN_BIG_PICTURE,
             DownloadContract.Batches.COLUMN_VISIBILITY,
-            DownloadContract.Batches.COLUMN_TOTAL_BYTES,
-            DownloadContract.Batches.COLUMN_CURRENT_BYTES,
+            DownloadContract.BatchesWithSizes.COLUMN_TOTAL_BYTES,
+            DownloadContract.BatchesWithSizes.COLUMN_CURRENT_BYTES,
             OpenableColumns.DISPLAY_NAME,
             OpenableColumns.SIZE,
     };
@@ -550,7 +550,7 @@ public final class DownloadProvider extends ContentProvider {
             case BATCHES_ID:
                 SqlSelection batchSelection = getWhereClause(uri, selection, selectionArgs, match);
                 return db.query(
-                        DownloadContract.Batches.BATCHES_TABLE_NAME, projection, batchSelection.getSelection(),
+                        DownloadContract.BatchesWithSizes.VIEW_NAME_BATCHES_WITH_SIZES, projection, batchSelection.getSelection(),
                         batchSelection.getParameters(), null, null, sort);
             case DOWNLOADS_BY_BATCH:
                 return db.query(DownloadContract.DownloadsByBatch.VIEW_NAME_DOWNLOADS_BY_BATCH, projection, selection, selectionArgs, null, null, sort);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -389,10 +389,7 @@ public class DownloadService extends Service {
                 long totalBytes = contentLengthFetcher.fetchContentLengthFor(downloadInfo);
                 values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, totalBytes);
                 getContentResolver().update(downloadInfo.getAllDownloadsUri(), values, null, null);
-
-                batchRepository.updateTotalSize(downloadInfo.getBatchId());
             }
-            batchRepository.updateCurrentSize(downloadInfo.getBatchId());
         }
     }
 


### PR DESCRIPTION
Removes the updating of the total size and current size for batches, instead using a view to calculate the size on demand. 

The public API is still the same, the demo apps work as before.

Running time of `updateLocked()` before and after:
```
BEFORE

173ms
168ms
206ms
247ms
145ms
178ms
169ms
321ms
188ms
150ms
182ms
266ms
173ms
152ms
212ms

AFTER

78ms
112ms
143ms
78ms
82ms
74ms
76ms
82ms
88ms
88ms
79ms
105ms
80ms
```