### PR TITLE
Batch with timestamp

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
@@ -40,4 +40,5 @@ class BatchInfo {
     public String getExtraData() {
         return extraData;
     }
+
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchInfo.java
@@ -8,7 +8,11 @@ class BatchInfo {
     private final int visibility;
     private final String extraData;
 
-    public BatchInfo(String title, String description, String bigPictureUrl, @NotificationVisibility.Value int visibility, String extraData) {
+    public BatchInfo(String title,
+                     String description,
+                     String bigPictureUrl,
+                     @NotificationVisibility.Value int visibility,
+                     String extraData) {
         this.title = title;
         this.description = description;
         this.bigPictureUrl = bigPictureUrl;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -39,16 +39,19 @@ class BatchRepository {
     private final ContentResolver resolver;
     private final DownloadDeleter downloadDeleter;
     private final DownloadsUriProvider downloadsUriProvider;
+    private final SystemFacade systemFacade;
 
-    BatchRepository(ContentResolver resolver, DownloadDeleter downloadDeleter, DownloadsUriProvider downloadsUriProvider) {
+    BatchRepository(ContentResolver resolver, DownloadDeleter downloadDeleter, DownloadsUriProvider downloadsUriProvider, SystemFacade systemFacade) {
         this.resolver = resolver;
         this.downloadDeleter = downloadDeleter;
         this.downloadsUriProvider = downloadsUriProvider;
+        this.systemFacade = systemFacade;
     }
 
     void updateBatchStatus(long batchId, int status) {
         ContentValues values = new ContentValues();
         values.put(DownloadContract.Batches.COLUMN_STATUS, status);
+        values.put(DownloadContract.Batches.COLUMN_LAST_MODIFICATION, systemFacade.currentTimeMillis());
         resolver.update(downloadsUriProvider.getBatchesUri(), values, DownloadContract.Batches._ID + " = ?", new String[]{String.valueOf(batchId)});
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -36,7 +36,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             DownloadContract.Downloads.COLUMN_FILE_NAME_HINT,
             DownloadContract.Downloads.COLUMN_MIME_TYPE,
             DownloadContract.Downloads.COLUMN_TOTAL_BYTES,
-            DownloadContract.Downloads.COLUMN_LAST_MODIFICATION,
+            DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads.COLUMN_LAST_MODIFICATION,
             DownloadContract.Downloads.COLUMN_CURRENT_BYTES,
             DownloadContract.Downloads.COLUMN_NOTIFICATION_EXTRAS,
             DownloadContract.Downloads.DOWNLOADS_TABLE_NAME + "." + DownloadContract.Downloads.COLUMN_EXTRA_DATA,
@@ -74,7 +74,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
             DownloadContract.Batches.COLUMN_DESCRIPTION,
             DownloadContract.Batches.COLUMN_BIG_PICTURE,
             DownloadContract.Batches.COLUMN_STATUS,
-            DownloadContract.Batches.COLUMN_EXTRA_DATA
+            DownloadContract.Batches.COLUMN_EXTRA_DATA,
+            DownloadContract.Batches.COLUMN_LAST_MODIFICATION
     };
 
     public DatabaseHelper(Context context, String dbName) {
@@ -193,7 +194,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         + DownloadContract.Batches.COLUMN_STATUS + " INTEGER,"
                         + DownloadContract.Batches.COLUMN_VISIBILITY + " INTEGER,"
                         + DownloadContract.Batches.COLUMN_DELETED + " BOOLEAN NOT NULL DEFAULT 0,"
-                        + DownloadContract.Batches.COLUMN_EXTRA_DATA + " TEXT"
+                        + DownloadContract.Batches.COLUMN_EXTRA_DATA + " TEXT,"
+                        + DownloadContract.Batches.COLUMN_LAST_MODIFICATION + " TEXT"
                         + ");"
         );
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -79,7 +79,7 @@ final class DownloadContract {
          * <P>Type: BIGINT</P>
          * <P>Owner can Read</P>
          */
-        public static final String COLUMN_LAST_MODIFICATION = "lastmod";
+        public static final String COLUMN_LAST_MODIFICATION = "last_modified_timestamp";
         /**
          * The name of the column containing the component name of the class that
          * will receive notifications associated with the download. The
@@ -322,7 +322,7 @@ final class DownloadContract {
          * <P>Type: BIGINT</P>
          * <P>Owner can Read</P>
          */
-        public static final String COLUMN_LAST_MODIFICATION = "lastmod";
+        public static final String COLUMN_LAST_MODIFICATION = "last_modified_timestamp";
 
         private Batches() {
             // non-instantiable class

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -315,6 +315,14 @@ final class DownloadContract {
          * <P>Type: TEXT</P>
          */
         public static final String COLUMN_EXTRA_DATA = "extra_data";
+        /**
+         * The name of the column containing the date at which some interesting
+         * status changed in the batch. Stored as a System.currentTimeMillis()
+         * value.
+         * <P>Type: BIGINT</P>
+         * <P>Owner can Read</P>
+         */
+        public static final String COLUMN_LAST_MODIFICATION = "lastmod";
 
         private Batches() {
             // non-instantiable class

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -174,7 +174,7 @@ public class DownloadManager {
      * Timestamp when the download was last modified, in {@link System#currentTimeMillis
      * System.currentTimeMillis()} (wall clock time in UTC).
      */
-    public static final String COLUMN_LAST_MODIFIED_TIMESTAMP = "last_modified_timestamp";
+    public static final String COLUMN_LAST_MODIFIED_TIMESTAMP = DownloadContract.Downloads.COLUMN_LAST_MODIFICATION;
 
     /**
      * The URI to the corresponding entry in MediaProvider for this downloaded entry. It is
@@ -355,7 +355,7 @@ public class DownloadManager {
             DownloadContract.Downloads.COLUMN_FILE_NAME_HINT,
             DownloadContract.Downloads.COLUMN_MIME_TYPE + " AS " + COLUMN_MEDIA_TYPE,
             DownloadContract.Downloads.COLUMN_TOTAL_BYTES + " AS " + COLUMN_TOTAL_SIZE_BYTES,
-            DownloadContract.Downloads.COLUMN_LAST_MODIFICATION + " AS " + COLUMN_LAST_MODIFIED_TIMESTAMP,
+            DownloadContract.Downloads.COLUMN_LAST_MODIFICATION,
             DownloadContract.Downloads.COLUMN_CURRENT_BYTES + " AS " + COLUMN_BYTES_DOWNLOADED_SO_FAR,
             DownloadContract.Downloads.COLUMN_BATCH_ID,
             DownloadContract.Downloads.COLUMN_EXTRA_DATA,

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -556,7 +556,9 @@ public class DownloadManager {
      * @return a Cursor over the result set of batches
      */
     public Cursor query(BatchQuery query) {
-        BatchRepository batchRepository = new BatchRepository(contentResolver, new DownloadDeleter(contentResolver), downloadsUriProvider);
+        DownloadDeleter downloadDeleter = new DownloadDeleter(contentResolver);
+        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext());
+        BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
         Cursor cursor = batchRepository.retrieveFor(query);
         if (cursor == null) {
             return null;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -377,6 +377,7 @@ public class DownloadManager {
 
     private final ContentResolver contentResolver;
     private final DownloadsUriProvider downloadsUriProvider;
+    private final SystemFacade systemFacade;
 
     private Uri baseUri;
 
@@ -394,10 +395,12 @@ public class DownloadManager {
 
     DownloadManager(Context context,
                     ContentResolver contentResolver,
-                    DownloadsUriProvider downloadsUriProvider, boolean verboseLogging) {
+                    DownloadsUriProvider downloadsUriProvider,
+                    boolean verboseLogging) {
         this.contentResolver = contentResolver;
         this.downloadsUriProvider = downloadsUriProvider;
         this.baseUri = downloadsUriProvider.getContentUri();
+        this.systemFacade = new RealSystemFacade(context);
         GlobalState.setContext(context);
         GlobalState.setVerboseLogging(verboseLogging);
     }
@@ -864,6 +867,7 @@ public class DownloadManager {
     private long insert(RequestBatch batch) {
         ContentValues values = batch.toContentValues();
         values.put(DownloadContract.Batches.COLUMN_STATUS, DownloadStatus.PENDING);
+        values.put(DownloadContract.Batches.COLUMN_LAST_MODIFICATION, systemFacade.currentTimeMillis());
         Uri batchUri = contentResolver.insert(downloadsUriProvider.getBatchesUri(), values);
         return ContentUris.parseId(batchUri);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -366,6 +366,7 @@ public class DownloadManager {
             DownloadContract.Batches.COLUMN_VISIBILITY,
             DownloadContract.Batches.COLUMN_STATUS,
             DownloadContract.Batches.COLUMN_EXTRA_DATA,
+            DownloadContract.Batches.COLUMN_LAST_MODIFICATION,
         /* add the following 'computed' columns to the cursor.
          * they are not 'returned' by the database, but their inclusion
          * eliminates need to have lot of methods in CursorTranslator

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -382,25 +382,26 @@ public class DownloadManager {
     private Uri baseUri;
 
     public DownloadManager(Context context, ContentResolver resolver) {
-        this(context, resolver, DownloadsUriProvider.getInstance(), false);
+        this(context, resolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context), false);
     }
 
     public DownloadManager(Context context, ContentResolver contentResolver, boolean verboseLogging) {
-        this(context, contentResolver, DownloadsUriProvider.getInstance(), verboseLogging);
+        this(context, contentResolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context), verboseLogging);
     }
 
     DownloadManager(Context context, ContentResolver resolver, DownloadsUriProvider downloadsUriProvider) {
-        this(context, resolver, downloadsUriProvider, false);
+        this(context, resolver, downloadsUriProvider, new RealSystemFacade(context), false);
     }
 
     DownloadManager(Context context,
                     ContentResolver contentResolver,
                     DownloadsUriProvider downloadsUriProvider,
+                    SystemFacade systemFacade,
                     boolean verboseLogging) {
         this.contentResolver = contentResolver;
         this.downloadsUriProvider = downloadsUriProvider;
         this.baseUri = downloadsUriProvider.getContentUri();
-        this.systemFacade = new RealSystemFacade(context);
+        this.systemFacade = systemFacade;
         GlobalState.setContext(context);
         GlobalState.setVerboseLogging(verboseLogging);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -119,11 +119,11 @@ public class DownloadService extends Service {
 
         this.downloadsUriProvider = DownloadsUriProvider.getInstance();
         this.downloadDeleter = new DownloadDeleter(getContentResolver());
-        this.batchRepository = new BatchRepository(getContentResolver(), downloadDeleter, downloadsUriProvider);
+        this.batchRepository = new BatchRepository(getContentResolver(), downloadDeleter, downloadsUriProvider, systemFacade);
         PublicFacingDownloadMarshaller downloadMarshaller = new PublicFacingDownloadMarshaller();
         DownloadClientReadyChecker downloadClientReadyChecker = getDownloadClientReadyChecker();
-        this.networkChecker = new NetworkChecker(systemFacade);
-        this.downloadReadyChecker = new DownloadReadyChecker(systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
+        this.networkChecker = new NetworkChecker(this.systemFacade);
+        this.downloadReadyChecker = new DownloadReadyChecker(this.systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
 
         String applicationPackageName = getApplicationContext().getPackageName();
         this.batchCompletionBroadcaster = new BatchCompletionBroadcaster(this, applicationPackageName);
@@ -164,7 +164,8 @@ public class DownloadService extends Service {
         DownloadExecutorFactory factory = new DownloadExecutorFactory(concurrentDownloadsLimitProvider);
         executor = factory.createExecutor();
 
-        this.downloadsRepository = new DownloadsRepository(getContentResolver(), new DownloadsRepository.DownloadInfoCreator() {
+        this.downloadsRepository = new DownloadsRepository(
+                getContentResolver(), new DownloadsRepository.DownloadInfoCreator() {
             @Override
             public FileDownloadInfo create(FileDownloadInfo.Reader reader) {
                 return createNewDownloadInfo(reader);
@@ -372,7 +373,8 @@ public class DownloadService extends Service {
     }
 
     private void download(FileDownloadInfo info) {
-        DownloadThread downloadThread = new DownloadThread(this, systemFacade, info, storageManager, downloadNotifier,
+        DownloadThread downloadThread = new DownloadThread(
+                this, systemFacade, info, storageManager, downloadNotifier,
                 batchCompletionBroadcaster, batchRepository, downloadsUriProvider, downloadsRepository, networkChecker, downloadReadyChecker);
 
         ContentValues contentValues = new ContentValues();

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchRepositoryTest.java
@@ -48,6 +48,8 @@ public class BatchRepositoryTest {
     private DownloadsUriProvider mockDownloadsUriProvider;
     @Mock
     private Uri mockUri;
+    @Mock
+    private SystemFacade mockSystem;
 
     private BatchRepository batchRepository;
 
@@ -58,7 +60,7 @@ public class BatchRepositoryTest {
         when(mockDownloadsUriProvider.getBatchesUri()).thenReturn(mockUri);
         when(mockDownloadsUriProvider.getAllDownloadsUri()).thenReturn(mockUri);
 
-        this.batchRepository = new BatchRepository(mockContentResolver, mockDownloadDeleter, mockDownloadsUriProvider);
+        this.batchRepository = new BatchRepository(mockContentResolver, mockDownloadDeleter, mockDownloadsUriProvider, mockSystem);
 
         when(mockFileDownloadInfoId1.getBatchId()).thenReturn(1L);
         when(mockFileDownloadInfoId2.getBatchId()).thenReturn(2L);

--- a/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/QueryTest.java
@@ -58,15 +58,15 @@ public class QueryTest {
     public void whenWeSetABatchStatusOrderByOnAQueryThenTheResolverIsQueriedWithTheCorrectSortOrder() {
         query.orderBy(COLUMN_LAST_MODIFIED_TIMESTAMP, Query.ORDER_ASCENDING).runQuery(resolver, null, uri);
 
-        // Actually resolves to Downloads.Impl.COLUMN_LAST_MODIFIED
-        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod ASC"));
+        // Actually resolves to DownloadContract.Downloads.COLUMN_LAST_MODIFIED
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("last_modified_timestamp ASC"));
     }
 
     @Test
     public void whenWeSetNoOrderByOnAQueryThenTheResolverIsQueriedWithTheLastModifiedSortOrder() {
         query.runQuery(resolver, null, uri);
 
-        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("lastmod DESC"));
+        verify(resolver).query(any(Uri.class), any(String[].class), anyString(), any(String[].class), eq("last_modified_timestamp DESC"));
     }
 
     @Test


### PR DESCRIPTION
Adds a new column that keeps the timestamp of the last modification made to a batch, that is when the status of a batch was last modified.

We also renamed the LAST_MODIFIED column from Downloads so that we can use the same name as the one in Batches.
