### PR TITLE
Avoid smashing the database while transferring bytes

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Clock.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Clock.java
@@ -1,0 +1,36 @@
+package com.novoda.downloadmanager.lib;
+
+import android.os.SystemClock;
+
+import java.util.concurrent.TimeUnit;
+
+class Clock {
+
+    public enum Interval {
+        ONE_SECOND(TimeUnit.SECONDS.toMillis(1));
+
+        private final long interval;
+
+        Interval(long interval) {
+            this.interval = interval;
+        }
+
+        public long toMillis() {
+            return interval;
+        }
+    }
+
+    private long lastUpdate;
+
+    public void startInterval() {
+        lastUpdate = SystemClock.elapsedRealtime();
+    }
+
+    public boolean intervalLessThan(Interval interval) {
+        return SystemClock.elapsedRealtime() - lastUpdate < interval.toMillis();
+    }
+
+    public long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -383,15 +383,15 @@ public class DownloadManager {
     private Uri baseUri;
 
     public DownloadManager(Context context, ContentResolver resolver) {
-        this(context, resolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context), false);
+        this(context, resolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context, new Clock()), false);
     }
 
     public DownloadManager(Context context, ContentResolver contentResolver, boolean verboseLogging) {
-        this(context, contentResolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context), verboseLogging);
+        this(context, contentResolver, DownloadsUriProvider.getInstance(), new RealSystemFacade(context, new Clock()), verboseLogging);
     }
 
     DownloadManager(Context context, ContentResolver resolver, DownloadsUriProvider downloadsUriProvider) {
-        this(context, resolver, downloadsUriProvider, new RealSystemFacade(context), false);
+        this(context, resolver, downloadsUriProvider, new RealSystemFacade(context, new Clock()), false);
     }
 
     DownloadManager(Context context,
@@ -453,7 +453,7 @@ public class DownloadManager {
         contentResolver.update(downloadsUriProvider.getAllDownloadsUri(), values, where, selectionArgs);
 
         DownloadDeleter downloadDeleter = new DownloadDeleter(contentResolver);
-        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext());
+        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext(), new Clock());
         BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
         batchRepository.updateBatchStatus(id, DownloadStatus.PENDING);
         notifyBatchesHaveChanged();
@@ -576,7 +576,7 @@ public class DownloadManager {
      */
     public Cursor query(BatchQuery query) {
         DownloadDeleter downloadDeleter = new DownloadDeleter(contentResolver);
-        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext());
+        RealSystemFacade systemFacade = new RealSystemFacade(GlobalState.getContext(), new Clock());
         BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
         Cursor cursor = batchRepository.retrieveFor(query);
         if (cursor == null) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -273,7 +273,7 @@ public final class DownloadProvider extends ContentProvider {
     @Override
     public boolean onCreate() {
         if (systemFacade == null) {
-            systemFacade = new RealSystemFacade(getContext());
+            systemFacade = new RealSystemFacade(getContext(), new Clock());
         }
 
         Context context = getContext();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -114,7 +114,7 @@ public class DownloadService extends Service {
         Log.v("Service onCreate");
 
         if (systemFacade == null) {
-            systemFacade = new RealSystemFacade(this);
+            systemFacade = new RealSystemFacade(this, new Clock());
         }
 
         this.downloadsUriProvider = DownloadsUriProvider.getInstance();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -518,7 +518,13 @@ class DownloadThread implements Runnable {
     private void transferData(State state, InputStream in, OutputStream out) throws StopRequestException {
         StorageSpaceVerifier spaceVerifier = new StorageSpaceVerifier(storageManager, originalDownloadInfo.getDestination(), state.filename);
         DataWriter checkedWriter = new CheckedWriter(spaceVerifier, out);
-        DataWriter dataWriter = new NotifierWriter(getContentResolver(), checkedWriter, downloadNotifier, downloadsRepository, originalDownloadInfo);
+        Clock clock = new Clock();
+        DataWriter dataWriter = new NotifierWriter(getContentResolver(),
+                                                   checkedWriter,
+                                                   downloadNotifier,
+                                                   downloadsRepository,
+                                                   originalDownloadInfo,
+                                                   clock);
 
         DataTransferer dataTransferer;
         if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -13,17 +13,20 @@ class NotifierWriter implements DataWriter {
     private final DownloadNotifier downloadNotifier;
     private final DownloadsRepository downloadsRepository;
     private final FileDownloadInfo downloadInfo;
+    private final Clock clock;
 
     public NotifierWriter(ContentResolver contentResolver,
                           DataWriter dataWriter,
                           DownloadNotifier downloadNotifier,
                           DownloadsRepository downloadsRepository,
-                          FileDownloadInfo downloadInfo) {
+                          FileDownloadInfo downloadInfo,
+                          Clock clock) {
         this.contentResolver = contentResolver;
         this.dataWriter = dataWriter;
         this.downloadNotifier = downloadNotifier;
         this.downloadsRepository = downloadsRepository;
         this.downloadInfo = downloadInfo;
+        this.clock = clock;
     }
 
     @Override
@@ -73,6 +76,12 @@ class NotifierWriter implements DataWriter {
      * has been.
      */
     private void checkPausedOrCanceled() throws StopRequestException {
+        if (clock.intervalLessThan(Clock.Interval.ONE_SECOND)) {
+            return;
+        }
+
+        clock.startInterval();
+
         FileDownloadInfo.ControlStatus controlStatus = downloadsRepository.getDownloadInfoControlStatusFor(downloadInfo.getId());
 
         if (controlStatus.isPaused()) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/RealSystemFacade.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/RealSystemFacade.java
@@ -28,14 +28,16 @@ import com.novoda.notils.logger.simple.Log;
 
 class RealSystemFacade implements SystemFacade {
     private final Context context;
+    private final Clock clock;
 
-    public RealSystemFacade(Context context) {
+    public RealSystemFacade(Context context, Clock clock) {
         this.context = context;
+        this.clock = clock;
     }
 
     @Override
     public long currentTimeMillis() {
-        return System.currentTimeMillis();
+        return clock.currentTimeMillis();
     }
 
     @Override


### PR DESCRIPTION
## Task description ##

I've noticed that the GC goes crazy while downloading

## Solution implemented ##

At every HTTP byte transfer there is a check for paused or cancelled downloads that leads to a database query. Even though the query is small, is too frequent.

The solution implemented prevents fast queries in series to the database preventing more than one query per second.

This will allow a check of paused or cancelled inside a time frame of 1s that is good enough and reduces dramatically the GC

**Screenshots**

Before | After
--- | ---
<img width="1440" alt="old-memory" src="https://cloud.githubusercontent.com/assets/2845931/8848309/80905410-3136-11e5-98ba-ffb417530e34.png"> | <img width="1440" alt="new-memory" src="https://cloud.githubusercontent.com/assets/2845931/8848314/87cb8f56-3136-11e5-9536-26c7994f723f.png">
<img width="1440" alt="old-cpu" src="https://cloud.githubusercontent.com/assets/2845931/8848320/9162f16c-3136-11e5-8292-a1375fbd90aa.png"> | <img width="1440" alt="new-cpu" src="https://cloud.githubusercontent.com/assets/2845931/8848323/98f4a1e6-3136-11e5-9401-a1af2c3cb270.png">

**Before small log snipped for GC logs**
```
07-23 11:12:56.819  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 107078(5MB) AllocSpace objects, 0(0B) LOS objects, 40% free, 20MB/34MB, paused 557us total 15.386ms
07-23 11:12:57.607  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 109726(5MB) AllocSpace objects, 1(1302KB) LOS objects, 40% free, 19MB/32MB, paused 896us total 13.422ms
07-23 11:12:58.247  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 109045(5MB) AllocSpace objects, 0(0B) LOS objects, 40% free, 20MB/34MB, paused 679us total 14.400ms
07-23 11:12:58.945  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 107889(5MB) AllocSpace objects, 1(1302KB) LOS objects, 39% free, 19MB/32MB, paused 503us total 29.020ms
07-23 11:12:59.616  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 107429(5MB) AllocSpace objects, 0(0B) LOS objects, 40% free, 20MB/34MB, paused 812us total 13.052ms
07-23 11:13:00.381  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 108781(5MB) AllocSpace objects, 1(1302KB) LOS objects, 39% free, 19MB/32MB, paused 1.425ms total 14.065ms
07-23 11:13:02.315  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 110088(5MB) AllocSpace objects, 0(0B) LOS objects, 40% free, 20MB/34MB, paused 1.049ms total 24.511ms
07-23 11:13:02.985  15125-15183/com.novoda.downloadmanager.demo.extended I/art﹕ Explicit concurrent mark sweep GC freed 108935(5MB) AllocSpace objects, 1(1302KB) LOS objects, 39% free, 19MB/32MB, paused 583us total 18.004ms
```

**After full GC logs**
```
07-23 11:16:17.906  17002-17060/com.novoda.downloadmanager.demo.extended I/NoTils﹕ [pool-2-thread-1][DownloadThread.runInternal:258] Download 27 starting
07-23 11:17:15.863  17002-17017/com.novoda.downloadmanager.demo.extended I/art﹕ Background partial concurrent mark sweep GC freed 8859(467KB) AllocSpace objects, 12(15MB) LOS objects, 40% free, 22MB/38MB, paused 6.087ms total 22.389ms
07-23 11:19:19.355  17002-17060/com.novoda.downloadmanager.demo.extended I/NoTils﹕ [pool-2-thread-1][DownloadThread.runInternal:330] Download 27 finished with status SUCCESS
```
