### PR TITLE
Replace ListView with RecyclerView in demos

### DIFF
--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -30,4 +30,5 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/QueryForDownloadsAsyncTask.java
@@ -2,6 +2,7 @@ package com.novoda.downloadmanager.demo.extended;
 
 import android.database.Cursor;
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
 
 import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.Query;
@@ -25,7 +26,7 @@ public class QueryForDownloadsAsyncTask extends AsyncTask<Query, Void, List<Down
     }
 
     @Override
-    protected List<Download> doInBackground(Query... params) {
+    protected List<Download> doInBackground(@NonNull Query... params) {
         Cursor cursor = downloadManager.query(params[0]);
         List<Download> downloads = new ArrayList<>();
         try {
@@ -43,7 +44,7 @@ public class QueryForDownloadsAsyncTask extends AsyncTask<Query, Void, List<Down
     }
 
     @Override
-    protected void onPostExecute(List<Download> downloads) {
+    protected void onPostExecute(@NonNull List<Download> downloads) {
         super.onPostExecute(downloads);
         Callback callback = weakCallback.get();
         if (callback == null) {

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsActivity.java
@@ -9,8 +9,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.widget.ListView;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
@@ -32,18 +33,22 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private DownloadManager downloadManager;
-    private ListView listView;
     private BatchDownloadsAdapter batchDownloadsAdapter;
+    private View emptyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_batches);
-        listView = (ListView) findViewById(R.id.main_downloads_list);
+
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.main_downloads_list);
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
         batchDownloadsAdapter = new BatchDownloadsAdapter(new ArrayList<Download>());
-        listView.setAdapter(batchDownloadsAdapter);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setAdapter(batchDownloadsAdapter);
+
+        emptyView = findViewById(R.id.main_no_downloads_view);
 
         findViewById(R.id.batch_download_button).setOnClickListener(
                 new View.OnClickListener() {
@@ -66,7 +71,6 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
 
     private void setupQueryingExample() {
         queryForDownloads();
-        listView.setEmptyView(findViewById(R.id.main_no_downloads_view));
     }
 
     private void queryForDownloads() {
@@ -126,6 +130,7 @@ public class BatchDownloadsActivity extends AppCompatActivity implements QueryFo
     @Override
     public void onQueryResult(List<Download> downloads) {
         batchDownloadsAdapter.updateDownloads(downloads);
+        emptyView.setVisibility(downloads.isEmpty() ? View.VISIBLE : View.GONE);
     }
 
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchDownloadsAdapter.java
@@ -1,8 +1,8 @@
 package com.novoda.downloadmanager.demo.extended.batches;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
@@ -11,46 +11,46 @@ import com.novoda.downloadmanager.demo.extended.Download;
 import java.util.List;
 import java.util.Locale;
 
-public class BatchDownloadsAdapter extends BaseAdapter {
+public class BatchDownloadsAdapter extends RecyclerView.Adapter<BatchDownloadsAdapter.ViewHolder> {
     private final List<Download> downloads;
 
     public BatchDownloadsAdapter(List<Download> downloads) {
         this.downloads = downloads;
     }
 
-    @Override
-    public int getCount() {
-        return downloads.size();
-    }
-
-    @Override
-    public Download getItem(int position) {
-        return downloads.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_download, null);
-
-        final Download download = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
-
-        titleTextView.setText(download.getTitle());
-        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
-        locationTextView.setText(text);
-
-        return view;
-    }
-
     public void updateDownloads(List<Download> downloads) {
         this.downloads.clear();
         this.downloads.addAll(downloads);
         notifyDataSetChanged();
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_download, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        final Download download = downloads.get(position);
+        viewHolder.titleTextView.setText(download.getTitle());
+        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
+        viewHolder.locationTextView.setText(text);
+    }
+
+    @Override
+    public int getItemCount() {
+        return downloads.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView titleTextView;
+        private final TextView locationTextView;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            titleTextView = (TextView) itemView.findViewById(R.id.download_title_text);
+            locationTextView = (TextView) itemView.findViewById(R.id.download_location_text);
+        }
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesActivity.java
@@ -5,7 +5,9 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.v7.app.AppCompatActivity;
-import android.widget.ListView;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
 import android.widget.RadioGroup;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
@@ -23,19 +25,21 @@ public class BatchesActivity extends AppCompatActivity implements QueryForBatche
     private DownloadManager downloadManager;
     private BatchesAdapter adapter;
     private BatchQuery query = BatchQuery.ALL;
+    private View emptyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_show_batches);
 
-        ListView listView = (ListView) findViewById(R.id.show_batches_list);
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.show_batches_list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
         adapter = new BatchesAdapter(new ArrayList<Batch>());
-        listView.setAdapter(adapter);
+        recyclerView.setAdapter(adapter);
 
-        listView.setEmptyView(findViewById(R.id.show_batches_no_batches_view));
+        emptyView = findViewById(R.id.show_batches_no_batches_view);
         RadioGroup queryGroup = (RadioGroup) findViewById(R.id.show_batches_query_radio_group);
         queryGroup.setOnCheckedChangeListener(
                 new RadioGroup.OnCheckedChangeListener() {
@@ -105,5 +109,6 @@ public class BatchesActivity extends AppCompatActivity implements QueryForBatche
     @Override
     public void onQueryResult(List<Batch> batches) {
         adapter.updateBatches(batches);
+        emptyView.setVisibility(batches.isEmpty() ? View.VISIBLE : View.GONE);
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/batches/BatchesAdapter.java
@@ -1,8 +1,8 @@
 package com.novoda.downloadmanager.demo.extended.batches;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
@@ -10,54 +10,58 @@ import com.novoda.downloadmanager.demo.R;
 import java.util.List;
 import java.util.Locale;
 
-public class BatchesAdapter extends BaseAdapter {
+public class BatchesAdapter extends RecyclerView.Adapter<BatchesAdapter.ViewHolder> {
     private final List<Batch> batches;
 
     public BatchesAdapter(List<Batch> batches) {
         this.batches = batches;
     }
 
-    @Override
-    public int getCount() {
-        return batches.size();
-    }
-
-    @Override
-    public Batch getItem(int position) {
-        return batches.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_batch, null);
-
-        final Batch batch = getItem(position);
-        TextView idTextView = (TextView) view.findViewById(R.id.batch_id_text);
-        TextView titleTextView = (TextView) view.findViewById(R.id.batch_title_text);
-        TextView statusTextView = (TextView) view.findViewById(R.id.batch_status_text);
-        TextView totalSizeTextView = (TextView) view.findViewById(R.id.batch_total_size_text);
-        TextView currentSizeTextView = (TextView) view.findViewById(R.id.batch_current_size_text);
-        TextView extraDataTextView = (TextView) view.findViewById(R.id.batch_extra_data_text);
-
-        idTextView.setText(String.format(Locale.getDefault(), "Id: %d", batch.getId()));
-        titleTextView.setText(batch.getTitle());
-        String status = String.format(Locale.getDefault(), "Status: %s", batch.getDownloadStatusText());
-        statusTextView.setText(status);
-        totalSizeTextView.setText(String.format(Locale.getDefault(), "Total size: %d bytes", batch.getTotalBytes()));
-        currentSizeTextView.setText(String.format(Locale.getDefault(), "Current size: %d bytes", batch.getCurrentBytes()));
-        extraDataTextView.setText(batch.getExtraData());
-
-        return view;
-    }
-
     public void updateBatches(List<Batch> batches) {
         this.batches.clear();
         this.batches.addAll(batches);
         notifyDataSetChanged();
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_batch, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        Batch batch = batches.get(position);
+        viewHolder.idTextView.setText(String.format(Locale.getDefault(), "Id: %d", batch.getId()));
+        viewHolder.titleTextView.setText(batch.getTitle());
+        String status = String.format(Locale.getDefault(), "Status: %s", batch.getDownloadStatusText());
+        viewHolder.statusTextView.setText(status);
+        viewHolder.totalSizeTextView.setText(String.format(Locale.getDefault(), "Total size: %d bytes", batch.getTotalBytes()));
+        viewHolder.currentSizeTextView.setText(String.format(Locale.getDefault(), "Current size: %d bytes", batch.getCurrentBytes()));
+        viewHolder.extraDataTextView.setText(batch.getExtraData());
+    }
+
+    @Override
+    public int getItemCount() {
+        return batches.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView idTextView;
+        private final TextView titleTextView;
+        private final TextView statusTextView;
+        private final TextView totalSizeTextView;
+        private final TextView currentSizeTextView;
+        private final TextView extraDataTextView;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            idTextView = (TextView) itemView.findViewById(R.id.batch_id_text);
+            titleTextView = (TextView) itemView.findViewById(R.id.batch_title_text);
+            statusTextView = (TextView) itemView.findViewById(R.id.batch_status_text);
+            totalSizeTextView = (TextView) itemView.findViewById(R.id.batch_total_size_text);
+            currentSizeTextView = (TextView) itemView.findViewById(R.id.batch_current_size_text);
+            extraDataTextView = (TextView) itemView.findViewById(R.id.batch_extra_data_text);
+        }
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteActivity.java
@@ -8,8 +8,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.widget.ListView;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
@@ -30,14 +31,16 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private DownloadManager downloadManager;
-    private ListView listView;
     private DeleteAdapter deleteAdapter;
+    private View emptyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_delete);
-        listView = (ListView) findViewById(R.id.main_downloads_list);
+
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.main_downloads_list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
         deleteAdapter = new DeleteAdapter(
@@ -49,7 +52,9 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
                     }
                 }
         );
-        listView.setAdapter(deleteAdapter);
+        recyclerView.setAdapter(deleteAdapter);
+
+        emptyView = findViewById(R.id.main_no_downloads_view);
 
         findViewById(R.id.single_download_button).setOnClickListener(
                 new View.OnClickListener() {
@@ -65,7 +70,6 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
 
     private void setupQueryingExample() {
         queryForDownloads();
-        listView.setEmptyView(findViewById(R.id.main_no_downloads_view));
     }
 
     private void queryForDownloads() {
@@ -109,6 +113,7 @@ public class DeleteActivity extends AppCompatActivity implements QueryForDownloa
     @Override
     public void onQueryResult(List<Download> downloads) {
         deleteAdapter.updateDownloads(downloads);
+        emptyView.setVisibility(downloads.isEmpty() ? View.VISIBLE : View.GONE);
     }
 
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/delete/DeleteAdapter.java
@@ -1,9 +1,9 @@
 package com.novoda.downloadmanager.demo.extended.delete;
 
 import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.Button;
 import android.widget.TextView;
 
@@ -13,61 +13,13 @@ import com.novoda.downloadmanager.demo.extended.Download;
 import java.util.List;
 import java.util.Locale;
 
-public class DeleteAdapter extends BaseAdapter {
+public class DeleteAdapter extends RecyclerView.Adapter<DeleteAdapter.ViewHolder> {
     private final List<Download> downloads;
     private final Listener listener;
-
-    public DeleteAdapter(List<Download> downloads) {
-        this(downloads, null);
-    }
 
     public DeleteAdapter(List<Download> downloads, Listener listener) {
         this.downloads = downloads;
         this.listener = listener;
-    }
-
-    @Override
-    public int getCount() {
-        return downloads.size();
-    }
-
-    @Override
-    public Download getItem(int position) {
-        return downloads.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_download_delete, null);
-
-        final Download download = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
-        Button deleteButton = (Button) view.findViewById(R.id.download_delete_button);
-
-        titleTextView.setText(download.getTitle());
-        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
-        locationTextView.setText(text);
-
-        if (listener == null) {
-            deleteButton.setVisibility(View.GONE);
-            deleteButton.setOnClickListener(null);
-        } else {
-            deleteButton.setVisibility(View.VISIBLE);
-            deleteButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(@NonNull View v) {
-                    listener.onDelete(download);
-                }
-            });
-        }
-
-        return view;
     }
 
     public void updateDownloads(List<Download> downloads) {
@@ -76,7 +28,55 @@ public class DeleteAdapter extends BaseAdapter {
         notifyDataSetChanged();
     }
 
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_download_delete, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        final Download download = downloads.get(position);
+
+        viewHolder.titleTextView.setText(download.getTitle());
+        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
+        viewHolder.locationTextView.setText(text);
+
+        if (listener == null) {
+            viewHolder.deleteButton.setVisibility(View.GONE);
+            viewHolder.deleteButton.setOnClickListener(null);
+        } else {
+            viewHolder.deleteButton.setVisibility(View.VISIBLE);
+            viewHolder.deleteButton.setOnClickListener(
+                    new View.OnClickListener() {
+                        @Override
+                        public void onClick(@NonNull View v) {
+                            listener.onDelete(download);
+                        }
+                    }
+            );
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return downloads.size();
+    }
+
     public interface Listener {
         void onDelete(Download download);
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView titleTextView;
+        private final TextView locationTextView;
+        private final Button deleteButton;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            titleTextView = (TextView) itemView.findViewById(R.id.download_title_text);
+            locationTextView = (TextView) itemView.findViewById(R.id.download_location_text);
+            deleteButton = (Button) itemView.findViewById(R.id.download_delete_button);
+        }
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataActivity.java
@@ -7,8 +7,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.widget.ListView;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
@@ -25,21 +26,25 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
     private static final String BIG_FILE = "http://download.thinkbroadband.com/20MB.zip";
 
     private final Handler handler = new Handler(Looper.getMainLooper());
-    private DownloadManager downloadManager;
-    private ListView listView;
-    private ExtraDataAdapter downloadAdapter;
-
     private final QueryTimestamp lastQueryTimestamp = new QueryTimestamp();
+
+    private DownloadManager downloadManager;
+    private ExtraDataAdapter downloadAdapter;
+    private View emptyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_extra_data);
-        listView = (ListView) findViewById(R.id.main_downloads_list);
+
+        RecyclerView recyclerView = (RecyclerView) findViewById(R.id.main_downloads_list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
         downloadAdapter = new ExtraDataAdapter();
-        listView.setAdapter(downloadAdapter);
+        recyclerView.setAdapter(downloadAdapter);
+
+        emptyView = findViewById(R.id.main_no_downloads_view);
 
         findViewById(R.id.download_button).setOnClickListener(
                 new View.OnClickListener() {
@@ -55,7 +60,6 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
 
     private void setupQueryingExample() {
         queryForDownloads();
-        listView.setEmptyView(findViewById(R.id.main_no_downloads_view));
     }
 
     private void queryForDownloads() {
@@ -102,5 +106,6 @@ public class ExtraDataActivity extends AppCompatActivity implements QueryForExtr
     @Override
     public void onQueryResult(List<ExtraDataDownload> extraDataDownloads) {
         downloadAdapter.updateDownloads(extraDataDownloads);
+        emptyView.setVisibility(extraDataDownloads.isEmpty() ? View.VISIBLE : View.GONE);
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/extra_data/ExtraDataAdapter.java
@@ -1,8 +1,8 @@
 package com.novoda.downloadmanager.demo.extended.extra_data;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
@@ -11,46 +11,46 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-public class ExtraDataAdapter extends BaseAdapter {
+public class ExtraDataAdapter extends RecyclerView.Adapter<ExtraDataAdapter.ViewHolder> {
     private final List<ExtraDataDownload> extraDataDownloads;
 
     public ExtraDataAdapter() {
         this.extraDataDownloads = new ArrayList<>();
     }
 
-    @Override
-    public int getCount() {
-        return extraDataDownloads.size();
-    }
-
-    @Override
-    public ExtraDataDownload getItem(int position) {
-        return extraDataDownloads.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_extra_data_download, null);
-
-        ExtraDataDownload extraDataDownload = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
-
-        titleTextView.setText(extraDataDownload.getTitle());
-        String text = String.format(Locale.getDefault(), "%1$s : %2$s", extraDataDownload.getTitle(), extraDataDownload.getExtraData());
-        locationTextView.setText(text);
-
-        return view;
-    }
-
     public void updateDownloads(List<ExtraDataDownload> extraDataDownloads) {
         this.extraDataDownloads.clear();
         this.extraDataDownloads.addAll(extraDataDownloads);
         notifyDataSetChanged();
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_extra_data_download, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        final ExtraDataDownload extraDataDownload = extraDataDownloads.get(position);
+        viewHolder.titleTextView.setText(extraDataDownload.getTitle());
+        String text = String.format(Locale.getDefault(), "%1$s : %2$s", extraDataDownload.getTitle(), extraDataDownload.getExtraData());
+        viewHolder.locationTextView.setText(text);
+    }
+
+    @Override
+    public int getItemCount() {
+        return extraDataDownloads.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView titleTextView;
+        private final TextView locationTextView;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            titleTextView = (TextView) itemView.findViewById(R.id.download_title_text);
+            locationTextView = (TextView) itemView.findViewById(R.id.download_location_text);
+        }
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeAdapter.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/pause_resume/PauseResumeAdapter.java
@@ -1,8 +1,9 @@
 package com.novoda.downloadmanager.demo.extended.pause_resume;
 
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
@@ -11,46 +12,62 @@ import com.novoda.downloadmanager.demo.extended.Download;
 import java.util.List;
 import java.util.Locale;
 
-public class PauseResumeAdapter extends BaseAdapter {
+public class PauseResumeAdapter extends RecyclerView.Adapter<PauseResumeAdapter.ViewHolder> {
     private final List<Download> downloads;
+    private final Listener listener;
 
-    public PauseResumeAdapter(List<Download> downloads) {
+    public PauseResumeAdapter(List<Download> downloads, Listener listener) {
         this.downloads = downloads;
-    }
-
-    @Override
-    public int getCount() {
-        return downloads.size();
-    }
-
-    @Override
-    public Download getItem(int position) {
-        return downloads.get(position);
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_download, null);
-
-        final Download download = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
-
-        titleTextView.setText(download.getTitle());
-        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
-        locationTextView.setText(text);
-
-        return view;
+        this.listener = listener;
     }
 
     public void updateDownloads(List<Download> downloads) {
         this.downloads.clear();
         this.downloads.addAll(downloads);
         notifyDataSetChanged();
+    }
+
+    @Override
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_download, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        final Download download = downloads.get(position);
+        viewHolder.titleTextView.setText(download.getTitle());
+        String text = String.format(Locale.getDefault(), "%1$s : %2$s\nBatch %3$d", download.getDownloadStatusText(), download.getFileName(), download.getBatchId());
+        viewHolder.locationTextView.setText(text);
+        viewHolder.root.setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(@NonNull View v) {
+                        listener.onItemClick(download);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public int getItemCount() {
+        return downloads.size();
+    }
+
+    interface Listener {
+        void onItemClick(Download download);
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final View root;
+        private final TextView titleTextView;
+        private final TextView locationTextView;
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+            root = itemView;
+            titleTextView = (TextView) itemView.findViewById(R.id.download_title_text);
+            locationTextView = (TextView) itemView.findViewById(R.id.download_location_text);
+        }
     }
 }

--- a/demo-extended/src/main/res/layout/activity_batches.xml
+++ b/demo-extended/src/main/res/layout/activity_batches.xml
@@ -28,8 +28,7 @@
   <TextView
     android:id="@+id/main_no_downloads_view"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="100"
+    android:layout_height="wrap_content"
     android:gravity="center"
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />

--- a/demo-extended/src/main/res/layout/activity_batches.xml
+++ b/demo-extended/src/main/res/layout/activity_batches.xml
@@ -34,7 +34,7 @@
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/main_downloads_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/demo-extended/src/main/res/layout/activity_delete.xml
+++ b/demo-extended/src/main/res/layout/activity_delete.xml
@@ -28,7 +28,7 @@
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/main_downloads_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/demo-extended/src/main/res/layout/activity_delete.xml
+++ b/demo-extended/src/main/res/layout/activity_delete.xml
@@ -22,8 +22,7 @@
   <TextView
     android:id="@+id/main_no_downloads_view"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="100"
+    android:layout_height="wrap_content"
     android:gravity="center"
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />

--- a/demo-extended/src/main/res/layout/activity_extra_data.xml
+++ b/demo-extended/src/main/res/layout/activity_extra_data.xml
@@ -28,7 +28,7 @@
     android:text="@string/no_downloads"
     android:textAppearance="?android:textAppearanceMedium" />
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/main_downloads_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/demo-extended/src/main/res/layout/activity_extra_data.xml
+++ b/demo-extended/src/main/res/layout/activity_extra_data.xml
@@ -22,8 +22,7 @@
   <TextView
     android:id="@+id/main_no_downloads_view"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="100"
+    android:layout_height="wrap_content"
     android:gravity="center"
     android:text="@string/no_downloads"
     android:textAppearance="?android:textAppearanceMedium" />

--- a/demo-extended/src/main/res/layout/activity_pause_resume.xml
+++ b/demo-extended/src/main/res/layout/activity_pause_resume.xml
@@ -28,7 +28,7 @@
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/main_downloads_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/demo-extended/src/main/res/layout/activity_pause_resume.xml
+++ b/demo-extended/src/main/res/layout/activity_pause_resume.xml
@@ -22,8 +22,7 @@
   <TextView
     android:id="@+id/main_no_downloads_view"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="100"
+    android:layout_height="wrap_content"
     android:gravity="center"
     android:textAppearance="?android:textAppearanceMedium"
     android:text="@string/no_downloads" />

--- a/demo-extended/src/main/res/layout/activity_show_batches.xml
+++ b/demo-extended/src/main/res/layout/activity_show_batches.xml
@@ -69,18 +69,17 @@
       android:text="@string/live" />
   </RadioGroup>
 
+  <TextView
+    android:id="@+id/show_batches_no_batches_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center"
+    android:textAppearance="?android:textAppearanceMedium"
+    android:text="@string/no_batches" />
+
   <android.support.v7.widget.RecyclerView
     android:id="@+id/show_batches_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />
-
-  <TextView
-    android:id="@+id/show_batches_no_batches_view"
-    android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="100"
-    android:gravity="center"
-    android:textAppearance="?android:textAppearanceMedium"
-    android:text="@string/no_batches" />
 
 </LinearLayout>

--- a/demo-extended/src/main/res/layout/activity_show_batches.xml
+++ b/demo-extended/src/main/res/layout/activity_show_batches.xml
@@ -69,7 +69,7 @@
       android:text="@string/live" />
   </RadioGroup>
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/show_batches_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -30,4 +30,5 @@ android {
 dependencies {
     compile project(':library')
     compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:recyclerview-v7:22.2.1'
 }

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/DownloadAdapter.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/DownloadAdapter.java
@@ -1,15 +1,15 @@
 package com.novoda.downloadmanager.demo.simple;
 
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.novoda.downloadmanager.demo.R;
 
 import java.util.List;
 
-class DownloadAdapter extends BaseAdapter {
+class DownloadAdapter extends RecyclerView.Adapter<DownloadAdapter.ViewHolder> {
     private final List<Download> downloads;
 
     public DownloadAdapter(List<Download> downloads) {
@@ -17,31 +17,31 @@ class DownloadAdapter extends BaseAdapter {
     }
 
     @Override
-    public int getCount() {
+    public ViewHolder onCreateViewHolder(ViewGroup viewGroup, int position) {
+        return new ViewHolder(View.inflate(viewGroup.getContext(), R.layout.list_item_download, null));
+    }
+
+    @Override
+    public void onBindViewHolder(ViewHolder viewHolder, int position) {
+        final Download download = downloads.get(position);
+        viewHolder.titleTextView.setText(download.getTitle());
+        viewHolder.locationTextView.setText(download.getDownloadStatusText() + ": " + download.getFileName());
+    }
+
+    @Override
+    public int getItemCount() {
         return downloads.size();
     }
 
-    @Override
-    public Download getItem(int position) {
-        return downloads.get(position);
-    }
+    static class ViewHolder extends RecyclerView.ViewHolder {
 
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
+        private final TextView titleTextView;
+        private final TextView locationTextView;
 
-    @Override
-    public View getView(int position, View convertView, ViewGroup parent) {
-        View view = View.inflate(parent.getContext(), R.layout.list_item_download, null);
-
-        Download download = getItem(position);
-        TextView titleTextView = (TextView) view.findViewById(R.id.download_title_text);
-        TextView locationTextView = (TextView) view.findViewById(R.id.download_location_text);
-
-        titleTextView.setText(download.getTitle());
-        locationTextView.setText(download.getDownloadStatusText() + " : " + download.getFileName());
-
-        return view;
+        public ViewHolder(View itemView) {
+            super(itemView);
+            titleTextView = (TextView) itemView.findViewById(R.id.download_title_text);
+            locationTextView = (TextView) itemView.findViewById(R.id.download_location_text);
+        }
     }
 }

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/simple/MainActivity.java
@@ -5,8 +5,9 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.view.View;
-import android.widget.ListView;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.demo.R;
@@ -18,18 +19,21 @@ import com.novoda.downloadmanager.lib.Request;
 import java.util.List;
 
 public class MainActivity extends AppCompatActivity implements QueryForDownloadsAsyncTask.Callback {
+
     private static final String BIG_FILE = "http://ipv4.download.thinkbroadband.com/200MB.zip";
     private static final String PENGUINS_IMAGE = "http://i.imgur.com/Y7pMO5Kb.jpg";
 
-
     private DownloadManager downloadManager;
-    private ListView listView;
+    private RecyclerView recyclerView;
+    private View emptyView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-        listView = (ListView) findViewById(R.id.main_downloads_list);
+        emptyView = findViewById(R.id.main_no_downloads_view);
+        recyclerView = (RecyclerView) findViewById(R.id.main_downloads_list);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
         downloadManager = DownloadManagerBuilder.from(this)
                 .build();
 
@@ -60,11 +64,11 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
         findViewById(R.id.main_refresh_button).setOnClickListener(
                 new View.OnClickListener() {
                     @Override
-                    public void onClick(View v) {
+                    public void onClick(@NonNull View v) {
                         queryForDownloads();
                     }
-                });
-        listView.setEmptyView(findViewById(R.id.main_no_downloads_view));
+                }
+        );
     }
 
     private void queryForDownloads() {
@@ -73,6 +77,7 @@ public class MainActivity extends AppCompatActivity implements QueryForDownloads
 
     @Override
     public void onQueryResult(List<Download> downloads) {
-        listView.setAdapter(new DownloadAdapter(downloads));
+        recyclerView.setAdapter(new DownloadAdapter(downloads));
+        emptyView.setVisibility(downloads.isEmpty() ? View.VISIBLE : View.GONE);
     }
 }

--- a/demo-simple/src/main/res/layout/activity_main.xml
+++ b/demo-simple/src/main/res/layout/activity_main.xml
@@ -27,7 +27,7 @@
     android:layout_height="wrap_content"
     android:text="@string/no_downloads" />
 
-  <ListView
+  <android.support.v7.widget.RecyclerView
     android:id="@+id/main_downloads_list"
     android:layout_width="match_parent"
     android:layout_height="wrap_content" />

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-v4:22.2.0'
+    compile 'com.android.support:support-v4:22.2.1'
     compile 'com.novoda:notils:2.2.13'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
 


### PR DESCRIPTION
The lists in the demos were using `ListView` without the ViewHolder pattern. This caused higher CPU usage than necessary when updating the lists as all the Views were being recreated on each update.

Rather than just implementing the ViewHolder pattern on the ListView adapters I decided to move all the lists to RecyclerView.

UI is the same as before.