### PR TITLE
Reducing transfer object creation

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -176,7 +176,7 @@ public class DownloadService extends Service {
             public FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id) {
                 return createNewDownloadInfoControlStatus(reader, id);
             }
-        }, downloadsUriProvider);
+        }, downloadsUriProvider, new FileDownloadInfo.ControlStatus.Reader(contentResolver, downloadsUriProvider));
 
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -165,6 +165,7 @@ public class DownloadService extends Service {
         DownloadExecutorFactory factory = new DownloadExecutorFactory(concurrentDownloadsLimitProvider);
         executor = factory.createExecutor();
 
+        FileDownloadInfo.ControlStatus.Reader controlReader = new FileDownloadInfo.ControlStatus.Reader(contentResolver, downloadsUriProvider);
         this.downloadsRepository = new DownloadsRepository(
                 getContentResolver(), new DownloadsRepository.DownloadInfoCreator() {
             @Override
@@ -176,7 +177,7 @@ public class DownloadService extends Service {
             public FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id) {
                 return createNewDownloadInfoControlStatus(reader, id);
             }
-        }, downloadsUriProvider, new FileDownloadInfo.ControlStatus.Reader(contentResolver, downloadsUriProvider));
+        }, downloadsUriProvider, controlReader);
 
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -17,11 +17,14 @@ class DownloadsRepository {
     private final ContentResolver contentResolver;
     private final DownloadInfoCreator downloadInfoCreator;
     private final DownloadsUriProvider downloadsUriProvider;
+    private final FileDownloadInfo.ControlStatus.Reader controlReader;
 
-    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator, DownloadsUriProvider downloadsUriProvider) {
+    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator, DownloadsUriProvider downloadsUriProvider,
+                               FileDownloadInfo.ControlStatus.Reader controlReader) {
         this.contentResolver = contentResolver;
         this.downloadInfoCreator = downloadInfoCreator;
         this.downloadsUriProvider = downloadsUriProvider;
+        this.controlReader = controlReader;
     }
 
     public List<FileDownloadInfo> getAllDownloads() {
@@ -59,8 +62,7 @@ class DownloadsRepository {
     }
 
     public FileDownloadInfo.ControlStatus getDownloadInfoControlStatusFor(long id) {
-        FileDownloadInfo.ControlStatus.Reader reader = new FileDownloadInfo.ControlStatus.Reader(contentResolver, downloadsUriProvider);
-        return downloadInfoCreator.create(reader, id);
+        return downloadInfoCreator.create(controlReader, id);
     }
 
     public void moveDownloadsStatusTo(List<Long> ids, int status) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -61,13 +61,16 @@ class NotifierWriter implements DataWriter {
 
         if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
                 now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
-            values.clear();
-            values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
+            updateCurrentBytesValues(state);
             contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
             state.bytesNotified = state.currentBytes;
             state.timeLastNotification = now;
         }
         return state;
+    }
+
+    private void updateCurrentBytesValues(DownloadThread.State state) {
+        values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
     }
 
     public interface WriteChunkListener {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -14,6 +14,8 @@ class NotifierWriter implements DataWriter {
     private final FileDownloadInfo downloadInfo;
     private final WriteChunkListener writeChunkListener;
 
+    private final ContentValues values = new ContentValues();
+
     public NotifierWriter(ContentResolver contentResolver,
                           DataWriter dataWriter,
                           DownloadNotifier downloadNotifier,
@@ -59,7 +61,7 @@ class NotifierWriter implements DataWriter {
 
         if (state.currentBytes - state.bytesNotified > Constants.MIN_PROGRESS_STEP &&
                 now - state.timeLastNotification > Constants.MIN_PROGRESS_TIME) {
-            ContentValues values = new ContentValues();
+            values.clear();
             values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
             contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
             state.bytesNotified = state.currentBytes;


### PR DESCRIPTION
One of the outcomes of the DownloadManager meeting was about the amount of garbage collection (potentially) being caused by data transfer loop.

---------

This PR removes the content values and ControlStatus.Reader object creation from deep within the transfer data while(true) loop to reduce unnecessary garbage collection 