### PR TITLE
Tar truncation at download time

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/CheckedWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/CheckedWriter.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager.lib;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class CheckedWriter implements DataWriter {
+class CheckedWriter implements DataWriter {
 
     private final SpaceVerifier spaceVerifier;
     private final OutputStream outputStream;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/CheckedWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/CheckedWriter.java
@@ -1,0 +1,46 @@
+package com.novoda.downloadmanager.lib;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class CheckedWriter implements DataWriter {
+
+    private final StorageManager storageManager;
+    private final int destination;
+    private final String fileName;
+    private final OutputStream outputStream;
+
+    public CheckedWriter(StorageManager storageManager, int destination, String fileName, OutputStream outputStream) {
+        this.storageManager = storageManager;
+        this.destination = destination;
+        this.fileName = fileName;
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public DownloadThread.State write(DownloadThread.State state, byte[] buffer, int count) throws StopRequestException {
+
+        storageManager.verifySpaceBeforeWritingToFile(destination, fileName, count);
+
+        boolean forceVerified = false;
+        while (true) {
+            try {
+                state.gotData = true;
+                outputStream.write(buffer, 0, count);
+                state.currentBytes += count;
+                return state;
+            } catch (IOException ex) {
+                // TODO: better differentiate between DRM and disk failures
+                if (!forceVerified) {
+                    // couldn't write to file. are we out of space? check.
+                    storageManager.verifySpace(destination, fileName, count);
+                    forceVerified = true;
+                } else {
+                    throw new StopRequestException(
+                            DownloadStatus.FILE_ERROR,
+                            "Failed to write data: " + ex);
+                }
+            }
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -4,7 +4,7 @@ package com.novoda.downloadmanager.lib;
  * Contains the internal constants that are used in the download manager.
  * As a general rule, modifying these constants should be done with care.
  */
-public class Constants {
+class Constants {
 
     /**
      * The column that used to be used for the HTTP method of the request

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -4,7 +4,7 @@ package com.novoda.downloadmanager.lib;
  * Contains the internal constants that are used in the download manager.
  * As a general rule, modifying these constants should be done with care.
  */
-class Constants {
+public class Constants {
 
     /**
      * The column that used to be used for the HTTP method of the request
@@ -126,6 +126,11 @@ class Constants {
      * The buffer size used to stream the data
      */
     public static final int BUFFER_SIZE = 4096;
+
+    /**
+     * The value representing the end of stream when, reading an InputStream
+     */
+    public static final int NO_BYTES_READ = -1;
 
     /**
      * The minimum amount of progress that has to be done before the progress bar gets updated

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DataTransferer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DataTransferer.java
@@ -1,0 +1,7 @@
+package com.novoda.downloadmanager.lib;
+
+import java.io.InputStream;
+
+public interface DataTransferer {
+    DownloadThread.State transferData(DownloadThread.State state, InputStream in) throws StopRequestException;
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DataTransferer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DataTransferer.java
@@ -2,6 +2,6 @@ package com.novoda.downloadmanager.lib;
 
 import java.io.InputStream;
 
-public interface DataTransferer {
+interface DataTransferer {
     DownloadThread.State transferData(DownloadThread.State state, InputStream in) throws StopRequestException;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DataWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DataWriter.java
@@ -1,0 +1,7 @@
+package com.novoda.downloadmanager.lib;
+
+public interface DataWriter {
+
+    DownloadThread.State write(DownloadThread.State state, byte[] buffer, int count) throws StopRequestException;
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DataWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DataWriter.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager.lib;
 
-public interface DataWriter {
+interface DataWriter {
 
     DownloadThread.State write(DownloadThread.State state, byte[] buffer, int count) throws StopRequestException;
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -79,7 +79,6 @@ public class DownloadService extends Service {
     private DownloadsRepository downloadsRepository;
     private DownloadDeleter downloadDeleter;
     private DownloadReadyChecker downloadReadyChecker;
-    private TarFileTruncator tarFileTruncator;
     private DownloadsUriProvider downloadsUriProvider;
     private BatchCompletionBroadcaster batchCompletionBroadcaster;
     private NetworkChecker networkChecker;
@@ -125,7 +124,6 @@ public class DownloadService extends Service {
         DownloadClientReadyChecker downloadClientReadyChecker = getDownloadClientReadyChecker();
         this.networkChecker = new NetworkChecker(this.systemFacade);
         this.downloadReadyChecker = new DownloadReadyChecker(this.systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
-        this.tarFileTruncator = new TarFileTruncator();
 
         String applicationPackageName = getApplicationContext().getPackageName();
         this.batchCompletionBroadcaster = new BatchCompletionBroadcaster(this, applicationPackageName);
@@ -385,7 +383,7 @@ public class DownloadService extends Service {
         DownloadThread downloadThread = new DownloadThread(
                 this, systemFacade, info, storageManager, downloadNotifier,
                 batchCompletionBroadcaster, batchRepository, downloadsUriProvider,
-                downloadsRepository, networkChecker, downloadReadyChecker, tarFileTruncator
+                downloadsRepository, networkChecker, downloadReadyChecker
         );
 
         ContentValues contentValues = new ContentValues();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -515,7 +515,8 @@ class DownloadThread implements Runnable {
      * destination file.
      */
     private void transferData(State state, InputStream in, OutputStream out) throws StopRequestException {
-        DataWriter checkedWriter = new CheckedWriter(storageManager, originalDownloadInfo.getDestination(), state.filename, out);
+        StorageSpaceVerifier spaceVerifier = new StorageSpaceVerifier(storageManager, originalDownloadInfo.getDestination(), state.filename);
+        DataWriter checkedWriter = new CheckedWriter(spaceVerifier, out);
         DataWriter dataWriter = new NotifierWriter(getContentResolver(), checkedWriter, downloadNotifier, downloadsRepository, originalDownloadInfo);
 
         DataTransferer dataTransferer;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -25,7 +25,6 @@ import android.net.NetworkInfo;
 import android.net.TrafficStats;
 import android.os.PowerManager;
 import android.os.Process;
-import android.os.SystemClock;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -87,9 +86,6 @@ class DownloadThread implements Runnable {
     private final DownloadsRepository downloadsRepository;
     private final NetworkChecker networkChecker;
     private final DownloadReadyChecker downloadReadyChecker;
-    private final TarFileTruncator tarFileTruncator;
-
-    private volatile boolean policyDirty;
 
     public DownloadThread(Context context,
                           SystemFacade systemFacade,
@@ -101,8 +97,7 @@ class DownloadThread implements Runnable {
                           DownloadsUriProvider downloadsUriProvider,
                           DownloadsRepository downloadsRepository,
                           NetworkChecker networkChecker,
-                          DownloadReadyChecker downloadReadyChecker,
-                          TarFileTruncator tarFileTruncator) {
+                          DownloadReadyChecker downloadReadyChecker) {
         this.context = context;
         this.systemFacade = systemFacade;
         this.originalDownloadInfo = originalDownloadInfo;
@@ -114,7 +109,6 @@ class DownloadThread implements Runnable {
         this.downloadsRepository = downloadsRepository;
         this.networkChecker = networkChecker;
         this.downloadReadyChecker = downloadReadyChecker;
-        this.tarFileTruncator = tarFileTruncator;
     }
 
     /**
@@ -164,6 +158,7 @@ class DownloadThread implements Runnable {
 
         public int redirectionCount;
         public URL url;
+        public boolean shouldPause;
 
         public State(FileDownloadInfo info) {
             mimeType = normalizeMimeType(info.getMimeType());
@@ -171,6 +166,9 @@ class DownloadThread implements Runnable {
             filename = info.getFileName();
             totalBytes = info.getTotalBytes();
             currentBytes = info.getCurrentBytes();
+        }
+
+        State() {
         }
 
         public void resetBeforeExecute() {
@@ -347,12 +345,8 @@ class DownloadThread implements Runnable {
         state.resetBeforeExecute();
         setupDestinationFile(state);
 
-        if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {
-            state.totalBytes = UNKNOWN_BYTE_SIZE;
-        }
-
         // skip when already finished; remove after fixing race in 5217390
-        if (state.currentBytes == state.totalBytes) {
+        if (downloadAlreadyFinished(state)) {
             Log.i("Skipping initiating request for download " + originalDownloadInfo.getId() + "; already completed");
             return;
         }
@@ -431,6 +425,10 @@ class DownloadThread implements Runnable {
         throw new StopRequestException(DownloadStatus.TOO_MANY_REDIRECTS, "Too many redirects");
     }
 
+    private boolean downloadAlreadyFinished(State state) {
+        return (state.currentBytes == state.totalBytes) && !originalDownloadInfo.shouldAllowTarUpdate(state.mimeType);
+    }
+
     /**
      * Transfer data from the given connection to the destination file.
      */
@@ -463,7 +461,7 @@ class DownloadThread implements Runnable {
 
             // Start streaming data, periodically watch for pause/cancel
             // commands and checking disk space as needed.
-            transferData(state, in, out, outFd);
+            transferData(state, in, out);
 
 //            try {
 //                if (out instanceof DrmOutputStream) {
@@ -488,8 +486,6 @@ class DownloadThread implements Runnable {
      * Check if current connectivity is valid for this request.
      */
     private void checkConnectivity() throws StopRequestException {
-        // checking connectivity will apply current policy
-        policyDirty = false;
 
         final NetworkState networkUsable = networkChecker.checkCanUseNetwork(originalDownloadInfo);
         if (networkUsable != NetworkState.OK) {
@@ -518,24 +514,19 @@ class DownloadThread implements Runnable {
      * Transfer as much data as possible from the HTTP response to the
      * destination file.
      */
-    private void transferData(State state, InputStream in, OutputStream out, FileDescriptor outFd) throws StopRequestException {
-        final byte data[] = new byte[Constants.BUFFER_SIZE];
-        for (; ; ) {
-            int bytesRead = readFromResponse(state, data, in);
-            if (bytesRead == -1) { // success, end of stream already reached
-                handleEndOfStream(state, out, outFd);
-                return;
-            }
+    private void transferData(State state, InputStream in, OutputStream out) throws StopRequestException {
+        DataWriter checkedWriter = new CheckedWriter(storageManager, originalDownloadInfo.getDestination(), state.filename, out);
+        DataWriter dataWriter = new NotifierWriter(getContentResolver(), checkedWriter, downloadNotifier, downloadsRepository, originalDownloadInfo);
 
-            state.gotData = true;
-            writeDataToDestination(state, data, bytesRead, out);
-            state.currentBytes += bytesRead;
-            reportProgress(state);
-
-//            Log.v("downloaded " + state.currentBytes + " for " + downloadInfo.uri);
-
-            checkPausedOrCanceled();
+        DataTransferer dataTransferer;
+        if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {
+            dataTransferer = new TarFileTruncator(dataWriter);
+        } else {
+            dataTransferer = new RegularDataTransferer(dataWriter);
         }
+
+        State newState = dataTransferer.transferData(state, in);
+        handleEndOfStream(newState);
     }
 
     /**
@@ -566,100 +557,15 @@ class DownloadThread implements Runnable {
     }
 
     /**
-     * Check if the download has been paused or canceled, stopping the request appropriately if it
-     * has been.
-     */
-    private void checkPausedOrCanceled() throws StopRequestException {
-        FileDownloadInfo.ControlStatus controlStatus = downloadsRepository.getDownloadInfoControlStatusFor(originalDownloadInfo.getId());
-
-        if (controlStatus.isPaused()) {
-            throw new StopRequestException(DownloadStatus.PAUSED_BY_APP, "download paused by owner");
-        }
-        if (controlStatus.isCanceled()) {
-            throw new StopRequestException(DownloadStatus.CANCELED, "download canceled");
-        }
-
-        // if policy has been changed, trigger connectivity check
-        if (policyDirty) {
-            checkConnectivity();
-        }
-    }
-
-    /**
-     * Report download progress through the database if necessary.
-     */
-    private void reportProgress(State state) {
-        final long now = SystemClock.elapsedRealtime();
-
-        final long sampleDelta = now - state.speedSampleStart;
-        if (sampleDelta > 500) {
-            final long sampleSpeed = ((state.currentBytes - state.speedSampleBytes) * 1000) / sampleDelta;
-
-            if (state.speed == 0) {
-                state.speed = sampleSpeed;
-            } else {
-                state.speed = ((state.speed * 3) + sampleSpeed) / 4;
-            }
-
-            // Only notify once we have a full sample window
-            if (state.speedSampleStart != 0) {
-                downloadNotifier.notifyDownloadSpeed(originalDownloadInfo.getId(), state.speed);
-            }
-
-            state.speedSampleStart = now;
-            state.speedSampleBytes = state.currentBytes;
-        }
-
-        if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
-                now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
-            ContentValues values = new ContentValues();
-            values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
-            getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
-            state.bytesNotified = state.currentBytes;
-            state.timeLastNotification = now;
-        }
-    }
-
-    /**
-     * Write a data buffer to the destination file.
-     *
-     * @param data      buffer containing the data to write
-     * @param bytesRead how many bytes to write from the buffer
-     */
-    private void writeDataToDestination(State state, byte[] data, int bytesRead, OutputStream out) throws StopRequestException {
-        storageManager.verifySpaceBeforeWritingToFile(originalDownloadInfo.getDestination(), state.filename, bytesRead);
-
-        boolean forceVerified = false;
-        while (true) {
-            try {
-                out.write(data, 0, bytesRead);
-                return;
-            } catch (IOException ex) {
-                // TODO: better differentiate between DRM and disk failures
-                if (!forceVerified) {
-                    // couldn't write to file. are we out of space? check.
-                    storageManager.verifySpace(originalDownloadInfo.getDestination(), state.filename, bytesRead);
-                    forceVerified = true;
-                } else {
-                    throw new StopRequestException(
-                            DownloadStatus.FILE_ERROR,
-                            "Failed to write data: " + ex);
-                }
-            }
-        }
-    }
-
-    /**
      * Called when we've reached the end of the HTTP response stream, to update the database and
      * check for consistency.
      */
-    private void handleEndOfStream(State state, OutputStream out, FileDescriptor outFd) throws StopRequestException {
-        if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {
-            closeAfterWrite(out, outFd);
-            state.currentBytes = tarFileTruncator.truncateIfNeeded(state.filename);
+    private void handleEndOfStream(State state) throws StopRequestException {
+        if (state.shouldPause) {
             updateStatusAndPause(state);
             return;
         }
+
         ContentValues values = new ContentValues(2);
         values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
         if (state.contentLength == UNKNOWN_BYTE_SIZE) {
@@ -682,41 +588,13 @@ class DownloadThread implements Runnable {
         ContentValues values = new ContentValues();
         values.put(COLUMN_STATUS, DownloadStatus.PAUSED_BY_APP);
         values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
-        values.put(COLUMN_TOTAL_BYTES, state.currentBytes);
+        values.put(COLUMN_TOTAL_BYTES, state.totalBytes);
         getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
         throw new StopRequestException(DownloadStatus.PAUSED_BY_APP, "download paused by owner");
     }
 
     private boolean cannotResume(State state) {
         return (state.currentBytes > 0 && !originalDownloadInfo.isResumable() || DownloadDrmHelper.isDrmConvertNeeded(state.mimeType));
-    }
-
-    /**
-     * Read some data from the HTTP response stream, handling I/O errors.
-     *
-     * @param data         buffer to use to read data
-     * @param entityStream stream for reading the HTTP response entity
-     * @return the number of bytes actually read or -1 if the end of the stream has been reached
-     */
-    private int readFromResponse(State state, byte[] data, InputStream entityStream)
-            throws StopRequestException {
-        try {
-            return entityStream.read(data);
-        } catch (IOException ex) {
-            // TODO: handle stream errors the same as other retries
-            if ("unexpected end of stream".equals(ex.getMessage())) {
-                return -1;
-            }
-
-            ContentValues values = new ContentValues(1);
-            values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
-            getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
-            if (cannotResume(state)) {
-                throw new StopRequestException(DownloadStatus.CANNOT_RESUME, "Failed reading response: " + ex + "; unable to resume", ex);
-            } else {
-                throw new StopRequestException(HTTP_DATA_ERROR, "Failed reading response: " + ex, ex);
-            }
-        }
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -520,7 +520,7 @@ class DownloadThread implements Runnable {
 
         DataTransferer dataTransferer;
         if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {
-            dataTransferer = new TarFileTruncator(dataWriter);
+            dataTransferer = new TarTruncator(dataWriter);
         } else {
             dataTransferer = new RegularDataTransferer(dataWriter);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -169,6 +169,7 @@ class DownloadThread implements Runnable {
         }
 
         State() {
+            // This constructor is intentionally empty. Only used for tests.
         }
 
         public void resetBeforeExecute() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -6,7 +6,7 @@ import android.os.SystemClock;
 
 import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_CURRENT_BYTES;
 
-public class NotifierWriter implements DataWriter {
+class NotifierWriter implements DataWriter {
 
     private final ContentResolver contentResolver;
     private final DataWriter dataWriter;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -1,0 +1,86 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.os.SystemClock;
+
+import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_CURRENT_BYTES;
+
+public class NotifierWriter implements DataWriter {
+
+    private final ContentResolver contentResolver;
+    private final DataWriter dataWriter;
+    private final DownloadNotifier downloadNotifier;
+    private final DownloadsRepository downloadsRepository;
+    private final FileDownloadInfo downloadInfo;
+
+    public NotifierWriter(ContentResolver contentResolver,
+                          DataWriter dataWriter,
+                          DownloadNotifier downloadNotifier,
+                          DownloadsRepository downloadsRepository,
+                          FileDownloadInfo downloadInfo) {
+        this.contentResolver = contentResolver;
+        this.dataWriter = dataWriter;
+        this.downloadNotifier = downloadNotifier;
+        this.downloadsRepository = downloadsRepository;
+        this.downloadInfo = downloadInfo;
+    }
+
+    @Override
+    public DownloadThread.State write(DownloadThread.State state, byte[] buffer, int count) throws StopRequestException {
+        DownloadThread.State localState = state;
+        localState = dataWriter.write(localState, buffer, count);
+        localState = reportProgress(localState);
+        checkPausedOrCanceled();
+        return localState;
+    }
+
+    private DownloadThread.State reportProgress(DownloadThread.State state) {
+        final long now = SystemClock.elapsedRealtime();
+
+        final long sampleDelta = now - state.speedSampleStart;
+        if (sampleDelta > 500) {
+            final long sampleSpeed = ((state.currentBytes - state.speedSampleBytes) * 1000) / sampleDelta;
+
+            if (state.speed == 0) {
+                state.speed = sampleSpeed;
+            } else {
+                state.speed = ((state.speed * 3) + sampleSpeed) / 4;
+            }
+
+            // Only notify once we have a full sample window
+            if (state.speedSampleStart != 0) {
+                downloadNotifier.notifyDownloadSpeed(downloadInfo.getId(), state.speed);
+            }
+
+            state.speedSampleStart = now;
+            state.speedSampleBytes = state.currentBytes;
+        }
+
+        if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
+                now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
+            ContentValues values = new ContentValues();
+            values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
+            contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
+            state.bytesNotified = state.currentBytes;
+            state.timeLastNotification = now;
+        }
+        return state;
+    }
+
+    /**
+     * Check if the download has been paused or canceled, stopping the request appropriately if it
+     * has been.
+     */
+    private void checkPausedOrCanceled() throws StopRequestException {
+        FileDownloadInfo.ControlStatus controlStatus = downloadsRepository.getDownloadInfoControlStatusFor(downloadInfo.getId());
+
+        if (controlStatus.isPaused()) {
+            throw new StopRequestException(DownloadStatus.PAUSED_BY_APP, "download paused by owner");
+        }
+        if (controlStatus.isCanceled()) {
+            throw new StopRequestException(DownloadStatus.CANCELED, "download canceled");
+        }
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/RegularDataTransferer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/RegularDataTransferer.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager.lib;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class RegularDataTransferer implements DataTransferer {
+class RegularDataTransferer implements DataTransferer {
 
     private final DataWriter dataWriter;
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/RegularDataTransferer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/RegularDataTransferer.java
@@ -1,0 +1,31 @@
+package com.novoda.downloadmanager.lib;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RegularDataTransferer implements DataTransferer {
+
+    private final DataWriter dataWriter;
+
+    public RegularDataTransferer(DataWriter dataWriter) {
+        this.dataWriter = dataWriter;
+    }
+
+    @Override
+    public DownloadThread.State transferData(DownloadThread.State state, InputStream in) throws StopRequestException {
+        DownloadThread.State newState = state;
+        try {
+            byte[] buffer = new byte[Constants.BUFFER_SIZE];
+            int readLast = in.read(buffer);
+            while (readLast != Constants.NO_BYTES_READ) {
+                newState = dataWriter.write(newState, buffer, readLast);
+                readLast = in.read(buffer);
+            }
+            return newState;
+        } catch (IOException e) {
+            // It was doing the same thing in regular and exception cases
+            return newState;
+        }
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/SpaceVerifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/SpaceVerifier.java
@@ -1,0 +1,9 @@
+package com.novoda.downloadmanager.lib;
+
+public interface SpaceVerifier {
+
+    void verifySpacePreemptively(int count) throws StopRequestException;
+
+    void verifySpace(int count) throws StopRequestException;
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/SpaceVerifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/SpaceVerifier.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager.lib;
 
-public interface SpaceVerifier {
+interface SpaceVerifier {
 
     void verifySpacePreemptively(int count) throws StopRequestException;
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageSpaceVerifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageSpaceVerifier.java
@@ -1,0 +1,24 @@
+package com.novoda.downloadmanager.lib;
+
+public class StorageSpaceVerifier implements SpaceVerifier {
+
+    private final StorageManager storageManager;
+    private final int destination;
+    private final String fileName;
+
+    public StorageSpaceVerifier(StorageManager storageManager, int destination, String fileName) {
+        this.storageManager = storageManager;
+        this.destination = destination;
+        this.fileName = fileName;
+    }
+
+    @Override
+    public void verifySpacePreemptively(int count) throws StopRequestException {
+        storageManager.verifySpaceBeforeWritingToFile(destination, fileName, count);
+    }
+
+    @Override
+    public void verifySpace(int count) throws StopRequestException {
+        storageManager.verifySpace(destination, fileName, count);
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageSpaceVerifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageSpaceVerifier.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager.lib;
 
-public class StorageSpaceVerifier implements SpaceVerifier {
+class StorageSpaceVerifier implements SpaceVerifier {
 
     private final StorageManager storageManager;
     private final int destination;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/TarFileTruncator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/TarFileTruncator.java
@@ -1,70 +1,53 @@
 package com.novoda.downloadmanager.lib;
 
-import java.io.File;
-import java.io.FileDescriptor;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
-import static com.novoda.downloadmanager.lib.IOHelpers.closeAfterWrite;
-import static com.novoda.downloadmanager.lib.IOHelpers.closeQuietly;
+public class TarFileTruncator implements DataTransferer {
 
-class TarFileTruncator {
-
-    private static final String COPY_SUFFIX = ".tmp";
     private static final byte BYTE_ZERO = 0x0;
     private static final int BLOCK_SIZE = 512;
     private static final int NO_BYTES_READ = -1;
 
-    public long truncateIfNeeded(String fileOriginal) throws StopRequestException {
-        String fileCopy = fileOriginal + COPY_SUFFIX;
-        long newLength = copyFileTruncatingLastBytesIfNeeded(fileOriginal, fileCopy);
-        replace(fileOriginal, fileCopy);
-        return newLength;
+    private final DataWriter dataWriter;
+
+    public TarFileTruncator(DataWriter dataWriter) {
+        this.dataWriter = dataWriter;
     }
 
-    private long copyFileTruncatingLastBytesIfNeeded(String fileOriginal, String fileCopy) throws StopRequestException {
-        OutputStream out = null;
-        FileDescriptor outFd = null;
-        InputStream in = null;
+    @Override
+    public DownloadThread.State transferData(DownloadThread.State state, InputStream in) throws StopRequestException {
+        DownloadThread.State newState = state;
         try {
-            FileInputStream fileInputStream = new FileInputStream(fileOriginal);
-            FileOutputStream fileOutputStream = new FileOutputStream(fileCopy);
-            out = fileOutputStream;
-            outFd = fileOutputStream.getFD();
-            in = fileInputStream;
             byte[] buffer = new byte[BLOCK_SIZE];
-            int readLast;
-            int readTotal = 0;
-            do {
-                readLast = readBlock(fileInputStream, buffer);
-                if ((readLast == -1) || isFullOfZeroes(buffer)) {
-                    return readTotal;
-                }
-                out.write(buffer, 0, readLast);
-                readTotal += readLast;
-            } while (readLast == BLOCK_SIZE);
-            return readTotal;
+            int readLast = readBlock(in, buffer);
+            while (readsData(readLast) && isNotFullOfZeroes(buffer)) {
+                newState = dataWriter.write(newState, buffer, readLast);
+                readLast = readBlock(in, buffer);
+            }
+            state.totalBytes = state.currentBytes;
+            return newState;
         } catch (IOException e) {
-            throw new StopRequestException(DownloadStatus.FILE_ERROR, e);
-        } finally {
-            closeAfterWrite(out, outFd);
-            closeQuietly(in);
+            // It was doing the same thing in regular and exception cases
+            state.totalBytes = state.currentBytes;
+            return newState;
         }
     }
 
-    private boolean isFullOfZeroes(byte[] buffer) {
+    private boolean readsData(int readLast) {
+        return readLast != -1 && readLast != 0;
+    }
+
+    private boolean isNotFullOfZeroes(byte[] buffer) {
         for (byte b : buffer) {
             if (b != BYTE_ZERO) {
-                return false;
+                return true;
             }
         }
-        return true;
+        return false;
     }
 
-    private int readBlock(FileInputStream fileInputStream, byte[] buffer) throws IOException {
+    private int readBlock(InputStream fileInputStream, byte[] buffer) throws IOException {
         int read = 0;
         int readLast;
         while (read < BLOCK_SIZE) {
@@ -75,16 +58,6 @@ class TarFileTruncator {
             read += readLast;
         }
         return read;
-    }
-
-    private void replace(String fileOriginal, String fileCopy) {
-        File oldFile = new File(fileOriginal);
-        File newFile = new File(fileCopy);
-        boolean deleted = oldFile.delete();
-        boolean renamed = newFile.renameTo(oldFile);
-        if (!deleted || !renamed) {
-            throw new IllegalStateException("Could not replace file by truncated one");
-        }
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager.lib;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class TarFileTruncator implements DataTransferer {
+public class TarTruncator implements DataTransferer {
 
     private static final byte BYTE_ZERO = 0x0;
     private static final int BLOCK_SIZE = 512;
@@ -11,7 +11,7 @@ public class TarFileTruncator implements DataTransferer {
 
     private final DataWriter dataWriter;
 
-    public TarFileTruncator(DataWriter dataWriter) {
+    public TarTruncator(DataWriter dataWriter) {
         this.dataWriter = dataWriter;
     }
 
@@ -25,11 +25,11 @@ public class TarFileTruncator implements DataTransferer {
                 newState = dataWriter.write(newState, buffer, readLast);
                 readLast = readBlock(in, buffer);
             }
+            state.shouldPause = true;
             state.totalBytes = state.currentBytes;
             return newState;
         } catch (IOException e) {
             // It was doing the same thing in regular and exception cases
-            state.totalBytes = state.currentBytes;
             return newState;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager.lib;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class TarTruncator implements DataTransferer {
+class TarTruncator implements DataTransferer {
 
     private static final byte BYTE_ZERO = 0x0;
     private static final int BLOCK_SIZE = 512;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
@@ -7,7 +7,6 @@ class TarTruncator implements DataTransferer {
 
     private static final byte BYTE_ZERO = 0x0;
     private static final int BLOCK_SIZE = 512;
-    private static final int NO_BYTES_READ = -1;
 
     private final DataWriter dataWriter;
 
@@ -52,7 +51,7 @@ class TarTruncator implements DataTransferer {
         int readLast;
         while (read < BLOCK_SIZE) {
             readLast = fileInputStream.read(buffer, read, BLOCK_SIZE - read);
-            if (readLast == NO_BYTES_READ) {
+            if (readLast == Constants.NO_BYTES_READ) {
                 return read;
             }
             read += readLast;

--- a/library/src/test/java/com/novoda/downloadmanager/lib/CheckedWriterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/CheckedWriterTest.java
@@ -1,0 +1,90 @@
+package com.novoda.downloadmanager.lib;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class CheckedWriterTest {
+
+    private static final int WRITER_OFFSET = 0;
+
+    @Mock
+    SpaceVerifier spaceVerifier;
+    @Mock
+    OutputStream outputStream;
+
+    private int count;
+    private long initialCurrentBytes;
+    private DownloadThread.State state;
+    private byte[] buffer;
+
+    private CheckedWriter checkedWriter;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+        checkedWriter = new CheckedWriter(spaceVerifier, outputStream);
+    }
+
+    @Test
+    public void itWritesToTheOutputStream() throws Exception {
+        givenANormalStateForACopy();
+
+        checkedWriter.write(state, buffer, count);
+
+        verify(outputStream).write(buffer, WRITER_OFFSET, count);
+    }
+
+    @Test
+    public void gotDataIsSetToTrueAfterReceivingData() throws Exception {
+        givenANormalStateForACopy();
+
+        checkedWriter.write(state, buffer, count);
+
+        assertThat(state.gotData).isTrue();
+    }
+
+    @Test
+    public void currentBytesIsEqualToTotalBytesAfterReceivingData() throws Exception {
+        givenANormalStateForACopy();
+
+        checkedWriter.write(state, buffer, count);
+
+        assertThat(state.currentBytes).isEqualTo(count + initialCurrentBytes);
+    }
+
+    @Test
+    public void itShouldVerifySpaceIfIOException() throws Exception {
+        givenAnIOExceptionOccurs();
+
+        checkedWriter.write(state, buffer, count);
+
+        verify(outputStream, times(2)).write(buffer, WRITER_OFFSET, count);
+        verify(spaceVerifier).verifySpace(count);
+    }
+
+    private void givenANormalStateForACopy() {
+        state = new DownloadThread.State();
+        count = 42;
+        initialCurrentBytes = state.currentBytes;
+        buffer = new byte[]{};
+    }
+
+    private void givenAnIOExceptionOccurs() throws IOException {
+        givenANormalStateForACopy();
+        doThrow(new IOException())
+                .doNothing()
+                .when(outputStream)
+                .write(buffer, WRITER_OFFSET, count);
+    }
+
+}

--- a/library/src/test/java/com/novoda/downloadmanager/lib/TarTruncatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/TarTruncatorTest.java
@@ -18,11 +18,12 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class TarTruncatorTest {
 
     private static final int TRUNCATED_TEST_FILE_SIZE = 349696;
-    
-    private TarTruncator tarTruncator;
+
     private InputStream resourceAsStream;
     private FileOutputStream fileOutputStream;
     private DownloadThread.State state;
+
+    private TarTruncator tarTruncator;
 
     @Test
     public void itTruncatesProperlyTarFileThatContainsEndBlockMarker() throws Exception {


### PR DESCRIPTION
This change allows to avoid doing a file replacement during processing
time and thus allows to process files while someone has a read
inputstream open.

This is also cleaning a lot the DownloadThread in the process to allow
that customisation