### PR TITLE
simplifies logging

### DIFF
--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DemoApplication.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DemoApplication.java
@@ -5,7 +5,6 @@ import android.hardware.SensorManager;
 
 import com.novoda.downloadmanager.Download;
 import com.novoda.downloadmanager.lib.DownloadClientReadyChecker;
-import com.novoda.downloadmanager.lib.logger.LLog;
 
 public class DemoApplication extends Application implements DownloadClientReadyChecker {
 
@@ -15,7 +14,6 @@ public class DemoApplication extends Application implements DownloadClientReadyC
     public void onCreate() {
         super.onCreate();
         oneRuleToBindThem = new OneRuleToBindThem();
-        LLog.setShowLogs(true);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DemoApplication.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DemoApplication.java
@@ -5,7 +5,7 @@ import android.hardware.SensorManager;
 
 import com.novoda.downloadmanager.Download;
 import com.novoda.downloadmanager.lib.DownloadClientReadyChecker;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 public class DemoApplication extends Application implements DownloadClientReadyChecker {
 
@@ -15,7 +15,7 @@ public class DemoApplication extends Application implements DownloadClientReadyC
     public void onCreate() {
         super.onCreate();
         oneRuleToBindThem = new OneRuleToBindThem();
-        Log.setShowLogs(true);
+        LLog.setShowLogs(true);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
@@ -21,7 +21,7 @@ import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
 import com.novoda.downloadmanager.lib.RequestBatch;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,7 +41,6 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
         setContentView(R.layout.activity_batches);
         listView = (ListView) findViewById(R.id.main_downloads_list);
         downloadManager = DownloadManagerBuilder.from(this)
-                .withVerboseLogging()
                 .build();
         batchDownloadsAdapter = new BatchDownloadsAdapter(new ArrayList<Download>());
         listView.setAdapter(batchDownloadsAdapter);
@@ -100,7 +99,7 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
         batch.addRequest(request);
 
         long batchId = downloadManager.enqueue(batch);
-        Log.d("Download enqueued with batch ID: " + batchId);
+        LLog.d("Download enqueued with batch ID: " + batchId);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
@@ -31,47 +31,48 @@ public class BatchesActivity extends AppCompatActivity implements QueryForBatche
 
         ListView listView = (ListView) findViewById(R.id.show_batches_list);
         downloadManager = DownloadManagerBuilder.from(this)
-                .withVerboseLogging()
                 .build();
         adapter = new BatchesAdapter(new ArrayList<Batch>());
         listView.setAdapter(adapter);
 
         listView.setEmptyView(findViewById(R.id.show_batches_no_batches_view));
         RadioGroup queryGroup = (RadioGroup) findViewById(R.id.show_batches_query_radio_group);
-        queryGroup.setOnCheckedChangeListener(new RadioGroup.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(RadioGroup group, int checkedId) {
-                switch (checkedId) {
-                    case R.id.show_batches_query_all:
-                        query = BatchQuery.ALL;
-                        break;
-                    case R.id.show_batches_query_successful:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_SUCCESSFUL).build();
-                        break;
-                    case R.id.show_batches_query_pending:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_PENDING).build();
-                        break;
-                    case R.id.show_batches_query_downloading:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_RUNNING).build();
-                        break;
-                    case R.id.show_batches_query_failed:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_FAILED).build();
-                        break;
-                    case R.id.show_batches_query_failed_pending:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_FAILED | DownloadManager.STATUS_PENDING).build();
-                        break;
-                    case R.id.show_batches_query_live:
-                        query = new BatchQuery.Builder().withSortByLiveness().build();
-                        break;
-                    case R.id.show_batches_query_deleting:
-                        query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_DELETING).build();
-                        break;
-                    default:
-                        break;
+        queryGroup.setOnCheckedChangeListener(
+                new RadioGroup.OnCheckedChangeListener() {
+                    @Override
+                    public void onCheckedChanged(RadioGroup group, int checkedId) {
+                        switch (checkedId) {
+                            case R.id.show_batches_query_all:
+                                query = BatchQuery.ALL;
+                                break;
+                            case R.id.show_batches_query_successful:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_SUCCESSFUL).build();
+                                break;
+                            case R.id.show_batches_query_pending:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_PENDING).build();
+                                break;
+                            case R.id.show_batches_query_downloading:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_RUNNING).build();
+                                break;
+                            case R.id.show_batches_query_failed:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_FAILED).build();
+                                break;
+                            case R.id.show_batches_query_failed_pending:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_FAILED | DownloadManager.STATUS_PENDING).build();
+                                break;
+                            case R.id.show_batches_query_live:
+                                query = new BatchQuery.Builder().withSortByLiveness().build();
+                                break;
+                            case R.id.show_batches_query_deleting:
+                                query = new BatchQuery.Builder().withStatusFilter(DownloadManager.STATUS_DELETING).build();
+                                break;
+                            default:
+                                break;
+                        }
+                        queryForBatches(query);
+                    }
                 }
-                queryForBatches(query);
-            }
-        });
+        );
         queryForBatches(BatchQuery.ALL);
 
     }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
@@ -41,12 +41,13 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
         deleteAdapter = new DeleteAdapter(
-                new ArrayList<Download>(), new DeleteAdapter.Listener() {
-            @Override
-            public void onDelete(Download download) {
-                downloadManager.removeBatches(download.getBatchId());
-            }
-        }
+                new ArrayList<Download>(),
+                new DeleteAdapter.Listener() {
+                    @Override
+                    public void onDelete(Download download) {
+                        downloadManager.removeBatches(download.getBatchId());
+                    }
+                }
         );
         listView.setAdapter(deleteAdapter);
 

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
@@ -19,7 +19,7 @@ import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,14 +39,15 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
         setContentView(R.layout.activity_delete);
         listView = (ListView) findViewById(R.id.main_downloads_list);
         downloadManager = DownloadManagerBuilder.from(this)
-                .withVerboseLogging()
                 .build();
-        deleteAdapter = new DeleteAdapter(new ArrayList<Download>(), new DeleteAdapter.Listener() {
+        deleteAdapter = new DeleteAdapter(
+                new ArrayList<Download>(), new DeleteAdapter.Listener() {
             @Override
             public void onDelete(Download download) {
                 downloadManager.removeBatches(download.getBatchId());
             }
-        });
+        }
+        );
         listView.setAdapter(deleteAdapter);
 
         findViewById(R.id.single_download_button).setOnClickListener(
@@ -55,7 +56,8 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
                     public void onClick(@NonNull View v) {
                         enqueueSingleDownload();
                     }
-                });
+                }
+        );
 
         setupQueryingExample();
     }
@@ -79,7 +81,7 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
                 .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
 
         long requestId = downloadManager.enqueue(request);
-        Log.d("Download enqueued with request ID: " + requestId);
+        LLog.d("Download enqueued with request ID: " + requestId);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataActivity.java
@@ -17,7 +17,7 @@ import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.List;
 
@@ -37,7 +37,6 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
         setContentView(R.layout.activity_extra_data);
         listView = (ListView) findViewById(R.id.main_downloads_list);
         downloadManager = DownloadManagerBuilder.from(this)
-                .withVerboseLogging()
                 .build();
         downloadAdapter = new ExtraDataAdapter();
         listView.setAdapter(downloadAdapter);
@@ -48,7 +47,8 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
                     public void onClick(@NonNull View v) {
                         enqueueSingleDownload();
                     }
-                });
+                }
+        );
 
         setupQueryingExample();
     }
@@ -71,7 +71,7 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
                 .setNotificationVisibility(NotificationVisibility.ACTIVE_OR_COMPLETE);
 
         long requestId = downloadManager.enqueue(request);
-        Log.d("Download enqueued with request ID: " + requestId);
+        LLog.d("Download enqueued with request ID: " + requestId);
     }
 
     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeActivity.java
@@ -20,7 +20,7 @@ import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.NotificationVisibility;
 import com.novoda.downloadmanager.lib.Query;
 import com.novoda.downloadmanager.lib.Request;
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,22 +40,23 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
         setContentView(R.layout.activity_pause_resume);
 
         listView = (ListView) findViewById(R.id.main_downloads_list);
-        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                PauseResumeAdapter adapter = (PauseResumeAdapter) parent.getAdapter();
-                Download item = adapter.getItem(position);
-                long batchId = item.getBatchId();
-                if (item.isPaused()) {
-                    downloadManager.resumeBatch(batchId);
-                } else {
-                    downloadManager.pauseBatch(batchId);
+        listView.setOnItemClickListener(
+                new AdapterView.OnItemClickListener() {
+                    @Override
+                    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                        PauseResumeAdapter adapter = (PauseResumeAdapter) parent.getAdapter();
+                        Download item = adapter.getItem(position);
+                        long batchId = item.getBatchId();
+                        if (item.isPaused()) {
+                            downloadManager.resumeBatch(batchId);
+                        } else {
+                            downloadManager.pauseBatch(batchId);
+                        }
+                        queryForDownloads();
+                    }
                 }
-                queryForDownloads();
-            }
-        });
+        );
         downloadManager = DownloadManagerBuilder.from(this)
-                .withVerboseLogging()
                 .build();
         pauseResumeAdapter = new PauseResumeAdapter(new ArrayList<Download>());
         listView.setAdapter(pauseResumeAdapter);
@@ -66,7 +67,8 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                     public void onClick(@NonNull View v) {
                         enqueueSingleDownload();
                     }
-                });
+                }
+        );
 
         setupQueryingExample();
     }
@@ -92,7 +94,7 @@ public class PauseResumeActivity extends AppCompatActivity implements QueryForDo
                 .alwaysAttemptResume();
 
         long requestId = downloadManager.enqueue(request);
-        Log.d("Download enqueued with request ID: " + requestId);
+        LLog.d("Download enqueued with request ID: " + requestId);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/ConcurrentDownloadsLimitProvider.java
@@ -4,7 +4,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 class ConcurrentDownloadsLimitProvider {
 
@@ -24,7 +24,7 @@ class ConcurrentDownloadsLimitProvider {
             ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
             return getMaximumConcurrentDownloads(applicationInfo.metaData);
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
+            LLog.e("Application info not found for: " + packageName + " " + e.getMessage());
             return DEFAULT_MAX_CONCURRENT_DOWNLOADS;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/ContentLengthFetcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/ContentLengthFetcher.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager.lib;
 
 import android.util.Pair;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -37,7 +37,7 @@ class ContentLengthFetcher {
             }
 
         } catch (IOException e) {
-            Log.e("Could not fetch content length.");
+            LLog.e("Could not fetch content length.");
         } finally {
             if (conn != null) {
                 conn.disconnect();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseFilenameProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseFilenameProvider.java
@@ -5,7 +5,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 class DatabaseFilenameProvider {
     private static final String DATABASE_FILENAME = "com.novoda.downloadmanager.DatabaseFilename";
@@ -24,7 +24,7 @@ class DatabaseFilenameProvider {
             ApplicationInfo applicationInfo = packageManager.getApplicationInfo(packageName, PackageManager.GET_META_DATA);
             return getDatabaseFilename(applicationInfo.metaData);
         } catch (PackageManager.NameNotFoundException e) {
-            Log.e("Application info not found for: " + packageName + " " + e.getMessage());
+            LLog.e("Application info not found for: " + packageName + " " + e.getMessage());
             return defaultFilename;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -7,7 +7,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.NonNull;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 /**
  * Creates and updated database on demand when opening it.
@@ -87,7 +87,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
      */
     @Override
     public void onCreate(@NonNull SQLiteDatabase db) {
-        Log.v("populating new database");
+        LLog.v("populating new database");
         createDownloadsTable(db);
         createHeadersTable(db);
         createBatchesTable(db);
@@ -157,7 +157,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                             + Constants.MEDIA_SCANNED + " BOOLEAN);"
             );
         } catch (SQLException ex) {
-            Log.e("couldn't create table in downloads database");
+            LLog.e("couldn't create table in downloads database");
             throw ex;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadDeleter.java
@@ -5,7 +5,7 @@ import android.content.ContentValues;
 import android.net.Uri;
 import android.text.TextUtils;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 
@@ -37,10 +37,10 @@ class DownloadDeleter {
 
     private void deleteFileIfExists(String path) {
         if (!TextUtils.isEmpty(path)) {
-            Log.d("deleteFileIfExists() deleting " + path);
+            LLog.d("deleteFileIfExists() deleting " + path);
             final File file = new File(path);
             if (file.exists() && !file.delete()) {
-                Log.w("file: '" + path + "' couldn't be deleted");
+                LLog.w("file: '" + path + "' couldn't be deleted");
             }
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -31,7 +31,7 @@ import android.provider.Settings.SettingNotFoundException;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -487,7 +487,7 @@ public class DownloadManager {
                 removeDownloads(id);
                 return;
             }
-            Log.e("Didn't delete anything for uri: " + uri);
+            LLog.e("Didn't delete anything for uri: " + uri);
         } finally {
             if (cursor != null) {
                 cursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -410,7 +410,6 @@ public class DownloadManager {
         this.systemFacade = systemFacade;
         GlobalState.setContext(context);
         GlobalState.setVerboseLogging(verboseLogging);
-        Log.setShowLogs(verboseLogging);
     }
 
     /**
@@ -482,7 +481,9 @@ public class DownloadManager {
                     downloadsUriProvider.getContentUri(),
                     new String[]{"_id"},
                     DownloadContract.Downloads.COLUMN_FILE_NAME_HINT + "=?",
-                    new String[]{uri.toString()}, null);
+                    new String[]{uri.toString()},
+                    null
+            );
             if (cursor.moveToFirst()) {
                 long id = cursor.getLong(cursor.getColumnIndexOrThrow("_id"));
                 removeDownloads(id);
@@ -558,7 +559,8 @@ public class DownloadManager {
                 downloadsUriProvider.getBatchesUri(),
                 valuesDelete,
                 getWhereClauseFor(batchesIds, DownloadContract.Downloads._ID),
-                longArrayToStringArray(batchesIds));
+                longArrayToStringArray(batchesIds)
+        );
     }
 
     /**
@@ -630,7 +632,8 @@ public class DownloadManager {
                 int status = cursor.getInt(cursor.getColumnIndexOrThrow(COLUMN_STATUS));
                 if (DownloadManager.STATUS_SUCCESSFUL == status) {
                     int indx = cursor.getColumnIndexOrThrow(
-                            DownloadContract.Downloads.COLUMN_DESTINATION);
+                            DownloadContract.Downloads.COLUMN_DESTINATION
+                    );
                     int destination = cursor.getInt(indx);
                     // TODO: if we ever add API to DownloadManager to let the caller specify
                     // non-external storage for a downloaded file, then the following code
@@ -644,7 +647,8 @@ public class DownloadManager {
                     } else {
                         // return public uri
                         String path = cursor.getString(
-                                cursor.getColumnIndexOrThrow(COLUMN_LOCAL_FILENAME));
+                                cursor.getColumnIndexOrThrow(COLUMN_LOCAL_FILENAME)
+                        );
                         return Uri.fromFile(new File(path));
                     }
                 }
@@ -704,7 +708,8 @@ public class DownloadManager {
                 if (status != STATUS_SUCCESSFUL && status != STATUS_FAILED) {
                     throw new IllegalArgumentException(
                             "Cannot restart incomplete download: "
-                                    + cursor.getLong(cursor.getColumnIndex(COLUMN_ID)));
+                                    + cursor.getLong(cursor.getColumnIndex(COLUMN_ID))
+                    );
                 }
             }
         } finally {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadNotifier.java
@@ -23,7 +23,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.v4.util.SimpleArrayMap;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -182,6 +182,6 @@ class DownloadNotifier {
     }
 
     public void dumpSpeeds() {
-        Log.e("dump at speed");
+        LLog.e("dump at speed");
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -38,7 +38,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -291,7 +291,7 @@ public final class DownloadProvider extends ContentProvider {
             appInfo = getContext().getPackageManager().
                     getApplicationInfo("com.android.defcontainer", 0);
         } catch (NameNotFoundException e) {
-            Log.wtf("Could not get ApplicationInfo for com.android.defconatiner", e);
+            LLog.wtf(e, "Could not get ApplicationInfo for com.android.defconatiner");
         }
         if (appInfo != null) {
             defcontaineruid = appInfo.uid;
@@ -304,7 +304,7 @@ public final class DownloadProvider extends ContentProvider {
 //        try {
 //            android.os.SELinux.restorecon(downloadsDataDir.getCanonicalPath());
 //        } catch (IOException e) {
-//            Log.wtf("Could not get canonical path for download directory", e);
+//            LLog.wtf("Could not get canonical path for download directory", e);
 //        }
         return true;
     }
@@ -350,7 +350,7 @@ public final class DownloadProvider extends ContentProvider {
                 return DOWNLOADS_BY_BATCH_TYPE;
 
             default:
-                Log.v("calling getType on an unknown URI: " + uri);
+                LLog.v("calling getType on an unknown URI: " + uri);
                 throw new IllegalArgumentException("Unknown URI: " + uri);
 
         }
@@ -373,7 +373,7 @@ public final class DownloadProvider extends ContentProvider {
             notifyBatchesStatusChanged();
             return ContentUris.withAppendedId(downloadsUriProvider.getBatchesUri(), rowId);
         }
-        Log.d("calling insert on an unknown/invalid URI: " + uri);
+        LLog.d("calling insert on an unknown/invalid URI: " + uri);
         throw new IllegalArgumentException("Unknown/Invalid URI " + uri);
 
     }
@@ -492,14 +492,14 @@ public final class DownloadProvider extends ContentProvider {
 
         copyInteger(DownloadContract.Downloads.COLUMN_BATCH_ID, values, filteredValues);
 
-        Log.v("initiating download with UID " + filteredValues.getAsInteger(Constants.UID));
+        LLog.v("initiating download with UID " + filteredValues.getAsInteger(Constants.UID));
         if (filteredValues.containsKey(DownloadContract.Downloads.COLUMN_OTHER_UID)) {
-            Log.v("other UID " + filteredValues.getAsInteger(DownloadContract.Downloads.COLUMN_OTHER_UID));
+            LLog.v("other UID " + filteredValues.getAsInteger(DownloadContract.Downloads.COLUMN_OTHER_UID));
         }
 
         long rowID = db.insert(DownloadContract.Downloads.DOWNLOADS_TABLE_NAME, null, filteredValues);
         if (rowID == -1) {
-            Log.d("couldn't insert into downloads database");
+            LLog.d("couldn't insert into downloads database");
             return null;
         }
 
@@ -578,7 +578,7 @@ public final class DownloadProvider extends ContentProvider {
                 }
                 return queryRequestHeaders(db, uri);
             default:
-                Log.v("querying unknown URI: " + uri);
+                LLog.v("querying unknown URI: " + uri);
                 throw new IllegalArgumentException("Unknown URI: " + uri);
         }
     }
@@ -618,10 +618,10 @@ public final class DownloadProvider extends ContentProvider {
                 fullSelection.getParameters(), null, null, sort);
 
         if (ret == null) {
-            Log.v("query failed in downloads database");
+            LLog.v("query failed in downloads database");
         } else {
             ret.setNotificationUri(getContext().getContentResolver(), uri);
-            Log.v("created cursor " + ret + " on behalf of " + Binder.getCallingPid());
+            LLog.v("created cursor " + ret + " on behalf of " + Binder.getCallingPid());
         }
         return ret;
     }
@@ -669,7 +669,7 @@ public final class DownloadProvider extends ContentProvider {
         sb.append("sort is ");
         sb.append(sort);
         sb.append(".");
-        Log.v(sb.toString());
+        LLog.v(sb.toString());
     }
 
     private String getDownloadIdFromUri(final Uri uri) {
@@ -803,7 +803,7 @@ public final class DownloadProvider extends ContentProvider {
                 notifyStatusIfBatchesStatusChanged(values);
                 break;
             default:
-                Log.d("updating unknown/invalid URI: " + uri);
+                LLog.d("updating unknown/invalid URI: " + uri);
                 throw new UnsupportedOperationException("Cannot update URI: " + uri);
         }
 
@@ -899,7 +899,7 @@ public final class DownloadProvider extends ContentProvider {
                 break;
 
             default:
-                Log.d("deleting unknown/invalid URI: " + uri);
+                LLog.d("deleting unknown/invalid URI: " + uri);
                 throw new UnsupportedOperationException("Cannot delete URI: " + uri);
         }
         notifyContentChanged(uri, match);
@@ -937,7 +937,7 @@ public final class DownloadProvider extends ContentProvider {
             throw new FileNotFoundException("No filename found.");
         }
         if (!Helpers.isFilenameValid(path, downloadsDataDir)) {
-            Log.d("INTERNAL FILE DOWNLOAD LOL COMMENTED EXCEPTION");
+            LLog.d("INTERNAL FILE DOWNLOAD LOL COMMENTED EXCEPTION");
 //            throw new FileNotFoundException("Invalid filename: " + path);
         }
         if (!"r".equals(mode)) {
@@ -949,7 +949,7 @@ public final class DownloadProvider extends ContentProvider {
                 ParcelFileDescriptor.MODE_READ_ONLY);
 
         if (ret == null) {
-            Log.v("couldn't open file");
+            LLog.v("couldn't open file");
             throw new FileNotFoundException("couldn't open file");
         }
         return ret;
@@ -957,37 +957,38 @@ public final class DownloadProvider extends ContentProvider {
 
     @Override
     public void dump(FileDescriptor fd, @NonNull PrintWriter writer, String[] args) {
-        Log.e("I want dump, but nothing to dump into");
+        LLog.e("I want dump, but nothing to dump into");
     }
 
     private void logVerboseOpenFileInfo(Uri uri, String mode) {
-        Log.v(
+        LLog.v(
                 "openFile uri: " + uri + ", mode: " + mode
-                        + ", uid: " + Binder.getCallingUid());
+                        + ", uid: " + Binder.getCallingUid()
+        );
         Cursor cursor = query(downloadsUriProvider.getContentUri(), new String[]{"_id"}, null, null, "_id");
         if (cursor == null) {
-            Log.v("null cursor in openFile");
+            LLog.v("null cursor in openFile");
         } else {
             if (!cursor.moveToFirst()) {
-                Log.v("empty cursor in openFile");
+                LLog.v("empty cursor in openFile");
             } else {
                 do {
-                    Log.v("row " + cursor.getInt(0) + " available");
+                    LLog.v("row " + cursor.getInt(0) + " available");
                 } while (cursor.moveToNext());
             }
             cursor.close();
         }
         cursor = query(uri, new String[]{"_data"}, null, null, null);
         if (cursor == null) {
-            Log.v("null cursor in openFile");
+            LLog.v("null cursor in openFile");
         } else {
             if (!cursor.moveToFirst()) {
-                Log.v("empty cursor in openFile");
+                LLog.v("empty cursor in openFile");
             } else {
                 String filename = cursor.getString(0);
-                Log.v("filename in openFile: " + filename);
+                LLog.v("filename in openFile: " + filename);
                 if (new java.io.File(filename).isFile()) {
-                    Log.v("file exists in openFile");
+                    LLog.v("file exists in openFile");
                 }
             }
             cursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -16,7 +16,7 @@ import android.os.HandlerThread;
 import android.support.annotation.NonNull;
 import android.widget.Toast;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import static android.content.Intent.ACTION_BOOT_COMPLETED;
 import static android.content.Intent.ACTION_MEDIA_MOUNTED;
@@ -158,7 +158,7 @@ public class DownloadReceiver extends BroadcastReceiver {
         try {
             context.startActivity(intent);
         } catch (ActivityNotFoundException ex) {
-            Log.d("no activity for " + intent, ex);
+            LLog.d("no activity for " + intent, ex);
             Toast.makeText(context, "Cannot open file", Toast.LENGTH_LONG).show();
         }
     }
@@ -182,7 +182,7 @@ public class DownloadReceiver extends BroadcastReceiver {
                     context.getContentResolver().update(uri, values, null, null);
                 }
             } else {
-                Log.w("Missing details for download " + batchId);
+                LLog.w("Missing details for download " + batchId);
             }
         } finally {
             cursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadScanner.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadScanner.java
@@ -25,7 +25,7 @@ import android.media.MediaScannerConnection.MediaScannerConnectionClient;
 import android.net.Uri;
 import android.os.SystemClock;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -97,7 +97,7 @@ class DownloadScanner implements MediaScannerConnectionClient {
      * @see #hasPendingScans()
      */
     public void requestScan(FileDownloadInfo info) {
-        Log.v("requestScan() for " + info.getFileName());
+        LLog.v("requestScan() for " + info.getFileName());
         synchronized (mediaScannerConnection) {
             final ScanRequest req = new ScanRequest(info.getId(), info.getFileName(), info.getMimeType());
             pendingRequests.put(req.path, req);
@@ -130,7 +130,7 @@ class DownloadScanner implements MediaScannerConnectionClient {
             req = pendingRequests.remove(path);
         }
         if (req == null) {
-            Log.w("Missing request for path " + path);
+            LLog.w("Missing request for path " + path);
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -34,7 +34,7 @@ import android.os.Message;
 import android.os.Process;
 import android.support.annotation.NonNull;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -112,7 +112,7 @@ public class DownloadService extends Service {
     @Override
     public void onCreate() {
         super.onCreate();
-        Log.v("Service onCreate");
+        LLog.v("Service onCreate");
 
         if (systemFacade == null) {
             systemFacade = new RealSystemFacade(this, new Clock());
@@ -186,7 +186,7 @@ public class DownloadService extends Service {
      */
     private FileDownloadInfo createNewDownloadInfo(FileDownloadInfo.Reader reader) {
         FileDownloadInfo info = reader.newDownloadInfo(systemFacade, downloadsUriProvider);
-        Log.v("processing inserted download " + info.getId());
+        LLog.v("processing inserted download " + info.getId());
         return info;
     }
 
@@ -211,7 +211,7 @@ public class DownloadService extends Service {
     @Override
     public int onStartCommand(@NonNull Intent intent, int flags, int startId) {
         int returnValue = super.onStartCommand(intent, flags, startId);
-        Log.v("Service onStart");
+        LLog.v("Service onStart");
         lastStartId = startId;
         enqueueUpdate();
         return returnValue;
@@ -220,12 +220,12 @@ public class DownloadService extends Service {
     @Override
     public void onDestroy() {
         shutDown();
-        Log.v("Service onDestroy");
+        LLog.v("Service onDestroy");
         super.onDestroy();
     }
 
     private void shutDown() {
-        Log.d("Shutting down service");
+        LLog.d("Shutting down service");
         getContentResolver().unregisterContentObserver(downloadManagerContentObserver);
         downloadScanner.shutdown();
         executor.shutdownNow();
@@ -261,7 +261,7 @@ public class DownloadService extends Service {
 
             final int startId = msg.arg1;
             if (DEBUG_LIFECYCLE) {
-                Log.v("Updating for startId " + startId);
+                LLog.v("Updating for startId " + startId);
             }
 
             // Since database is current source of truth, our "active" status
@@ -278,14 +278,14 @@ public class DownloadService extends Service {
                 for (Map.Entry<Thread, StackTraceElement[]> entry :
                         Thread.getAllStackTraces().entrySet()) {
                     if (entry.getKey().getName().startsWith("pool")) {
-                        Log.d(entry.getKey() + ": " + Arrays.toString(entry.getValue()));
+                        LLog.d(entry.getKey() + ": " + Arrays.toString(entry.getValue()));
                     }
                 }
 
                 // Dump speed and update details
                 downloadNotifier.dumpSpeeds();
 
-                Log.wtf("Final update pass triggered, isActive=" + isActive, new IllegalStateException("someone didn't update correctly"));
+                LLog.wtf(new IllegalStateException("someone didn't update correctly"), "Final update pass triggered, isActive=" + isActive);
             }
 
             if (isActive) {
@@ -303,7 +303,7 @@ public class DownloadService extends Service {
 
                 if (stopSelfResult(startId)) {
                     if (DEBUG_LIFECYCLE) {
-                        Log.v("Nothing left; stopped");
+                        LLog.v("Nothing left; stopped");
                     }
                     shutDown();
                 }
@@ -363,7 +363,7 @@ public class DownloadService extends Service {
         // Set alarm when next action is in future. It's okay if the service
         // continues to run in meantime, since it will kick off an update pass.
         if (nextRetryTimeMillis > 0 && nextRetryTimeMillis < Long.MAX_VALUE) {
-            Log.v("scheduling start in " + nextRetryTimeMillis + "ms");
+            LLog.v("scheduling start in " + nextRetryTimeMillis + "ms");
 
             Intent intent = new Intent(Constants.ACTION_RETRY);
             intent.setClass(this, DownloadReceiver.class);
@@ -437,6 +437,6 @@ public class DownloadService extends Service {
 
     @Override
     protected void dump(FileDescriptor fd, @NonNull PrintWriter writer, String[] args) {
-        Log.e("I want to dump but nothing to dump into");
+        LLog.e("I want to dump but nothing to dump into");
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -8,7 +8,7 @@ import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -367,7 +367,7 @@ class FileDownloadInfo {
             return true;
         }
 
-        Log.e("Flag allowTarUpdates set but file not matching Tar mimeType, functionality will be disabled.");
+        LLog.e("Flag allowTarUpdates set but file not matching Tar mimeType, functionality will be disabled.");
         return false;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/GlobalState.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/GlobalState.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager.lib;
 
 import android.content.Context;
 
+import com.novoda.downloadmanager.lib.logger.LLog;
+
 class GlobalState {
 
     private static Context context;
@@ -20,6 +22,7 @@ class GlobalState {
     }
 
     public static void setVerboseLogging(boolean verboseLogging) {
+        LLog.setShowLogs(verboseLogging);
         GlobalState.verboseLogging = verboseLogging;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Helpers.java
@@ -21,7 +21,7 @@ import android.os.Environment;
 import android.os.SystemClock;
 import android.webkit.MimeTypeMap;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 import java.io.IOException;
@@ -121,7 +121,7 @@ class Helpers {
             filename = base.getPath() + File.separator + filename;
         }
 
-        Log.v("target file: " + filename + extension);
+        LLog.v("target file: " + filename + extension);
 
         synchronized (UNIQUE_LOCK) {
             final String path = chooseUniqueFilenameLocked(
@@ -144,7 +144,7 @@ class Helpers {
 
         // First, try to use the hint from the application, if there's one
         if (hint != null && !hint.endsWith("/")) {
-            Log.v("getting filename from hint");
+            LLog.v("getting filename from hint");
             int index = hint.lastIndexOf('/') + 1;
             if (index > 0) {
                 filename = hint.substring(index);
@@ -157,7 +157,7 @@ class Helpers {
         if (filename == null && contentDisposition != null) {
             filename = parseContentDisposition(contentDisposition);
             if (filename != null) {
-                Log.v("getting filename from content-disposition");
+                LLog.v("getting filename from content-disposition");
                 int index = filename.lastIndexOf('/') + 1;
                 if (index > 0) {
                     filename = filename.substring(index);
@@ -171,7 +171,7 @@ class Helpers {
             if (decodedContentLocation != null
                     && !decodedContentLocation.endsWith("/")
                     && decodedContentLocation.indexOf('?') < 0) {
-                Log.v("getting filename from content-location");
+                LLog.v("getting filename from content-location");
                 int index = decodedContentLocation.lastIndexOf('/') + 1;
                 if (index > 0) {
                     filename = decodedContentLocation.substring(index);
@@ -188,7 +188,7 @@ class Helpers {
                     && !decodedUrl.endsWith("/") && decodedUrl.indexOf('?') < 0) {
                 int index = decodedUrl.lastIndexOf('/') + 1;
                 if (index > 0) {
-                    Log.v("getting filename from uri");
+                    LLog.v("getting filename from uri");
                     filename = decodedUrl.substring(index);
                 }
             }
@@ -196,7 +196,7 @@ class Helpers {
 
         // Finally, if couldn't get filename from URI, get a generic filename
         if (filename == null) {
-            Log.v("using default filename");
+            LLog.v("using default filename");
             filename = Constants.DEFAULT_DL_FILENAME;
         }
 
@@ -212,23 +212,23 @@ class Helpers {
         if (mimeType != null) {
             extension = MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType);
             if (extension != null) {
-                Log.v("adding extension from type");
+                LLog.v("adding extension from type");
                 extension = "." + extension;
             } else {
-                Log.v("couldn't find extension for " + mimeType);
+                LLog.v("couldn't find extension for " + mimeType);
             }
         }
         if (extension == null) {
             if (mimeType != null && mimeType.toLowerCase(Locale.US).startsWith("text/")) {
                 if (mimeType.equalsIgnoreCase("text/html")) {
-                    Log.v("adding default html extension");
+                    LLog.v("adding default html extension");
                     extension = Constants.DEFAULT_DL_HTML_EXTENSION;
                 } else if (useDefaults) {
-                    Log.v("adding default text extension");
+                    LLog.v("adding default text extension");
                     extension = Constants.DEFAULT_DL_TEXT_EXTENSION;
                 }
             } else if (useDefaults) {
-                Log.v("adding default binary extension");
+                LLog.v("adding default binary extension");
                 extension = Constants.DEFAULT_DL_BINARY_EXTENSION;
             }
         }
@@ -246,14 +246,14 @@ class Helpers {
             if (typeFromExt == null || !typeFromExt.equalsIgnoreCase(mimeType)) {
                 extension = chooseExtensionFromMimeType(mimeType, false);
                 if (extension != null) {
-                    Log.v("substituting extension from type");
+                    LLog.v("substituting extension from type");
                 } else {
-                    Log.v("couldn't find extension for " + mimeType);
+                    LLog.v("couldn't find extension for " + mimeType);
                 }
             }
         }
         if (extension == null) {
-            Log.v("keeping extension");
+            LLog.v("keeping extension");
             extension = filename.substring(lastDotIndex);
         }
         return extension;
@@ -292,7 +292,7 @@ class Helpers {
                 if (!new File(fullFilename).exists()) {
                     return fullFilename;
                 }
-                Log.v("file with sequence number " + sequence + " exists");
+                LLog.v("file with sequence number " + sequence + " exists");
                 sequence += sRandom.nextInt(magnitude) + 1;
             }
         }
@@ -325,7 +325,7 @@ class Helpers {
                 throw new IllegalArgumentException("syntax error");
             }
         } catch (RuntimeException ex) {
-            Log.d("invalid selection [" + selection + "] triggered " + ex);
+            LLog.d("invalid selection [" + selection + "] triggered " + ex);
         }
 
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/IOHelpers.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/IOHelpers.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager.lib;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.Closeable;
 import java.io.FileDescriptor;
@@ -24,7 +24,7 @@ final class IOHelpers {
                 outFd.sync();
             }
         } catch (IOException e) {
-            Log.e("Fail sync");
+            LLog.e("Fail sync");
         } finally {
             closeQuietly(out);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/RealSystemFacade.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/RealSystemFacade.java
@@ -24,7 +24,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.telephony.TelephonyManager;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 class RealSystemFacade implements SystemFacade {
     private final Context context;
@@ -61,7 +61,7 @@ class RealSystemFacade implements SystemFacade {
     public boolean isNetworkRoaming() {
         ConnectivityManager connectivity = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         if (connectivity == null) {
-            Log.w("couldn't get connectivity manager");
+            LLog.w("couldn't get connectivity manager");
             return false;
         }
 
@@ -70,7 +70,7 @@ class RealSystemFacade implements SystemFacade {
         TelephonyManager telephony = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
         boolean isRoaming = isMobile && telephony.isNetworkRoaming();
         if (isRoaming) {
-            Log.v("network is roaming");
+            LLog.v("network is roaming");
         }
         return isRoaming;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/SizeLimitActivity.java
@@ -11,7 +11,7 @@ import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.text.format.Formatter;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.util.LinkedList;
 import java.util.Queue;
@@ -64,7 +64,7 @@ public class SizeLimitActivity extends Activity implements DialogInterface.OnCan
         Cursor cursor = getContentResolver().query(currentUri, null, null, null, null);
         try {
             if (!cursor.moveToFirst()) {
-                Log.e("Empty cursor for URI " + currentUri);
+                LLog.e("Empty cursor for URI " + currentUri);
                 dialogClosed();
                 return;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -26,7 +26,7 @@ import android.os.Environment;
 import android.os.StatFs;
 import android.text.TextUtils;
 
-import com.novoda.notils.logger.simple.Log;
+import com.novoda.downloadmanager.lib.logger.LLog;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -145,7 +145,7 @@ class StorageManager {
     void verifySpace(int destination, String path, long length) throws StopRequestException {
         resetBytesDownloadedSinceLastCheckOnSpace();
         File dir = null;
-//        Log.i("in verifySpace, destination: " + destination + ", path: " + path + ", length: " + length);
+//        LLog.i("in verifySpace, destination: " + destination + ", path: " + path + ", length: " + length);
         if (path == null) {
             throw new IllegalArgumentException("path can't be null");
         }
@@ -214,7 +214,7 @@ class StorageManager {
                  * few MB of space left on the filesystem.
                  */
                 if (root.equals(systemCacheDir)) {
-                    Log.w("System cache dir ('/cache') is running low on space." + "space available (in bytes): " + bytesAvailable);
+                    LLog.w("System cache dir ('/cache') is running low on space." + "space available (in bytes): " + bytesAvailable);
                 } else {
                     throw new StopRequestException(
                             DownloadStatus.INSUFFICIENT_SPACE_ERROR,
@@ -227,7 +227,7 @@ class StorageManager {
             bytesAvailable = getAvailableBytesInDownloadsDataDir(downloadDataDir);
             if (bytesAvailable < DOWNLOAD_DATA_DIR_LOW_SPACE_THRESHOLD_BYTES) {
                 // print a warning
-                Log.w("Downloads data dir: " + root + " is running low on space. space available (in bytes): " + bytesAvailable);
+                LLog.w("Downloads data dir: " + root + " is running low on space. space available (in bytes): " + bytesAvailable);
             }
             if (bytesAvailable < targetBytes) {
                 // Insufficient space; make space.
@@ -303,7 +303,7 @@ class StorageManager {
      * the total byte size is greater than targetBytes
      */
     private long discardPurgeableFiles(int destination, long targetBytes) {
-        Log.i("discardPurgeableFiles: destination = " + destination + ", targetBytes = " + targetBytes);
+        LLog.i("discardPurgeableFiles: destination = " + destination + ", targetBytes = " + targetBytes);
         String destStr = (destination == DownloadsDestination.DESTINATION_SYSTEMCACHE_PARTITION) ?
                 String.valueOf(destination) :
                 String.valueOf(DownloadsDestination.DESTINATION_CACHE_PARTITION_PURGEABLE);
@@ -327,7 +327,7 @@ class StorageManager {
                 if (TextUtils.isEmpty(data)) continue;
 
                 File file = new File(data);
-                Log.d("purging " + file.getAbsolutePath() + " for " + file.length() + " bytes");
+                LLog.d("purging " + file.getAbsolutePath() + " for " + file.length() + " bytes");
                 totalFreed += file.length();
                 file.delete();
                 long id = cursor.getLong(cursor.getColumnIndex(DownloadContract.Downloads._ID));
@@ -336,7 +336,7 @@ class StorageManager {
         } finally {
             cursor.close();
         }
-        Log.i("Purged files, freed " + totalFreed + " for " + targetBytes + " requested");
+        LLog.i("Purged files, freed " + totalFreed + " for " + targetBytes + " requested");
         return totalFreed;
     }
 
@@ -348,7 +348,7 @@ class StorageManager {
      * This is not a very common occurrence. So, do this only once in a while.
      */
     private void removeSpuriousFiles() {
-        Log.i("in removeSpuriousFiles");
+        LLog.i("in removeSpuriousFiles");
         // get a list of all files in system cache dir and downloads data dir
         List<File> files = new ArrayList<>();
         File[] listOfFiles = systemCacheDir.listFiles();
@@ -369,7 +369,7 @@ class StorageManager {
                 while (cursor.moveToNext()) {
                     String filename = cursor.getString(0);
                     if (!TextUtils.isEmpty(filename)) {
-                        Log.v("in removeSpuriousFiles, preserving file " + filename);
+                        LLog.v("in removeSpuriousFiles, preserving file " + filename);
                         files.remove(new File(filename));
                     }
                 }
@@ -387,13 +387,13 @@ class StorageManager {
 //            try {
 //                final StructStat stat = Libcore.os.stat(path);
 //                if (stat.st_uid == myUid) {
-            Log.v("deleting spurious file " + path);
+            LLog.v("deleting spurious file " + path);
             if (file.delete()) {
-                Log.v("spurious file deleted");
+                LLog.v("spurious file deleted");
             }
 //                }
 //            } catch (ErrnoException e) {
-//                Log.w("stat(" + path + ") result: " + e);
+//                LLog.w("stat(" + path + ") result: " + e);
 //            }
         }
     }
@@ -404,7 +404,7 @@ class StorageManager {
      * in memory - so that this method can limit the amount of data read.
      */
     private void trimDatabase() {
-        Log.i("in trimDatabase");
+        LLog.i("in trimDatabase");
         Cursor cursor = null;
         try {
             cursor = contentResolver.query(
@@ -414,7 +414,7 @@ class StorageManager {
                     DownloadContract.Downloads.COLUMN_LAST_MODIFICATION);
             if (cursor == null) {
                 // This isn't good - if we can't do basic queries in our database, nothings gonna work
-                Log.e("null cursor in trimDatabase");
+                LLog.e("null cursor in trimDatabase");
                 return;
             }
             if (cursor.moveToFirst()) {
@@ -434,7 +434,7 @@ class StorageManager {
             // trimming the database raised an exception. alright, ignore the exception
             // and return silently. trimming database is not exactly a critical operation
             // and there is no need to propagate the exception.
-            Log.w("trimDatabase failed with exception: " + e.getMessage());
+            LLog.w("trimDatabase failed with exception: " + e.getMessage());
             return;
         } finally {
             if (cursor != null) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
@@ -7,7 +7,7 @@ public final class LLog {
 
     private static boolean INITIALISED = false;
 
-    public static String TAG = "DownloadManager";
+    private static final String TAG = "DownloadManager";
 
     private LLog() {
         // util class

--- a/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
@@ -1,0 +1,86 @@
+package com.novoda.downloadmanager.lib.logger;
+
+/**
+ * Wrapper around Android LLog that can be easily toggled for libraries
+ */
+public final class LLog {
+
+    private static boolean INITIALISED = false;
+
+    public static String TAG = "DownloadManager";
+
+    private LLog() {
+        // util class
+    }
+
+    public static void v(Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.v(TAG, formatString(msg));
+        }
+    }
+
+    public static void i(Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.i(TAG, formatString(msg));
+        }
+    }
+
+    public static void d(Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.d(TAG, formatString(msg));
+        }
+    }
+
+    public static void w(Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.w(TAG, formatString(msg));
+        }
+    }
+
+    public static void e(Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.e(TAG, formatString(msg));
+        }
+    }
+
+    public static void w(Throwable t, Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.w(TAG, formatString(msg), t);
+        }
+    }
+
+    public static void d(Throwable t, Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.d(TAG, formatString(msg), t);
+        }
+    }
+
+    public static void e(Throwable t, Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.e(TAG, formatString(msg), t);
+        }
+    }
+
+    public static void wtf(Throwable t, Object... msg) {
+        if (shouldShowLogs()) {
+            android.util.Log.wtf(TAG, formatString(msg), t);
+        }
+    }
+
+    private static String formatString(Object... msg) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Object o : msg) {
+            String separator = " ";
+            stringBuilder.append(String.valueOf(o)).append(separator);
+        }
+        return stringBuilder.toString();
+    }
+
+    public static void setShowLogs(boolean showLogs) {
+        LLog.INITIALISED = showLogs;
+    }
+
+    public static boolean shouldShowLogs() {
+        return INITIALISED;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/logger/LLog.java
@@ -8,6 +8,7 @@ public final class LLog {
     private static boolean INITIALISED = false;
 
     private static final String TAG = "DownloadManager";
+    private static final String SEPARATOR = " ";
 
     private LLog() {
         // util class
@@ -70,8 +71,7 @@ public final class LLog {
     private static String formatString(Object... msg) {
         StringBuilder stringBuilder = new StringBuilder();
         for (Object o : msg) {
-            String separator = " ";
-            stringBuilder.append(String.valueOf(o)).append(separator);
+            stringBuilder.append(String.valueOf(o)).append(SEPARATOR);
         }
         return stringBuilder.toString();
     }


### PR DESCRIPTION
Removes NoTils Logger in favour of one that doesn't query the stacktraces when it logs.

This won't impact performance in production but will contribute to perceived performance in debugging.

The test here was using the advanced demo and pressing "download a batch of items" the screenies show from start to completion.

| before |
| --- |
|![screen shot 2015-07-24 at 15 23 42](https://cloud.githubusercontent.com/assets/655860/8876581/83218b26-3218-11e5-89b8-1e73533fbe36.png)|

| after |
| --- |
|![screen shot 2015-07-24 at 15 21 58](https://cloud.githubusercontent.com/assets/655860/8876587/86d9d3d6-3218-11e5-94da-a6cf1672fe8a.png)|

LLog == Library Log


![screen shot 2015-07-24 at 15 36 07](https://cloud.githubusercontent.com/assets/655860/8876770/ba426c0a-3219-11e5-9d3b-b7c42839b535.png)
