### PR TITLE
Provide restart mechanism

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -21,6 +21,7 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 import android.database.CursorWrapper;
 import android.net.Uri;
@@ -1100,5 +1101,17 @@ public class DownloadManager {
                     return STATUS_FAILED;
             }
         }
+    }
+
+    /**
+     * Restart will activate the downloads workflow in case that it was not already active
+     * <p/>
+     * A possible scenario: A client denies a download for a particular business rule and that
+     * rule does not apply any more. Calling this method will reactivate the downloads workflow,
+     * check the client rules and proceed if necessary
+     */
+    public void restart() {
+        Context context = GlobalState.getContext();
+        context.startService(new Intent(context, DownloadService.class));
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -1109,8 +1109,11 @@ public class DownloadManager {
      * A possible scenario: A client denies a download for a particular business rule and that
      * rule does not apply any more. Calling this method will reactivate the downloads workflow,
      * check the client rules and proceed if necessary
+     * <p/>
+     * This method can be called as many times as desired as the system will take care that only
+     * one instance is running, ignoring further calls if is currently active
      */
-    public void restart() {
+    public void forceStart() {
         Context context = GlobalState.getContext();
         context.startService(new Intent(context, DownloadService.class));
     }


### PR DESCRIPTION
### Feature requested ###

We need a way to restart the downloads workflow in case that it was not already active

A possible scenario: A client denies a download for a particular business rule and that rule does not apply any more. Calling this method will reactivate the downloads workflow, check the client rules and proceed if necessary

### Solution implemented ###

A new public method `restart` is provided