### PR TITLE
Prevent pause a non running task and prevent resume a non paused task

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -16,8 +16,6 @@ import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
 import com.novoda.downloadmanager.demo.extended.Download;
 import com.novoda.downloadmanager.demo.extended.QueryForDownloadsAsyncTask;
-import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchPauseException;
-import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchResumeException;
 import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
@@ -50,9 +48,9 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                         Download item = adapter.getItem(position);
                         long batchId = item.getBatchId();
                         if (item.isPaused()) {
-                            resumeBatch(batchId);
+                            downloadManager.resumeBatch(batchId);
                         } else {
-                            pauseBatch(batchId);
+                            downloadManager.pauseBatch(batchId);
                         }
                         queryForDownloads();
                     }
@@ -73,22 +71,6 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
         );
 
         setupQueryingExample();
-    }
-
-    private void resumeBatch(long batchId) {
-        try {
-            downloadManager.pauseBatch(batchId);
-        } catch (BatchPauseException e) {
-            LLog.w(e.getLocalizedMessage());
-        }
-    }
-
-    private void pauseBatch(long batchId) {
-        try {
-            downloadManager.resumeBatch(batchId);
-        } catch (BatchResumeException e) {
-            LLog.w(e.getLocalizedMessage());
-        }
     }
 
     private void setupQueryingExample() {

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -47,9 +47,9 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                 Download item = adapter.getItem(position);
                 long batchId = item.getBatchId();
                 if (item.isPaused()) {
-                    downloadManager.resumeBatch(batchId);
+                    pauseBatch(batchId);
                 } else {
-                    downloadManager.pauseBatch(batchId);
+                    resumeBatch(batchId);
                 }
                 queryForDownloads();
             }
@@ -69,6 +69,22 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                 });
 
         setupQueryingExample();
+    }
+
+    private void resumeBatch(long batchId) {
+        try {
+            downloadManager.pauseBatch(batchId);
+        } catch (DownloadManager.ControlPauseException e) {
+            Log.w(e.getLocalizedMessage());
+        }
+    }
+
+    private void pauseBatch(long batchId) {
+        try {
+            downloadManager.resumeBatch(batchId);
+        } catch (DownloadManager.ControlResumeException e) {
+            Log.w(e.getLocalizedMessage());
+        }
     }
 
     private void setupQueryingExample() {

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -16,6 +16,8 @@ import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
 import com.novoda.downloadmanager.demo.extended.Download;
 import com.novoda.downloadmanager.demo.extended.QueryForDownloadsAsyncTask;
+import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchPauseException;
+import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchResumeException;
 import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
@@ -40,16 +42,20 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
         setContentView(R.layout.activity_pause_resume);
 
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                PauseResumeAdapter adapter = (PauseResumeAdapter) parent.getAdapter();
-                Download item = adapter.getItem(position);
-                long batchId = item.getBatchId();
-                if (item.isPaused()) {
-                    downloadManager.resumeBatch(batchId);
-                } else {
-                    downloadManager.pauseBatch(batchId);
+        listView.setOnItemClickListener(
+                new AdapterView.OnItemClickListener() {
+                    @Override
+                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                        PauseResumeAdapter adapter = (PauseResumeAdapter) parent.getAdapter();
+                        Download item = adapter.getItem(position);
+                        long batchId = item.getBatchId();
+                        if (item.isPaused()) {
+                            resumeBatch(batchId);
+                        } else {
+                            pauseBatch(batchId);
+                        }
+                        queryForDownloads();
+                    }
                 }
         );
         downloadManager = DownloadManagerBuilder.from(this)
@@ -72,16 +78,16 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
     private void resumeBatch(long batchId) {
         try {
             downloadManager.pauseBatch(batchId);
-        } catch (DownloadManager.ControlPauseException e) {
-            Log.w(e.getLocalizedMessage());
+        } catch (BatchPauseException e) {
+            LLog.w(e.getLocalizedMessage());
         }
     }
 
     private void pauseBatch(long batchId) {
         try {
             downloadManager.resumeBatch(batchId);
-        } catch (DownloadManager.ControlResumeException e) {
-            Log.w(e.getLocalizedMessage());
+        } catch (BatchResumeException e) {
+            LLog.w(e.getLocalizedMessage());
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchPauseResumeController.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchPauseResumeController.java
@@ -1,0 +1,58 @@
+package com.novoda.downloadmanager.lib;
+
+import android.content.ContentResolver;
+
+public class BatchPauseResumeController {
+
+    private final BatchRepository batchRepository;
+    private final DownloadsRepository downloadsRepository;
+    private final ContentResolver contentResolver;
+    private final DownloadsUriProvider downloadsUriProvider;
+
+    BatchPauseResumeController(ContentResolver contentResolver,
+                               DownloadsUriProvider downloadsUriProvider,
+                               BatchRepository batchRepository,
+                               DownloadsRepository downloadsRepository) {
+        this.contentResolver = contentResolver;
+        this.batchRepository = batchRepository;
+        this.downloadsRepository = downloadsRepository;
+        this.downloadsUriProvider = downloadsUriProvider;
+    }
+
+    public void pauseBatch(long batchId) throws BatchPauseException {
+        int batchStatus = batchRepository.getBatchStatus(batchId);
+        if (DownloadStatus.isRunning(batchStatus)) {
+            downloadsRepository.pauseDownloadWithBatchId(batchId);
+        } else {
+            throw new BatchPauseException("Batch " + batchId + " cannot be paused as is not currently running");
+        }
+    }
+
+    public void resumeBatch(long batchId) throws BatchResumeException {
+        int batchStatus = batchRepository.getBatchStatus(batchId);
+        if (DownloadStatus.isPausedByApp(batchStatus)) {
+            downloadsRepository.resumeDownloadWithBatchId(batchId);
+            batchRepository.updateBatchStatus(batchId, DownloadStatus.PENDING);
+            notifyBatchesHaveChanged();
+        } else {
+            throw new BatchResumeException("Batch " + batchId + " cannot be resumed as is not currently paused");
+        }
+    }
+
+    private void notifyBatchesHaveChanged() {
+        contentResolver.notifyChange(downloadsUriProvider.getBatchesUri(), null);
+        contentResolver.notifyChange(downloadsUriProvider.getBatchesWithoutProgressUri(), null);
+    }
+
+    public static class BatchPauseException extends Exception {
+        public BatchPauseException(String message) {
+            super(message);
+        }
+    }
+
+    public static class BatchResumeException extends Exception {
+        public BatchResumeException(String message) {
+            super(message);
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchPauseResumeController.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchPauseResumeController.java
@@ -19,40 +19,36 @@ public class BatchPauseResumeController {
         this.downloadsUriProvider = downloadsUriProvider;
     }
 
-    public void pauseBatch(long batchId) throws BatchPauseException {
+    /**
+     * Returns true if the batch was paused, false otherwise
+     */
+    public boolean pauseBatch(long batchId) {
         int batchStatus = batchRepository.getBatchStatus(batchId);
         if (DownloadStatus.isRunning(batchStatus)) {
             downloadsRepository.pauseDownloadWithBatchId(batchId);
+            return true;
         } else {
-            throw new BatchPauseException("Batch " + batchId + " cannot be paused as is not currently running");
+            return false;
         }
     }
 
-    public void resumeBatch(long batchId) throws BatchResumeException {
+    /**
+     * Returns true if the batch was resumed, false otherwise
+     */
+    public boolean resumeBatch(long batchId) {
         int batchStatus = batchRepository.getBatchStatus(batchId);
         if (DownloadStatus.isPausedByApp(batchStatus)) {
             downloadsRepository.resumeDownloadWithBatchId(batchId);
             batchRepository.updateBatchStatus(batchId, DownloadStatus.PENDING);
             notifyBatchesHaveChanged();
+            return true;
         } else {
-            throw new BatchResumeException("Batch " + batchId + " cannot be resumed as is not currently paused");
+            return false;
         }
     }
 
     private void notifyBatchesHaveChanged() {
         contentResolver.notifyChange(downloadsUriProvider.getBatchesUri(), null);
         contentResolver.notifyChange(downloadsUriProvider.getBatchesWithoutProgressUri(), null);
-    }
-
-    public static class BatchPauseException extends Exception {
-        public BatchPauseException(String message) {
-            super(message);
-        }
-    }
-
-    public static class BatchResumeException extends Exception {
-        public BatchResumeException(String message) {
-            super(message);
-        }
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -74,6 +74,28 @@ class BatchRepository {
     }
 
     int getBatchStatus(long batchId) {
+        String[] projection = {DownloadContract.Batches.COLUMN_STATUS};
+        String where = DownloadContract.Batches._ID + " = ?";
+        String[] selectionArgs = {String.valueOf(batchId)};
+
+        Cursor cursor = resolver.query(
+                downloadsUriProvider.getBatchesUri(),
+                projection,
+                where,
+                selectionArgs,
+                null);
+
+        try {
+            cursor.moveToFirst();
+            return cursor.getInt(0);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+    int calculateBatchStatus(long batchId) {
         Cursor cursor = null;
         statusCountMap.clear();
         try {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -451,7 +451,7 @@ public class DownloadManager {
         BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
 
         int batchStatus = batchRepository.getBatchStatus(batchId);
-        if (batchStatus == DownloadStatus.RUNNING) {
+        if (DownloadStatus.isRunning(batchStatus)) {
             ContentValues values = new ContentValues();
             String where = COLUMN_BATCH_ID + "= ? AND " + DownloadContract.Downloads.COLUMN_STATUS + " != ?";
             String[] selectionArgs = {String.valueOf(batchId), String.valueOf(DownloadStatus.SUCCESS)};
@@ -466,7 +466,7 @@ public class DownloadManager {
         BatchRepository batchRepository = new BatchRepository(contentResolver, downloadDeleter, downloadsUriProvider, systemFacade);
 
         int batchStatus = batchRepository.getBatchStatus(batchId);
-        if (batchStatus == DownloadStatus.PAUSED_BY_APP) {
+        if (DownloadStatus.isPausedByApp(batchStatus)) {
             ContentValues values = getResumeContentValues();
             String where = COLUMN_BATCH_ID + "= ? AND " + DownloadContract.Downloads.COLUMN_STATUS + " != ?";
             String[] selectionArgs = {String.valueOf(batchId), String.valueOf(DownloadStatus.SUCCESS)};

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -403,9 +403,7 @@ public class DownloadManager {
                      new DownloadsRepository(
                              contentResolver,
                              DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                             DownloadsUriProvider.getInstance(),
-                             new FileDownloadInfo.ControlStatus.Reader(contentResolver, DownloadsUriProvider.getInstance())
-                     )
+                             DownloadsUriProvider.getInstance())
              ),
              false);
     }
@@ -426,9 +424,7 @@ public class DownloadManager {
                      new DownloadsRepository(
                              contentResolver,
                              DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                             DownloadsUriProvider.getInstance(),
-                             new FileDownloadInfo.ControlStatus.Reader(contentResolver, DownloadsUriProvider.getInstance())
-                     )
+                             DownloadsUriProvider.getInstance())
              ),
              verboseLogging);
     }
@@ -450,9 +446,7 @@ public class DownloadManager {
                         new DownloadsRepository(
                                 contentResolver,
                                 DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                                DownloadsUriProvider.getInstance(),
-                                new FileDownloadInfo.ControlStatus.Reader(contentResolver, DownloadsUriProvider.getInstance())
-                        )
+                                DownloadsUriProvider.getInstance())
                 ),
                 false);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -30,8 +30,6 @@ import android.provider.Settings;
 import android.provider.Settings.SettingNotFoundException;
 import android.text.TextUtils;
 
-import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchPauseException;
-import com.novoda.downloadmanager.lib.BatchPauseResumeController.BatchResumeException;
 import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
@@ -436,25 +434,27 @@ public class DownloadManager {
     }
 
     DownloadManager(Context context, ContentResolver contentResolver, DownloadsUriProvider downloadsUriProvider) {
-        this(context,
-             contentResolver,
-             downloadsUriProvider,
-             new RealSystemFacade(context, new Clock()),
-             new BatchPauseResumeController(contentResolver,
-                                            DownloadsUriProvider.getInstance(),
-                                            new BatchRepository(
-                                                    contentResolver,
-                                                    new DownloadDeleter(contentResolver),
-                                                    DownloadsUriProvider.getInstance(),
-                                                    new RealSystemFacade(GlobalState.getContext(), new Clock())),
-                                            new DownloadsRepository(
-                                                    contentResolver,
-                                                    DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                                                    DownloadsUriProvider.getInstance(),
-                                                    new FileDownloadInfo.ControlStatus.Reader(contentResolver, DownloadsUriProvider.getInstance())
-                                            )
-             ),
-             false);
+        this(
+                context,
+                contentResolver,
+                downloadsUriProvider,
+                new RealSystemFacade(context, new Clock()),
+                new BatchPauseResumeController(
+                        contentResolver,
+                        DownloadsUriProvider.getInstance(),
+                        new BatchRepository(
+                                contentResolver,
+                                new DownloadDeleter(contentResolver),
+                                DownloadsUriProvider.getInstance(),
+                                new RealSystemFacade(GlobalState.getContext(), new Clock())),
+                        new DownloadsRepository(
+                                contentResolver,
+                                DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
+                                DownloadsUriProvider.getInstance(),
+                                new FileDownloadInfo.ControlStatus.Reader(contentResolver, DownloadsUriProvider.getInstance())
+                        )
+                ),
+                false);
     }
 
     DownloadManager(Context context,
@@ -505,12 +505,18 @@ public class DownloadManager {
         return ContentUris.parseId(downloadUri);
     }
 
-    public void pauseBatch(long batchId) throws BatchPauseException {
-        batchPauseResumeController.pauseBatch(batchId);
+    /**
+     * {@link BatchPauseResumeController#pauseBatch(long)}
+     */
+    public boolean pauseBatch(long batchId) {
+        return batchPauseResumeController.pauseBatch(batchId);
     }
 
-    public void resumeBatch(long batchId) throws BatchResumeException {
-        batchPauseResumeController.resumeBatch(batchId);
+    /**
+     * {@link BatchPauseResumeController#resumeBatch(long)}}
+     */
+    public boolean resumeBatch(long batchId) {
+        return batchPauseResumeController.resumeBatch(batchId);
     }
 
     public void removeDownload(URI uri) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -225,6 +225,10 @@ final class DownloadStatus {
         return status == DELETING;
     }
 
+    public static boolean isPausedByApp(int status) {
+        return status == PAUSED_BY_APP;
+    }
+
     /**
      * Returns whether the download did not start due to insufficient space
      */

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadThread.java
@@ -864,7 +864,7 @@ class DownloadThread implements Runnable {
     }
 
     private void updateBatchStatus(long batchId, long downloadId) {
-        int batchStatus = batchRepository.getBatchStatus(batchId);
+        int batchStatus = batchRepository.calculateBatchStatus(batchId);
 
         batchRepository.updateBatchStatus(batchId, batchStatus);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -6,6 +6,7 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 
+import com.novoda.downloadmanager.lib.logger.LLog;
 import com.novoda.notils.string.QueryUtils;
 import com.novoda.notils.string.StringUtils;
 
@@ -18,10 +19,7 @@ class DownloadsRepository {
     private final DownloadInfoCreator downloadInfoCreator;
     private final DownloadsUriProvider downloadsUriProvider;
 
-    public DownloadsRepository(ContentResolver contentResolver,
-                               DownloadInfoCreator downloadInfoCreator,
-                               DownloadsUriProvider downloadsUriProvider,
-                               FileDownloadInfo.ControlStatus.Reader controlReader) {
+    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator, DownloadsUriProvider downloadsUriProvider) {
         this.contentResolver = contentResolver;
         this.downloadInfoCreator = downloadInfoCreator;
         this.downloadsUriProvider = downloadsUriProvider;
@@ -101,19 +99,11 @@ class DownloadsRepository {
 
         FileDownloadInfo create(FileDownloadInfo.Reader reader);
 
-        FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id);
-
         class NonFunctional implements DownloadInfoCreator {
 
             @Override
             public FileDownloadInfo create(FileDownloadInfo.Reader reader) {
                 LLog.w("DownloadInfoCreator.NonFunctional.create()");
-                return null;
-            }
-
-            @Override
-            public FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id) {
-                LLog.w("DownloadInfoCreator.NonFunctional.ControlStatus.create()");
                 return null;
             }
         }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchStatusTests.java
@@ -26,7 +26,7 @@ public class BatchStatusTests {
     public void givenABatchWithSomeCompleteItemsAndSomeSubmittedItemsThenTheBatchStatusIsRunning() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUCCESS, DownloadStatus.SUBMITTED);
 
-        int batchStatus = repository.getBatchStatus(1);
+        int batchStatus = repository.calculateBatchStatus(1);
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
     }
@@ -35,7 +35,7 @@ public class BatchStatusTests {
     public void givenABatchWithItemsThatAreNotSubmittedOrSuccessThenTheBatchStatusIsNotRunning() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUCCESS, DownloadStatus.BATCH_FAILED);
 
-        int batchStatus = repository.getBatchStatus(1);
+        int batchStatus = repository.calculateBatchStatus(1);
 
         assertThat(batchStatus).isNotEqualTo(DownloadStatus.RUNNING);
     }
@@ -44,7 +44,7 @@ public class BatchStatusTests {
     public void givenABatchWithSubmittedAndSuccessStatesThenTheBatchStatusIsRunning() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUBMITTED, DownloadStatus.SUBMITTED, DownloadStatus.SUBMITTED, DownloadStatus.SUCCESS);
 
-        int batchStatus = repository.getBatchStatus(1);
+        int batchStatus = repository.calculateBatchStatus(1);
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.RUNNING);
     }
@@ -53,7 +53,7 @@ public class BatchStatusTests {
     public void givenABatchWithAllCompleteItemsThenTheBatchStatusIsSuccess() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.SUCCESS, DownloadStatus.SUCCESS);
 
-        int batchStatus = repository.getBatchStatus(1);
+        int batchStatus = repository.calculateBatchStatus(1);
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.SUCCESS);
     }
@@ -62,7 +62,7 @@ public class BatchStatusTests {
     public void givenABatchWithAllPendingItemsThenTheBatchStatusIsPending() {
         BatchRepository repository = givenABatchWithStatuses(DownloadStatus.PENDING, DownloadStatus.PENDING);
 
-        int batchStatus = repository.getBatchStatus(1);
+        int batchStatus = repository.calculateBatchStatus(1);
 
         assertThat(batchStatus).isEqualTo(DownloadStatus.PENDING);
     }


### PR DESCRIPTION
## Task description ##

I have noticed that a queued download can be paused and that causes the following bug:
- Proceed downloading two batches, the first one is running, the second one is queued
- Click to pause a queued batch, queued status stays in place
- Click to pause the running batch
- The queued batch does not start as it has been paused, but as is queued it should start

## Solution implemented ##

We should only be able to pause running batches, and resume paused ones

Before | After
--- | ---
![old](https://cloud.githubusercontent.com/assets/2845931/8875313/a4ff80f4-3218-11e5-967d-fb88fb8360ac.gif) | ![new](https://cloud.githubusercontent.com/assets/2845931/8875316/acf48e8a-3218-11e5-8b67-b2d0597b44bf.gif)
