### PR TITLE
Simplify query status control

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -169,6 +169,11 @@ public class DownloadService extends Service {
             public FileDownloadInfo create(FileDownloadInfo.Reader reader) {
                 return createNewDownloadInfo(reader);
             }
+
+            @Override
+            public FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id) {
+                return createNewDownloadInfoControlStatus(reader, id);
+            }
         }, downloadsUriProvider);
 
     }
@@ -181,6 +186,10 @@ public class DownloadService extends Service {
         FileDownloadInfo info = reader.newDownloadInfo(systemFacade, downloadsUriProvider);
         Log.v("processing inserted download " + info.getId());
         return info;
+    }
+
+    private FileDownloadInfo.ControlStatus createNewDownloadInfoControlStatus(FileDownloadInfo.ControlStatus.Reader reader, long id) {
+        return reader.newControlStatus(id);
     }
 
     private DownloadClientReadyChecker getDownloadClientReadyChecker() {
@@ -314,6 +323,8 @@ public class DownloadService extends Service {
      * snapshot taken in this update.
      */
     private boolean updateLocked() {
+
+        Log.d("Ferran, updateLocked");
 
         boolean isActive = false;
         long nextRetryTimeMillis = Long.MAX_VALUE;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -324,8 +324,6 @@ public class DownloadService extends Service {
      */
     private boolean updateLocked() {
 
-        Log.d("Ferran, updateLocked");
-
         boolean isActive = false;
         long nextRetryTimeMillis = Long.MAX_VALUE;
         long now = systemFacade.currentTimeMillis();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -571,12 +571,12 @@ class DownloadThread implements Runnable {
      * has been.
      */
     private void checkPausedOrCanceled() throws StopRequestException {
-        FileDownloadInfo currentDownloadInfo = downloadsRepository.getDownloadFor(originalDownloadInfo.getId());
+        FileDownloadInfo.ControlStatus controlStatus = downloadsRepository.getDownloadInfoControlStatusFor(originalDownloadInfo.getId());
 
-        if (currentDownloadInfo.getControl() == DownloadsControl.CONTROL_PAUSED) {
+        if (controlStatus.isPaused()) {
             throw new StopRequestException(DownloadStatus.PAUSED_BY_APP, "download paused by owner");
         }
-        if (currentDownloadInfo.getStatus() == DownloadStatus.CANCELED) {
+        if (controlStatus.isCanceled()) {
             throw new StopRequestException(DownloadStatus.CANCELED, "download canceled");
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -48,8 +48,15 @@ class DownloadsRepository {
         }
     }
 
+    public FileDownloadInfo.ControlStatus getDownloadInfoControlStatusFor(long id) {
+        FileDownloadInfo.ControlStatus.Reader reader = new FileDownloadInfo.ControlStatus.Reader(contentResolver, downloadsUriProvider);
+        return downloadInfoCreator.create(reader, id);
+    }
+
     interface DownloadInfoCreator {
         FileDownloadInfo create(FileDownloadInfo.Reader reader);
+
+        FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -449,4 +449,48 @@ class FileDownloadInfo {
             return cursor.getLong(cursor.getColumnIndexOrThrow(column));
         }
     }
+
+    static final class ControlStatus {
+
+        private int control;
+        private int status;
+
+        public ControlStatus(int control, int status) {
+            this.control = control;
+            this.status = status;
+        }
+
+        public boolean isPaused() {
+            return control == DownloadsControl.CONTROL_PAUSED;
+        }
+
+        public boolean isCanceled() {
+            return status == DownloadStatus.CANCELED;
+        }
+
+        static final class Reader {
+
+            private final ContentResolver contentResolver;
+            private final DownloadsUriProvider downloadsUriProvider;
+
+            public Reader(ContentResolver contentResolver, DownloadsUriProvider downloadsUriProvider) {
+                this.contentResolver = contentResolver;
+                this.downloadsUriProvider = downloadsUriProvider;
+            }
+
+            public ControlStatus newControlStatus(long id) {
+                String[] projection = {DownloadContract.Downloads.COLUMN_CONTROL, DownloadContract.Downloads.COLUMN_STATUS};
+                Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id);
+                Cursor downloadsCursor = contentResolver.query(uri, projection, null, null, null);
+                try {
+                    downloadsCursor.moveToFirst();
+                    int control = downloadsCursor.getInt(0);
+                    int status = downloadsCursor.getInt(1);
+                    return new FileDownloadInfo.ControlStatus(control, status);
+                } finally {
+                    downloadsCursor.close();
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Investigation done ##

I've noticed an excessive number of invocations to the creation of the `FileDownloadInfo` object.

This is the analysis:
- Creation of the `FileDownloadInfo` object have a class level `synchronise`, along with an extra database query for the headers
- `FileDownloadInfo` is fully created but only the values `status` and `control` are used, the rest of the values are completely useless for this trace
- The `status` and `control` are queried at the method `checkPausedOrCreated` and invokated at `DownloadThread.transferData`.

So everytime that there is a transfer data, we call checkPausedOrCreated that creates a full FileDownloadInfo object in order to just check the status and the control.

## Solution implemented ##

I've created a slimmed down version that only creates an object with the `status` and `control` fields, removing all the unnecessary code that is not involved in the `checkPausedOrCreated` task

**Time for downloading 100MB from the Demo application**

Before | Now
--- | ---
6m12s | 5m