### PR TITLE
Allow any resume

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -89,7 +89,8 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                 .setDescription("Fine facial hair")
                 .setBigPictureUrl(BEARD_IMAGE)
                 .setDestinationInInternalFilesDir(Environment.DIRECTORY_MOVIES, "pause_resume_example.beard")
-                .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
+                .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE)
+                .alwaysAttemptResume();
 
         long requestId = downloadManager.enqueue(request);
         Log.d("Download enqueued with request ID: " + requestId);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -149,6 +149,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                             DownloadContract.Downloads.COLUMN_ALLOW_METERED + " INTEGER NOT NULL DEFAULT 1, " +
                             DownloadContract.Downloads.COLUMN_BATCH_ID + " INTEGER, " +
                             DownloadContract.Downloads.COLUMN_EXTRA_DATA + " TEXT, " +
+                            DownloadContract.Downloads.COLUMN_ALWAYS_RESUME + " INTEGER NOT NULL DEFAULT 0, " +
                             Constants.MEDIA_SCANNED + " BOOLEAN);");
         } catch (SQLException ex) {
             Log.e("couldn't create table in downloads database");

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -249,6 +249,12 @@ final class DownloadContract {
          */
         public static final String COLUMN_EXTRA_DATA = "extra_data";
 
+        /**
+         * The column used to flag whether a download should always attempt a resume
+         * if it is paused, regardless of what the server says
+         */
+        public static final String COLUMN_ALWAYS_RESUME = "alwaysResume";
+
         private Downloads() {
             // non-instantiable class
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -253,7 +253,7 @@ final class DownloadContract {
          * The column used to flag whether a download should always attempt a resume
          * if it is paused, regardless of what the server says
          */
-        public static final String COLUMN_ALWAYS_RESUME = "alwaysResume";
+        public static final String COLUMN_ALWAYS_RESUME = "always_resume";
 
         private Downloads() {
             // non-instantiable class

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -169,6 +169,7 @@ public final class DownloadProvider extends ContentProvider {
             DownloadContract.Downloads.COLUMN_DELETED,
             DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS,
             DownloadContract.Downloads.COLUMN_BATCH_ID,
+            DownloadContract.Downloads.COLUMN_ALWAYS_RESUME,
             DownloadContract.Batches._ID,
             DownloadContract.Batches.COLUMN_STATUS,
             DownloadContract.Batches.COLUMN_TITLE,
@@ -484,6 +485,7 @@ public final class DownloadProvider extends ContentProvider {
         copyInteger(DownloadContract.Downloads.COLUMN_ALLOWED_NETWORK_TYPES, values, filteredValues);
         copyBoolean(DownloadContract.Downloads.COLUMN_ALLOW_ROAMING, values, filteredValues);
         copyBoolean(DownloadContract.Downloads.COLUMN_ALLOW_METERED, values, filteredValues);
+        copyBoolean(DownloadContract.Downloads.COLUMN_ALWAYS_RESUME, values, filteredValues);
 
         copyInteger(DownloadContract.Downloads.COLUMN_BATCH_ID, values, filteredValues);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -674,7 +674,7 @@ class DownloadThread implements Runnable {
     }
 
     private boolean cannotResume(State state) {
-        return (state.currentBytes > 0 && !originalDownloadInfo.isNoIntegrity() && state.headerETag == null) || DownloadDrmHelper.isDrmConvertNeeded(state.mimeType);
+        return (state.currentBytes > 0 && !originalDownloadInfo.isResumable() || DownloadDrmHelper.isDrmConvertNeeded(state.mimeType));
     }
 
     /**
@@ -816,7 +816,7 @@ class DownloadThread implements Runnable {
                 destinationFile.delete();
                 state.filename = null;
                 Log.i("resuming download for id: " + originalDownloadInfo.getId() + ", BUT starting from scratch again: ");
-            } else if (originalDownloadInfo.getETag() == null && !originalDownloadInfo.isNoIntegrity()) {
+            } else if (!originalDownloadInfo.isResumable()) {
                 // This should've been caught upon failure
                 Log.d("setupDestinationFile() unable to resume download, deleting " + state.filename);
                 destinationFile.delete();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -33,7 +33,6 @@ class FileDownloadInfo {
         OK,
 
         /**
-         *
          * There is no network connectivity.
          */
         NO_CONNECTION,
@@ -97,6 +96,7 @@ class FileDownloadInfo {
     private boolean allowMetered;
     private int bypassRecommendedSizeLimit;
     private long batchId;
+    private boolean alwaysResume;
 
     private final List<Pair<String, String>> requestHeaders = new ArrayList<>();
     private final SystemFacade systemFacade;
@@ -356,6 +356,10 @@ class FileDownloadInfo {
         requestHeaders.clear();
     }
 
+    public boolean isResumable() {
+        return alwaysResume || (eTag != null && isNoIntegrity());
+    }
+
     public static class Reader {
         private final ContentResolver resolver;
         private final Cursor cursor;
@@ -405,6 +409,7 @@ class FileDownloadInfo {
             info.allowMetered = getInt(DownloadContract.Downloads.COLUMN_ALLOW_METERED) != 0;
             info.bypassRecommendedSizeLimit = getInt(DownloadContract.Downloads.COLUMN_BYPASS_RECOMMENDED_SIZE_LIMIT);
             info.batchId = getLong(DownloadContract.Downloads.COLUMN_BATCH_ID);
+            info.alwaysResume = getInt(DownloadContract.Downloads.COLUMN_ALWAYS_RESUME) != 0;
 
             synchronized (this) {
                 info.control = getInt(DownloadContract.Downloads.COLUMN_CONTROL);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -53,6 +53,7 @@ public class Request {
     private String bigPictureUrl;
     private long batchId = -1L;
     private String extraData;
+    private boolean alwaysResume = false;
 
     /**
      * if a file is designated as a MediaScanner scannable file, the following value is
@@ -220,6 +221,16 @@ public class Request {
      */
     public void allowScanningByMediaScanner() {
         scannable = true;
+    }
+
+    /**
+     * Always attempt to resume the download, regardless of whether the server returns
+     * a Etag header or not. **CAUTION** if the file has changed then this flag will
+     * result in undefined behaviour.
+     */
+    public Request alwaysAttemptResume() {
+        alwaysResume = true;
+        return this;
     }
 
     /**
@@ -444,6 +455,7 @@ public class Request {
         values.put(DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS, notificationExtras);
         values.put(DownloadContract.Downloads.COLUMN_BATCH_ID, batchId);
         values.put(DownloadContract.Downloads.COLUMN_EXTRA_DATA, extraData);
+        values.put(DownloadContract.Downloads.COLUMN_ALWAYS_RESUME, alwaysResume);
 
         return values;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -53,7 +53,7 @@ public class Request {
     private String bigPictureUrl;
     private long batchId = -1L;
     private String extraData;
-    private boolean alwaysResume = false;
+    private boolean alwaysResume;
 
     /**
      * if a file is designated as a MediaScanner scannable file, the following value is


### PR DESCRIPTION
Adds a flag which allows a download to be resumed regardless of whether the server has returned an [Etag header](https://devcenter.heroku.com/articles/increasing-application-performance-with-http-cache-headers#content-based) or not