### PR TITLE
Reducing control reader query method allocations

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -173,11 +173,6 @@ public class DownloadService extends Service {
             public FileDownloadInfo create(FileDownloadInfo.Reader reader) {
                 return createNewDownloadInfo(reader);
             }
-
-            @Override
-            public FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id) {
-                return createNewDownloadInfoControlStatus(reader, id);
-            }
         }, downloadsUriProvider);
 
     }
@@ -190,10 +185,6 @@ public class DownloadService extends Service {
         FileDownloadInfo info = reader.newDownloadInfo(systemFacade, downloadsUriProvider);
         LLog.v("processing inserted download " + info.getId());
         return info;
-    }
-
-    private FileDownloadInfo.ControlStatus createNewDownloadInfoControlStatus(FileDownloadInfo.ControlStatus.Reader reader, long id) {
-        return reader.newControlStatus();
     }
 
     private DownloadClientReadyChecker getDownloadClientReadyChecker() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -17,14 +17,11 @@ class DownloadsRepository {
     private final ContentResolver contentResolver;
     private final DownloadInfoCreator downloadInfoCreator;
     private final DownloadsUriProvider downloadsUriProvider;
-    private final FileDownloadInfo.ControlStatus.Reader controlReader;
 
-    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator, DownloadsUriProvider downloadsUriProvider,
-                               FileDownloadInfo.ControlStatus.Reader controlReader) {
+    public DownloadsRepository(ContentResolver contentResolver, DownloadInfoCreator downloadInfoCreator, DownloadsUriProvider downloadsUriProvider) {
         this.contentResolver = contentResolver;
         this.downloadInfoCreator = downloadInfoCreator;
         this.downloadsUriProvider = downloadsUriProvider;
-        this.controlReader = controlReader;
     }
 
     public List<FileDownloadInfo> getAllDownloads() {
@@ -59,10 +56,6 @@ class DownloadsRepository {
         } finally {
             downloadsCursor.close();
         }
-    }
-
-    public FileDownloadInfo.ControlStatus getDownloadInfoControlStatusFor(long id) {
-        return downloadInfoCreator.create(controlReader, id);
     }
 
     public void moveDownloadsStatusTo(List<Long> ids, int status) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -74,8 +74,6 @@ class DownloadsRepository {
 
     interface DownloadInfoCreator {
         FileDownloadInfo create(FileDownloadInfo.Reader reader);
-
-        FileDownloadInfo.ControlStatus create(FileDownloadInfo.ControlStatus.Reader reader, long id);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -487,8 +487,11 @@ class FileDownloadInfo {
 
         static final class Reader {
 
+            private static final String[] PROJECTION = new String[]{
+                    DownloadContract.Downloads.COLUMN_CONTROL, DownloadContract.Downloads.COLUMN_STATUS
+            };
+
             private final ContentResolver contentResolver;
-            public static final String[] PROJECTION = new String[]{DownloadContract.Downloads.COLUMN_CONTROL, DownloadContract.Downloads.COLUMN_STATUS};
             private final Uri downloadUri;
 
             public Reader(ContentResolver contentResolver, Uri downloadUri) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -488,17 +488,16 @@ class FileDownloadInfo {
         static final class Reader {
 
             private final ContentResolver contentResolver;
-            private final DownloadsUriProvider downloadsUriProvider;
+            public static final String[] PROJECTION = new String[]{DownloadContract.Downloads.COLUMN_CONTROL, DownloadContract.Downloads.COLUMN_STATUS};
+            private final Uri downloadUri;
 
-            public Reader(ContentResolver contentResolver, DownloadsUriProvider downloadsUriProvider) {
+            public Reader(ContentResolver contentResolver, Uri downloadUri) {
                 this.contentResolver = contentResolver;
-                this.downloadsUriProvider = downloadsUriProvider;
+                this.downloadUri = downloadUri;
             }
 
-            public ControlStatus newControlStatus(long id) {
-                String[] projection = {DownloadContract.Downloads.COLUMN_CONTROL, DownloadContract.Downloads.COLUMN_STATUS};
-                Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id);
-                Cursor downloadsCursor = contentResolver.query(uri, projection, null, null, null);
+            public ControlStatus newControlStatus() {
+                Cursor downloadsCursor = contentResolver.query(downloadUri, PROJECTION, null, null, null);
                 try {
                     downloadsCursor.moveToFirst();
                     int control = downloadsCursor.getInt(0);


### PR DESCRIPTION
More transfer data while(true) loop allocation reductions!

Forces the `ControlStatus.Reader` to be constructed with all its query dependencies rather than creating them each time a query is requested.

This means we don't have to create the uri or projection upon querying

Allocations for a single GC from a fresh install

| Before | After
| --- | --- 
|<img width="644" alt="download-before" src="https://cloud.githubusercontent.com/assets/1848238/8889090/6ddde110-32c2-11e5-920d-493a436004b7.png">|<img width="622" alt="download-after" src="https://cloud.githubusercontent.com/assets/1848238/8889093/7da05c4a-32c2-11e5-9c1d-50f4046b3fbe.png">

Total allocations before **81,034** After **80,375**