### PR TITLE
Fix download goes to queued

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -26,6 +26,7 @@ class BatchRepository {
             DownloadStatus.WAITING_FOR_NETWORK,
             DownloadStatus.QUEUED_FOR_WIFI,
 
+            DownloadStatus.SUBMITTED,
             DownloadStatus.PENDING,
             DownloadStatus.SUCCESS
     );
@@ -56,18 +57,18 @@ class BatchRepository {
         Cursor cursor = null;
         SparseIntArray statusCounts = new SparseIntArray(PRIORITISED_STATUSES_SIZE);
         try {
+            String[] projection = {DownloadContract.Downloads.COLUMN_STATUS};
             String[] selectionArgs = {String.valueOf(batchId)};
+
             cursor = resolver.query(
                     downloadsUriProvider.getAllDownloadsUri(),
-                    null,
+                    projection,
                     DownloadContract.Downloads.COLUMN_BATCH_ID + " = ?",
                     selectionArgs,
                     null);
 
-            int statusColumnIndex = cursor.getColumnIndexOrThrow(DownloadContract.Downloads.COLUMN_STATUS);
-
             while (cursor.moveToNext()) {
-                int statusCode = cursor.getInt(statusColumnIndex);
+                int statusCode = cursor.getInt(0);
 
                 if (DownloadStatus.isError(statusCode)) {
                     return statusCode;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadBatch.java
@@ -113,12 +113,7 @@ class DownloadBatch {
     }
 
     public boolean isActive() {
-        for (FileDownloadInfo info : downloads) {
-            if (info.isSubmittedOrRunning()) {
-                return true;
-            }
-        }
-        return false;
+        return status == DownloadStatus.SUBMITTED || status == DownloadStatus.RUNNING;
     }
 
     public boolean scanCompletedMediaIfReady(DownloadScanner downloadScanner) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -997,6 +997,7 @@ public class DownloadManager {
 
         private int translateStatus(int status) {
             switch (status) {
+                case DownloadStatus.SUBMITTED:
                 case DownloadStatus.PENDING:
                     return STATUS_PENDING;
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -443,7 +443,12 @@ public class DownloadManager {
         ContentValues values = new ContentValues();
         values.put(DownloadContract.Downloads.COLUMN_CONTROL, DownloadsControl.CONTROL_RUN);
         values.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.PENDING);
-        contentResolver.update(downloadsUriProvider.getAllDownloadsUri(), values, COLUMN_BATCH_ID + "=?", new String[]{String.valueOf(id)});
+        String where = COLUMN_BATCH_ID + "= ? AND " + DownloadContract.Downloads.COLUMN_STATUS + " != ?";
+        String[] selectionArgs = {String.valueOf(id), String.valueOf(DownloadStatus.PENDING)};
+        contentResolver.update(downloadsUriProvider.getAllDownloadsUri(), values, where, selectionArgs);
+
+        BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
+        batchRepository.updateBatchStatus(id, DownloadStatus.PENDING);
     }
 
     public void removeDownload(URI uri) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -453,7 +453,9 @@ public class DownloadManager {
         String[] selectionArgs = {String.valueOf(id), String.valueOf(DownloadStatus.PENDING)};
         contentResolver.update(downloadsUriProvider.getAllDownloadsUri(), values, where, selectionArgs);
 
-        BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
+        DownloadDeleter downloadDeleter = new DownloadDeleter(contentResolver);
+        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext());
+        BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
         batchRepository.updateBatchStatus(id, DownloadStatus.PENDING);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -37,6 +37,7 @@ class DownloadReadyChecker {
         }
         switch (downloadInfo.getStatus()) {
             case 0: // status hasn't been initialized yet, this is a new download
+            case DownloadStatus.SUCCESS:
             case DownloadStatus.PENDING: // download is explicit marked as ready to start
             case DownloadStatus.RUNNING: // download interrupted (process killed etc) while
                 // running, without a chance to update the database

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -18,6 +18,10 @@ class DownloadReadyChecker {
     }
 
     public boolean canDownload(DownloadBatch downloadBatch) {
+        if (downloadBatch.getStatus() == DownloadStatus.PENDING) {
+            return true;
+        }
+
         for (FileDownloadInfo fileDownloadInfo : downloadBatch.getDownloads()) {
             if (!isDownloadManagerReadyToDownload(fileDownloadInfo)) {
                 return false;
@@ -37,7 +41,6 @@ class DownloadReadyChecker {
         }
         switch (downloadInfo.getStatus()) {
             case 0: // status hasn't been initialized yet, this is a new download
-            case DownloadStatus.SUCCESS:
             case DownloadStatus.PENDING: // download is explicit marked as ready to start
             case DownloadStatus.RUNNING: // download interrupted (process killed etc) while
                 // running, without a chance to update the database

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -338,10 +338,8 @@ public class DownloadService extends Service {
             if (!isActive && downloadReadyChecker.canDownload(downloadBatch)) {
                 downloadOrContinueBatch(downloadBatch.getDownloads());
                 isActive = true;
-            } else {
-                if (downloadBatch.scanCompletedMediaIfReady(downloadScanner)) {
-                    isActive = true;
-                }
+            } else if (downloadBatch.scanCompletedMediaIfReady(downloadScanner)) {
+                isActive = true;
             }
 
             nextRetryTimeMillis = downloadBatch.nextActionMillis(now, nextRetryTimeMillis);
@@ -383,7 +381,7 @@ public class DownloadService extends Service {
     }
 
     private void updateTotalBytesFor(Collection<FileDownloadInfo> downloadInfos) {
-        ContentValues values = new ContentValues();
+        ContentValues values = new ContentValues(1);
         for (FileDownloadInfo downloadInfo : downloadInfos) {
             if (downloadInfo.hasUnknownTotalBytes()) {
                 long totalBytes = contentLengthFetcher.fetchContentLengthFor(downloadInfo);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -21,7 +21,13 @@ class DownloadsRepository {
     }
 
     public List<FileDownloadInfo> getAllDownloads() {
-        Cursor downloadsCursor = contentResolver.query(downloadsUriProvider.getAllDownloadsUri(), null, null, null, null);
+        Cursor downloadsCursor = contentResolver.query(
+                downloadsUriProvider.getAllDownloadsUri(),
+                null,
+                null,
+                null,
+                DownloadContract.Batches._ID + " ASC");
+
         try {
             List<FileDownloadInfo> downloads = new ArrayList<>();
             FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);


### PR DESCRIPTION
## Problem description ##

We have seen how a batch moves to the `queued` status for no reason in the middle of a download

## Solution implemented ##

[PENDING TO BE UPDATED AFTER LASTS MODIFICATIONS]

After investigating the code, this is what is happening:
- The `downloadService` has the handler that executes the downloads and processes statuses. Inside the handler there is a method called `updateLocked` that returns a boolean and is assigned to a `isActive` local variable
- When `isActive` is false, the `downloadService` shuts down
- `updateLocked` checks if a client is ready for a download or if the downloadmanager itself is ready for a download.
- The check for `isDownloadManagerReadyToDownload` returns false and shuts down the `downloadService` when the status of the `FileDownloadInfo` is `SUCCESS`

The solution has been to add the status `SUCCESS` as a valid status and so the `downloadService` can proceed with a proper clean up

I provide several screenshots in order to show that the downloads are processed properly as expected

1 Download | Multiple downloads
--- | ---
![after](https://cloud.githubusercontent.com/assets/2845931/8729475/6b16680c-2be3-11e5-946b-e8698ebd2a1a.gif) | ![after](https://cloud.githubusercontent.com/assets/2845931/8729506/9163f876-2be3-11e5-9147-2c836c4a7fb1.gif)