### PR TITLE
Notify batch modified after all downloads

### DIFF
--- a/code-quality/rules/pmd/ruleset.xml
+++ b/code-quality/rules/pmd/ruleset.xml
@@ -22,7 +22,10 @@
     <exclude name="AvoidThrowingNullPointerException" />
     <exclude name="AvoidCatchingGenericException" />
   </rule>
-  <rule ref="rulesets/java/strings.xml" />
+  <rule ref="rulesets/java/strings.xml">
+    <exclude name="AvoidDuplicateLiterals" />
+  </rule>
+
   <rule ref="rulesets/java/typeresolution.xml" />
   <rule ref="rulesets/java/unnecessary.xml">
     <exclude name="UselessParentheses" />

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -847,6 +847,9 @@ public class DownloadManager {
             request.setBatchId(batchId);
             insert(request);
         }
+        contentResolver.notifyChange(getBatchesUri(), null);
+        contentResolver.notifyChange(getBatchesWithoutProgressUri(), null);
+
         return batchId;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -847,10 +847,14 @@ public class DownloadManager {
             request.setBatchId(batchId);
             insert(request);
         }
-        contentResolver.notifyChange(getBatchesUri(), null);
-        contentResolver.notifyChange(getBatchesWithoutProgressUri(), null);
+        notifyAllBatchHasBeenEnqueued();
 
         return batchId;
+    }
+
+    private void notifyAllBatchHasBeenEnqueued() {
+        contentResolver.notifyChange(getBatchesUri(), null);
+        contentResolver.notifyChange(getBatchesWithoutProgressUri(), null);
     }
 
     private long insert(RequestBatch batch) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -359,6 +359,7 @@ public class DownloadManager {
             DownloadContract.Downloads.COLUMN_CURRENT_BYTES + " AS " + COLUMN_BYTES_DOWNLOADED_SO_FAR,
             DownloadContract.Downloads.COLUMN_BATCH_ID,
             DownloadContract.Downloads.COLUMN_EXTRA_DATA,
+            DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS,
             DownloadContract.Batches.COLUMN_TITLE,
             DownloadContract.Batches.COLUMN_DESCRIPTION,
             DownloadContract.Batches.COLUMN_BIG_PICTURE,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -227,7 +227,7 @@ public class Query {
         for (String filterExtra : filterNotificiationExtras) {
             parts.add(notificationExtrasClause(filterExtra));
         }
-        selectionParts.add(joinStrings(" OR ", parts));
+        selectionParts.add("(" + joinStrings(" OR ", parts) + ")");
     }
 
     private void filterByExtraData(List<String> selectionParts) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Query.java
@@ -220,7 +220,7 @@ public class Query {
     }
 
     private void filterByNotificationExtras(List<String> selectionParts) {
-        if (filterNotificiationExtras == null) {
+        if (filterNotificiationExtras == null || filterNotificiationExtras.length == 0) {
             return;
         }
         List<String> parts = new ArrayList<>();

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -129,6 +129,25 @@ public class QueryTest {
         assertSelectionDoesNotContain(COLUMN_EXTRA_DATA + " IN ");
     }
 
+    @Test
+    public void givenMultipleNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementIsCorrect() {
+        query.setFilterByNotificationExtras("13", "14").runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertSelectionContains("(" + COLUMN_NOTIFICATION_EXTRAS + " = '13' OR " + COLUMN_NOTIFICATION_EXTRAS + " = '14')");
+    }
+
+    @Test
+    public void givenEmptyNotificationExtrasWhenTheQueryIsCreatedThenTheWhereStatementDoesNotContainExtrasPredicate() {
+        String[] empty = {};
+        query.setFilterByNotificationExtras(empty).runQuery(resolver, null, uri);
+
+        verify(resolver).query(any(Uri.class), any(String[].class), stringArgumentCaptor.capture(), any(String[].class), anyString());
+
+        assertSelectionDoesNotContain(COLUMN_NOTIFICATION_EXTRAS);
+    }
+
     private void assertSelectionContains(String sequence) {
         assertThat(stringArgumentCaptor.getValue()).contains(sequence);
     }


### PR DESCRIPTION
- We have found out that `DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS` was not part of the columns bundled up in the Cursor for a download query, so I have added it. 

- Also, in case of filtering by multiple notification extras, we should not attempt if the passed in array is empty as well as the `OR`s done between the statements should be inclosed in brackets. 

- After we enqueue a `RequestBatch` along with its `Requests` we have to notify that the batch has changed. This should be done because conceptually the batch is available only when its downloads are in the database as well, but because we cannot insert the batch at the end (i.e. after we insert the `Requests`) due to the fact that we need the `batch_id` for the requests, we have to manually notify after the whole process has ended. This enables us when watching the batch table, the later not to be out of sync with the downloads table. 
Consider the scenario when you want to query the downloads table when something changes on the whole batch, in this particular situation because the `insert(Batch)` is done first [here](https://github.com/novoda/download-manager/blob/master/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java#L844) we will get a notification that the batch table has changed, but the downloads have not been yet inserted so we get a inconsistent response for our query. 

- Reduced the number of PMDs by suppressing `AvoidDuplicateLiterals` because it doesn't give us any benefit. 