### PR TITLE
FileDownloadInfo setter removal

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
@@ -32,7 +32,6 @@ class DownloadDeleter {
             ContentValues blankData = new ContentValues();
             blankData.put(DownloadContract.Downloads.COLUMN_DATA, (String) null);
             resolver.update(info.getAllDownloadsUri(), blankData, null, null);
-            info.setFileName(null);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
@@ -8,8 +8,6 @@ import android.text.TextUtils;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.File;
-import java.util.Map;
-import java.util.Set;
 
 class DownloadDeleter {
 
@@ -36,27 +34,6 @@ class DownloadDeleter {
             resolver.update(info.getAllDownloadsUri(), blankData, null, null);
             info.setFileName(null);
         }
-    }
-
-    public void cleanUpStaleDownloadsThatDisappeared(Set<Long> staleIds, Map<Long, FileDownloadInfo> downloads) {
-        for (Long id : staleIds) {
-            deleteDownloadLocked(id, downloads);
-        }
-    }
-
-    /**
-     * Removes the local copy of the info about a download.
-     */
-    private void deleteDownloadLocked(long id, Map<Long, FileDownloadInfo> downloads) {
-        FileDownloadInfo info = downloads.get(id);
-        if (info.getStatus() == DownloadStatus.RUNNING) {
-            info.setStatus(DownloadStatus.CANCELED);
-        }
-        if (info.getDestination() != DownloadsDestination.DESTINATION_EXTERNAL && info.getFileName() != null) {
-            Log.d("deleteDownloadLocked() deleting " + info.getFileName());
-            deleteFileIfExists(info.getFileName());
-        }
-        downloads.remove(info.getId());
     }
 
     private void deleteFileIfExists(String path) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -742,7 +742,7 @@ class DownloadThread implements Runnable {
         if (state.mimeType != null) {
             values.put(DownloadContract.Downloads.COLUMN_MIME_TYPE, state.mimeType);
         }
-        values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, originalDownloadInfo.getTotalBytes());
+        values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, state.totalBytes);
         getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
     }
 
@@ -768,7 +768,6 @@ class DownloadThread implements Runnable {
         }
 
         state.totalBytes = state.contentLength;
-        originalDownloadInfo.setTotalBytes(state.contentLength);
 
         final boolean noSizeInfo = state.contentLength == -1 && (transferEncoding == null || !transferEncoding.equalsIgnoreCase("chunked"));
         if (!originalDownloadInfo.isNoIntegrity() && noSizeInfo) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -129,10 +129,6 @@ class FileDownloadInfo {
         return fileName;
     }
 
-    public void setFileName(String fileName) {
-        this.fileName = fileName;
-    }
-
     public String getMimeType() {
         return mimeType;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -161,10 +161,6 @@ class FileDownloadInfo {
         return totalBytes;
     }
 
-    public void setTotalBytes(long totalBytes) {
-        this.totalBytes = totalBytes;
-    }
-
     public long getCurrentBytes() {
         return currentBytes;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -145,11 +145,6 @@ class FileDownloadInfo {
         return status;
     }
 
-    public void setStatus(int status) {
-        // TODO remove me!
-        this.status = status;
-    }
-
     public int getNumFailed() {
         return numFailed;
     }


### PR DESCRIPTION
Removes all the setters from `FileDownloadInfo`! Next step, all final fields. 

- Removes unused `cleanUpStaleDownloadsThatDisappeared` which was part of the in memory downloads syncing which is no longer needed

- Makes use of the `state.totalSize` instead of setting and refetching the the total download size from the `FileDownloadInfo` 