### PR TITLE
Fix batch status flickering

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
@@ -28,7 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class BatchDownloadsActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
-    private static final String BIG_FILE = "http://download.thinkbroadband.com/100MB.zip";
+    private static final String BIG_FILE = "http://download.thinkbroadband.com/10MB.zip";
     private static final String BEARD_IMAGE = "http://i.imgur.com/9JL2QVl.jpg";
 
     private final Handler handler = new Handler(Looper.getMainLooper());
@@ -93,6 +93,12 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
         batch.addRequest(request);
 
         request.setNotificationExtra("beard_2");
+        batch.addRequest(request);
+        request.setNotificationExtra("beard_3");
+        batch.addRequest(request);
+        request.setNotificationExtra("beard_4");
+        batch.addRequest(request);
+        request.setNotificationExtra("beard_5");
         batch.addRequest(request);
 
         long batchId = downloadManager.enqueue(batch);

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
@@ -10,7 +10,6 @@ import android.widget.RadioGroup;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
-import com.novoda.downloadmanager.demo.extended.QueryTimestamp;
 import com.novoda.downloadmanager.lib.BatchQuery;
 import com.novoda.downloadmanager.lib.DownloadManager;
 
@@ -20,7 +19,6 @@ import java.util.List;
 public class BatchesActivity extends AppCompatActivity implements QueryForBatchesAsyncTask.Callback {
 
     private final Handler handler = new Handler(Looper.getMainLooper());
-    private final QueryTimestamp lastQueryTimestamp = new QueryTimestamp();
 
     private DownloadManager downloadManager;
     private BatchesAdapter adapter;
@@ -92,11 +90,7 @@ public class BatchesActivity extends AppCompatActivity implements QueryForBatche
 
         @Override
         public void onChange(boolean selfChange) {
-            if (lastQueryTimestamp.updatedRecently()) {
-                return;
-            }
             queryForBatches(query);
-            lastQueryTimestamp.setJustUpdated();
         }
 
     };

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -204,11 +204,11 @@ class BatchRepository {
         return resolver.query(downloadsUriProvider.getBatchesUri(), null, query.getSelection(), query.getSelectionArguments(), query.getSortOrder());
     }
 
-    private class StatusCountMap {
+    private static class StatusCountMap {
 
         private final SparseArrayCompat<Integer> statusCounts = new SparseArrayCompat<>(PRIORITISED_STATUSES_SIZE);
 
-        private boolean hasNoItemsWithStatuses(List<Integer> excludedStatuses) {
+        public boolean hasNoItemsWithStatuses(List<Integer> excludedStatuses) {
             boolean hasOtherItems = false;
             for (int status : excludedStatuses) {
                 boolean hasItemsForStatus = hasCountFor(status);
@@ -220,11 +220,11 @@ class BatchRepository {
             return hasOtherItems;
         }
 
-        private boolean hasCountFor(int status) {
+        public boolean hasCountFor(int status) {
             return statusCounts.get(status, 0) > 0;
         }
 
-        private void increment(int statusCode) {
+        public void increment(int statusCode) {
             int currentStatusCount = statusCounts.get(statusCode, 0);
             statusCounts.put(statusCode, currentStatusCount + 1);
         }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
@@ -1,0 +1,293 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.database.CharArrayBuffer;
+import android.database.ContentObserver;
+import android.database.Cursor;
+import android.database.DataSetObserver;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BatchStatusTests {
+
+    @Test
+    public void givenABatchWithSomePendingItemsAndSomeCompleteItemsThenTheBatchStatusIsRunning() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.PENDING);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
+    }
+    @Test
+    public void givenABatchWithAllCompleteItemsThenTheBatchStatusIsSuccess() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUCCESS, DownloadStatus.SUCCESS);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isEqualTo(DownloadStatus.SUCCESS);
+    }
+
+    @Test
+    public void givenABatchWithAllPendingItemsThenTheBatchStatusIsPending() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.PENDING);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isEqualTo(DownloadStatus.PENDING);
+    }
+
+    @Test
+    public void givenABatchWithAMixThenTheStatusIsNotRunning() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.SUBMITTED);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isNotEqualTo(DownloadStatus.PENDING);
+    }
+
+    @NonNull
+    private BatchRepository givenABatchWithStatuses(Integer... statuses) {
+        ContentResolver mockResolver = mock(ContentResolver.class);
+        DownloadsUriProvider mockUriProvider = mock(DownloadsUriProvider.class);
+        MockCursorWithStatuses mockCursorWithStatuses = new MockCursorWithStatuses(statuses);
+        when(mockResolver.query(eq(mockUriProvider.getAllDownloadsUri()), any(String[].class), anyString(), any(String[].class), anyString()))
+                .thenReturn(mockCursorWithStatuses);
+        return new BatchRepository(mockResolver, null, mockUriProvider, null);
+    }
+
+    private static class MockCursorWithStatuses implements Cursor {
+
+        private final List<Integer> statusList;
+        private int position = -1;
+
+        public MockCursorWithStatuses(Integer... statuses) {
+            this.statusList = new ArrayList<>();
+            Collections.addAll(statusList, statuses);
+        }
+
+        @Override
+        public int getCount() {
+            return statusList.size();
+        }
+
+        @Override
+        public int getPosition() {
+            return position;
+        }
+
+        @Override
+        public boolean move(int i) {
+            return position + i >= 0 && position + i < statusList.size();
+        }
+
+        @Override
+        public boolean moveToPosition(int i) {
+            return i >= 0 && i < statusList.size();
+        }
+
+        @Override
+        public boolean moveToFirst() {
+            position = 0;
+            return true;
+        }
+
+        @Override
+        public boolean moveToLast() {
+            position = statusList.size() - 1;
+            return false;
+        }
+
+        @Override
+        public boolean moveToNext() {
+            if (position < statusList.size() - 1) {
+                position++;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean moveToPrevious() {
+            if (position > 1) {
+                position--;
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public boolean isFirst() {
+            return position == 0;
+        }
+
+        @Override
+        public boolean isLast() {
+            return position == statusList.size() - 1;
+        }
+
+        @Override
+        public boolean isBeforeFirst() {
+            return false;
+        }
+
+        @Override
+        public boolean isAfterLast() {
+            return false;
+        }
+
+        @Override
+        public int getColumnIndex(String s) {
+            return 0;
+        }
+
+        @Override
+        public int getColumnIndexOrThrow(String s) throws IllegalArgumentException {
+            return 0;
+        }
+
+        @Override
+        public String getColumnName(int i) {
+            return null;
+        }
+
+        @Override
+        public String[] getColumnNames() {
+            return new String[0];
+        }
+
+        @Override
+        public int getColumnCount() {
+            return 1;
+        }
+
+        @Override
+        public byte[] getBlob(int i) {
+            return new byte[0];
+        }
+
+        @Override
+        public String getString(int i) {
+            return null;
+        }
+
+        @Override
+        public void copyStringToBuffer(int i, CharArrayBuffer charArrayBuffer) {
+
+        }
+
+        @Override
+        public short getShort(int i) {
+            return 0;
+        }
+
+        @Override
+        public int getInt(int i) {
+            return statusList.get(position);
+        }
+
+        @Override
+        public long getLong(int i) {
+            return 0;
+        }
+
+        @Override
+        public float getFloat(int i) {
+            return 0;
+        }
+
+        @Override
+        public double getDouble(int i) {
+            return 0;
+        }
+
+        @Override
+        public int getType(int i) {
+            return 0;
+        }
+
+        @Override
+        public boolean isNull(int i) {
+            return false;
+        }
+
+        @Override
+        public void deactivate() {
+
+        }
+
+        @Override
+        public boolean requery() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void registerContentObserver(ContentObserver contentObserver) {
+
+        }
+
+        @Override
+        public void unregisterContentObserver(ContentObserver contentObserver) {
+
+        }
+
+        @Override
+        public void registerDataSetObserver(DataSetObserver dataSetObserver) {
+
+        }
+
+        @Override
+        public void unregisterDataSetObserver(DataSetObserver dataSetObserver) {
+
+        }
+
+        @Override
+        public void setNotificationUri(ContentResolver contentResolver, Uri uri) {
+
+        }
+
+        @Override
+        public Uri getNotificationUri() {
+            return null;
+        }
+
+        @Override
+        public boolean getWantsAllOnMoveCalls() {
+            return false;
+        }
+
+        @Override
+        public Bundle getExtras() {
+            return null;
+        }
+
+        @Override
+        public Bundle respond(Bundle bundle) {
+            return null;
+        }
+    }
+
+}

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
@@ -32,6 +32,34 @@ public class BatchStatusTests {
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
     }
+
+    @Test
+    public void givenABatchWithSomePendingItemsAndSomeCompleteItemsAndSomeSubmittedItemsThenTheBatchStatusIsRunning() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.SUBMITTED);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
+    }
+
+    @Test
+    public void givenABatchWithAMixOfItemsThenTheBatchStatusIsNotRunning() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.BATCH_FAILED);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isNotEqualTo(DownloadStatus.RUNNING);
+    }
+
+    @Test
+    public void givenABatchWithSubmittedAndSuccessStatesThenTheBatchStatusIsRunning() {
+        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUBMITTED, DownloadStatus.SUBMITTED, DownloadStatus.SUBMITTED, DownloadStatus.SUCCESS);
+
+        int batchStatus = repository.getBatchStatus(1);
+
+        assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
+    }
+
     @Test
     public void givenABatchWithAllCompleteItemsThenTheBatchStatusIsSuccess() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUCCESS, DownloadStatus.SUCCESS);
@@ -48,15 +76,6 @@ public class BatchStatusTests {
         int batchStatus = repository.getBatchStatus(1);
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.PENDING);
-    }
-
-    @Test
-    public void givenABatchWithAMixThenTheStatusIsNotRunning() {
-        BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.SUBMITTED);
-
-        int batchStatus = repository.getBatchStatus(1);
-
-        assertThat(batchStatus).isNotEqualTo(DownloadStatus.PENDING);
     }
 
     @NonNull

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
@@ -43,7 +43,7 @@ public class BatchStatusTests {
     }
 
     @Test
-    public void givenABatchWithAMixOfItemsThenTheBatchStatusIsNotRunning() {
+    public void givenABatchWithItemsThatAreNotSubmittedOrSuccessOrPendingThenTheBatchStatusIsNotRunning() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.SUCCESS, DownloadStatus.BATCH_FAILED);
 
         int batchStatus = repository.getBatchStatus(1);


### PR DESCRIPTION
This PR adds fixes an issue where, when a download in a batch completes, the batch's status would briefly go to "queued", even though from the batch's point of view it is still running.

Also, it looks like the notification doesn't flicker either!

FYI the flicker happens at around 10MB

| Before | After |
| --- | --- |
| ![broken-wobble](https://cloud.githubusercontent.com/assets/666285/8802019/7b79e5a8-2fb6-11e5-9596-705ea7983fc8.gif) | ![fix-wobbly-state](https://cloud.githubusercontent.com/assets/666285/8802022/8194c8d6-2fb6-11e5-8ee6-554a02323c79.gif) |