### PR TITLE
Give the paused state a higher priority

### DIFF
--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 }

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -29,5 +29,5 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -17,11 +17,11 @@ class BatchRepository {
 
     private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
             DownloadStatus.CANCELED,
+            DownloadStatus.PAUSED_BY_APP,
             DownloadStatus.RUNNING,
             DownloadStatus.DELETING,
 
             // Paused statuses
-            DownloadStatus.PAUSED_BY_APP,
             DownloadStatus.WAITING_TO_RETRY,
             DownloadStatus.WAITING_FOR_NETWORK,
             DownloadStatus.QUEUED_FOR_WIFI,


### PR DESCRIPTION
Allows a batch which is half way through being paused to be considered paused, rather than flicking between running and paused as it currently does.

This also updates appcompat because of Lint errors