### PR TITLE
Add client checks along with pause and cancel checks and speed up calls

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -23,13 +23,13 @@ class DownloadReadyChecker {
 
     public boolean canDownload(DownloadBatch downloadBatch) {
         if (isDownloadManagerReadyToDownload(downloadBatch)) {
-            return clientAllowToDownload(downloadBatch);
+            return clientAllowsToDownload(downloadBatch);
         }
 
         return false;
     }
 
-    boolean clientAllowToDownload(DownloadBatch downloadBatch) {
+    boolean clientAllowsToDownload(DownloadBatch downloadBatch) {
         Download download = downloadMarshaller.marshall(downloadBatch);
         return downloadClientReadyChecker.isAllowedToDownload(download);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -23,11 +23,15 @@ class DownloadReadyChecker {
 
     public boolean canDownload(DownloadBatch downloadBatch) {
         if (isDownloadManagerReadyToDownload(downloadBatch)) {
-            Download download = downloadMarshaller.marshall(downloadBatch);
-            return downloadClientReadyChecker.isAllowedToDownload(download);
+            clientAllowToDownload(downloadBatch);
         }
 
         return false;
+    }
+
+    boolean clientAllowToDownload(DownloadBatch downloadBatch) {
+        Download download = downloadMarshaller.marshall(downloadBatch);
+        return downloadClientReadyChecker.isAllowedToDownload(download);
     }
 
     private boolean isDownloadManagerReadyToDownload(DownloadBatch downloadBatch) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -23,7 +23,7 @@ class DownloadReadyChecker {
 
     public boolean canDownload(DownloadBatch downloadBatch) {
         if (isDownloadManagerReadyToDownload(downloadBatch)) {
-            clientAllowToDownload(downloadBatch);
+            return clientAllowToDownload(downloadBatch);
         }
 
         return false;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -402,10 +402,12 @@ public class DownloadService extends Service {
     private void download(FileDownloadInfo info) {
         Uri downloadUri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), info.getId());
         FileDownloadInfo.ControlStatus.Reader controlReader = new FileDownloadInfo.ControlStatus.Reader(getContentResolver(), downloadUri);
+        DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(info);
         DownloadTask downloadTask = new DownloadTask(
-                this, systemFacade, info, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider,
-                controlReader, networkChecker, downloadReadyChecker, new Clock()
+                this, systemFacade, info, downloadBatch, storageManager,
+                downloadNotifier, batchCompletionBroadcaster, batchRepository,
+                downloadsUriProvider, controlReader, networkChecker, downloadReadyChecker,
+                new Clock()
         );
 
         ContentValues contentValues = new ContentValues();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -454,7 +454,7 @@ class DownloadTask implements Runnable {
     }
 
     private void checkClientRules() throws StopRequestException {
-        if (!downloadReadyChecker.clientAllowToDownload(originalDownloadBatch)) {
+        if (!downloadReadyChecker.clientAllowsToDownload(originalDownloadBatch)) {
             throw new StopRequestException(DownloadStatus.QUEUED_DUE_CLIENT_RESTRICTIONS, "Cannot proceed because client denies");
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingDownloadMarshaller.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingDownloadMarshaller.java
@@ -6,7 +6,6 @@ class PublicFacingDownloadMarshaller {
 
     public Download marshall(DownloadBatch downloadBatch) {
         return new Download(downloadBatch.getBatchId(), downloadBatch.getCurrentSize(), downloadBatch.getTotalSize());
-
     }
 
 }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadReadyCheckerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadReadyCheckerTest.java
@@ -32,7 +32,7 @@ public class DownloadReadyCheckerTest {
                 mock(PublicFacingDownloadMarshaller.class)
         );
 
-        boolean isReady = downloadReadyChecker.canDownload(mock(DownloadBatch.class));
+        boolean isReady = downloadReadyChecker.clientAllowToDownload(mock(DownloadBatch.class));
 
         assertThat(isReady).isTrue();
     }
@@ -46,7 +46,7 @@ public class DownloadReadyCheckerTest {
                 mock(PublicFacingDownloadMarshaller.class)
         );
 
-        boolean isReady = downloadReadyChecker.canDownload(mock(DownloadBatch.class));
+        boolean isReady = downloadReadyChecker.clientAllowToDownload(mock(DownloadBatch.class));
 
         assertThat(isReady).isFalse();
     }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/DownloadReadyCheckerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/DownloadReadyCheckerTest.java
@@ -32,7 +32,7 @@ public class DownloadReadyCheckerTest {
                 mock(PublicFacingDownloadMarshaller.class)
         );
 
-        boolean isReady = downloadReadyChecker.clientAllowToDownload(mock(DownloadBatch.class));
+        boolean isReady = downloadReadyChecker.clientAllowsToDownload(mock(DownloadBatch.class));
 
         assertThat(isReady).isTrue();
     }
@@ -46,7 +46,7 @@ public class DownloadReadyCheckerTest {
                 mock(PublicFacingDownloadMarshaller.class)
         );
 
-        boolean isReady = downloadReadyChecker.clientAllowToDownload(mock(DownloadBatch.class));
+        boolean isReady = downloadReadyChecker.clientAllowsToDownload(mock(DownloadBatch.class));
 
         assertThat(isReady).isFalse();
     }


### PR DESCRIPTION
### Task requested ###

When a transfer is on its way, when we write down some transfered bytes we check if the current download has moved to paused or canceled but we do not check if there are client rules that could potentially deny the progress of the current download

### Solution implemented ###

The solution is to include the client check along with the current pause and canceled checks

In terms of performance implications:
- New originalDownloadBatch along with the originalDownloadInfo in order to avoid the creation of the former when there is a bunch of bytes transferred on write
- Exposed packaged protected the method that checks the client rules in order to avoid the overhead of checking the internals of the download manager, specially the unnecessary query for all downloads