### PR TITLE
Status updating refactoring

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager.lib;
 
 import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.support.v4.util.SparseArrayCompat;
@@ -238,6 +239,25 @@ class BatchRepository {
         ContentValues values = new ContentValues(1);
         values.put(COLUMN_STATUS, DownloadStatus.CANCELED);
         resolver.update(downloadsUriProvider.getAllDownloadsUri(), values, COLUMN_BATCH_ID + " = ?", new String[]{String.valueOf(batchId)});
+    }
+
+    public void cancelBatch(long batchId) {
+        ContentValues downloadValues = new ContentValues(1);
+        downloadValues.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.CANCELED);
+        resolver.update(
+                downloadsUriProvider.getAllDownloadsUri(),
+                downloadValues,
+                DownloadContract.Downloads.COLUMN_BATCH_ID + " = ?",
+                new String[]{String.valueOf(batchId)}
+        );
+        ContentValues batchValues = new ContentValues(1);
+        batchValues.put(DownloadContract.Batches.COLUMN_STATUS, DownloadStatus.CANCELED);
+        resolver.update(
+                ContentUris.withAppendedId(downloadsUriProvider.getBatchesUri(), batchId),
+                batchValues,
+                null,
+                null
+        );
     }
 
     public void setBatchItemsFailed(long batchId, long downloadId) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -14,6 +14,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_BATCH_ID;
+import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_STATUS;
+
 class BatchRepository {
 
     private static final List<Integer> PRIORITISED_STATUSES = Arrays.asList(
@@ -229,6 +232,23 @@ class BatchRepository {
 
     public Cursor retrieveFor(BatchQuery query) {
         return resolver.query(downloadsUriProvider.getBatchesUri(), null, query.getSelection(), query.getSelectionArguments(), query.getSortOrder());
+    }
+
+    public void setBatchItemsCancelled(long batchId) {
+        ContentValues values = new ContentValues(1);
+        values.put(COLUMN_STATUS, DownloadStatus.CANCELED);
+        resolver.update(downloadsUriProvider.getAllDownloadsUri(), values, COLUMN_BATCH_ID + " = ?", new String[]{String.valueOf(batchId)});
+    }
+
+    public void setBatchItemsFailed(long batchId, long downloadId) {
+        ContentValues values = new ContentValues(1);
+        values.put(COLUMN_STATUS, DownloadStatus.BATCH_FAILED);
+        resolver.update(
+                downloadsUriProvider.getAllDownloadsUri(),
+                values,
+                COLUMN_BATCH_ID + " = ? AND " + DownloadContract.Downloads._ID + " <> ? ",
+                new String[]{String.valueOf(batchId), String.valueOf(downloadId)}
+        );
     }
 
     private static class StatusCountMap {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -389,44 +389,44 @@ public class DownloadManager {
 
     public DownloadManager(Context context, ContentResolver contentResolver) {
         this(context,
-             contentResolver,
-             DownloadsUriProvider.getInstance(),
-             new RealSystemFacade(context, new Clock()),
-             new BatchPauseResumeController(
-                     contentResolver,
-                     DownloadsUriProvider.getInstance(),
-                     new BatchRepository(
-                             contentResolver,
-                             new DownloadDeleter(contentResolver),
-                             DownloadsUriProvider.getInstance(),
-                             new RealSystemFacade(GlobalState.getContext(), new Clock())),
-                     new DownloadsRepository(
-                             contentResolver,
-                             DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                             DownloadsUriProvider.getInstance())
-             ),
-             false);
+                contentResolver,
+                DownloadsUriProvider.getInstance(),
+                new RealSystemFacade(context, new Clock()),
+                new BatchPauseResumeController(
+                        contentResolver,
+                        DownloadsUriProvider.getInstance(),
+                        new BatchRepository(
+                                contentResolver,
+                                new DownloadDeleter(contentResolver),
+                                DownloadsUriProvider.getInstance(),
+                                new RealSystemFacade(GlobalState.getContext(), new Clock())),
+                        new DownloadsRepository(
+                                new RealSystemFacade(GlobalState.getContext(), new Clock()), contentResolver,
+                                DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
+                                DownloadsUriProvider.getInstance())
+                ),
+                false);
     }
 
     public DownloadManager(Context context, ContentResolver contentResolver, boolean verboseLogging) {
         this(context,
-             contentResolver,
-             DownloadsUriProvider.getInstance(),
-             new RealSystemFacade(context, new Clock()),
-             new BatchPauseResumeController(
-                     contentResolver,
-                     DownloadsUriProvider.getInstance(),
-                     new BatchRepository(
-                             contentResolver,
-                             new DownloadDeleter(contentResolver),
-                             DownloadsUriProvider.getInstance(),
-                             new RealSystemFacade(GlobalState.getContext(), new Clock())),
-                     new DownloadsRepository(
-                             contentResolver,
-                             DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
-                             DownloadsUriProvider.getInstance())
-             ),
-             verboseLogging);
+                contentResolver,
+                DownloadsUriProvider.getInstance(),
+                new RealSystemFacade(context, new Clock()),
+                new BatchPauseResumeController(
+                        contentResolver,
+                        DownloadsUriProvider.getInstance(),
+                        new BatchRepository(
+                                contentResolver,
+                                new DownloadDeleter(contentResolver),
+                                DownloadsUriProvider.getInstance(),
+                                new RealSystemFacade(GlobalState.getContext(), new Clock())),
+                        new DownloadsRepository(
+                                new RealSystemFacade(GlobalState.getContext(), new Clock()), contentResolver,
+                                DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
+                                DownloadsUriProvider.getInstance())
+                ),
+                verboseLogging);
     }
 
     DownloadManager(Context context, ContentResolver contentResolver, DownloadsUriProvider downloadsUriProvider) {
@@ -444,7 +444,7 @@ public class DownloadManager {
                                 DownloadsUriProvider.getInstance(),
                                 new RealSystemFacade(GlobalState.getContext(), new Clock())),
                         new DownloadsRepository(
-                                contentResolver,
+                                new RealSystemFacade(GlobalState.getContext(), new Clock()), contentResolver,
                                 DownloadsRepository.DownloadInfoCreator.NON_FUNCTIONAL,
                                 DownloadsUriProvider.getInstance())
                 ),

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -168,7 +168,7 @@ public class DownloadService extends Service {
         executor = factory.createExecutor();
 
         this.downloadsRepository = new DownloadsRepository(
-                getContentResolver(), new DownloadsRepository.DownloadInfoCreator() {
+                systemFacade, getContentResolver(), new DownloadsRepository.DownloadInfoCreator() {
             @Override
             public FileDownloadInfo create(FileDownloadInfo.Reader reader) {
                 return createNewDownloadInfo(reader);
@@ -405,8 +405,8 @@ public class DownloadService extends Service {
         DownloadTask downloadTask = new DownloadTask(
                 this, systemFacade, info, storageManager, downloadNotifier,
                 batchCompletionBroadcaster, batchRepository, downloadsUriProvider,
-                controlReader, networkChecker, downloadReadyChecker, new Clock()
-        );
+                controlReader, networkChecker, downloadReadyChecker, new Clock(),
+                downloadsRepository);
 
         ContentValues contentValues = new ContentValues();
         contentValues.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.SUBMITTED);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -409,9 +409,7 @@ public class DownloadService extends Service {
                 controlReader, networkChecker, downloadReadyChecker, new Clock(),
                 downloadsRepository);
 
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.SUBMITTED);
-        getContentResolver().update(info.getAllDownloadsUri(), contentValues, null, null);
+        downloadsRepository.setDownloadSubmitted(info);
 
         executor.submit(downloadTask);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -248,9 +248,7 @@ class DownloadTask implements Runnable {
             }
 
             if (downloadStatus != DownloadStatus.RUNNING) {
-                ContentValues contentValues = new ContentValues();
-                contentValues.put(COLUMN_STATUS, DownloadStatus.RUNNING);
-                context.getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), contentValues, null, null);
+                downloadsRepository.setDownloadRunning(originalDownloadInfo);
                 updateBatchStatus(originalDownloadInfo.getBatchId(), originalDownloadInfo.getId());
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -215,7 +215,7 @@ class DownloadTask implements Runnable {
 
     private void runInternal() {
         // Skip when download already marked as finished; this download was probably started again while racing with UpdateThread.
-        int downloadStatus = FileDownloadInfo.queryDownloadStatus(getContentResolver(), originalDownloadInfo.getId(), downloadsUriProvider);
+        int downloadStatus = downloadsRepository.getDownloadStatus(originalDownloadInfo.getId());
         if (downloadStatus == DownloadStatus.SUCCESS) {
             LLog.d("Download " + originalDownloadInfo.getId() + " already finished; skipping");
             return;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -623,11 +623,7 @@ class DownloadTask implements Runnable {
     }
 
     private void updateStatusAndPause(State state) throws StopRequestException {
-        ContentValues values = new ContentValues();
-        values.put(COLUMN_STATUS, DownloadStatus.PAUSED_BY_APP);
-        values.put(COLUMN_CURRENT_BYTES, state.currentBytes);
-        values.put(COLUMN_TOTAL_BYTES, state.totalBytes);
-        getContentResolver().update(originalDownloadInfo.getAllDownloadsUri(), values, null, null);
+        downloadsRepository.pauseDownloadWithSize(originalDownloadInfo, state.currentBytes, state.totalBytes);
         throw new StopRequestException(DownloadStatus.PAUSED_BY_APP, "download paused by owner");
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -17,7 +17,6 @@
 package com.novoda.downloadmanager.lib;
 
 import android.content.ContentResolver;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.drm.DrmManagerClient;
@@ -47,7 +46,6 @@ import java.util.Locale;
 
 import static android.text.format.DateUtils.SECOND_IN_MILLIS;
 import static com.novoda.downloadmanager.lib.Constants.UNKNOWN_BYTE_SIZE;
-import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
 import static com.novoda.downloadmanager.lib.DownloadStatus.HTTP_DATA_ERROR;
 import static com.novoda.downloadmanager.lib.DownloadStatus.QUEUED_DUE_CLIENT_RESTRICTIONS;
 import static com.novoda.downloadmanager.lib.FileDownloadInfo.NetworkState;
@@ -824,18 +822,9 @@ class DownloadTask implements Runnable {
         batchRepository.updateBatchStatus(batchId, batchStatus);
 
         if (DownloadStatus.isCancelled(batchStatus)) {
-            ContentValues values = new ContentValues(1);
-            values.put(COLUMN_STATUS, DownloadStatus.CANCELED);
-            getContentResolver().update(downloadsUriProvider.getAllDownloadsUri(), values, COLUMN_BATCH_ID + " = ?", new String[]{String.valueOf(batchId)});
+            batchRepository.setBatchItemsCancelled(batchId);
         } else if (DownloadStatus.isError(batchStatus)) {
-            ContentValues values = new ContentValues(1);
-            values.put(COLUMN_STATUS, DownloadStatus.BATCH_FAILED);
-            getContentResolver().update(
-                    downloadsUriProvider.getAllDownloadsUri(),
-                    values,
-                    COLUMN_BATCH_ID + " = ? AND " + DownloadContract.Downloads._ID + " <> ? ",
-                    new String[]{String.valueOf(batchId), String.valueOf(downloadId)}
-            );
+            batchRepository.setBatchItemsFailed(batchId, downloadId);
         } else if (DownloadStatus.isSuccess(batchStatus)) {
             batchCompletionBroadcaster.notifyBatchCompletedFor(batchId);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -123,6 +123,12 @@ class DownloadsRepository {
         contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
     }
 
+    public void setDownloadRunning(FileDownloadInfo downloadInfo) {
+        ContentValues contentValues = new ContentValues(1);
+        contentValues.put(COLUMN_STATUS, DownloadStatus.RUNNING);
+        contentResolver.update(downloadInfo.getAllDownloadsUri(), contentValues, null, null);
+    }
+
     interface DownloadInfoCreator {
 
         DownloadInfoCreator NON_FUNCTIONAL = new NonFunctional();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -19,6 +19,8 @@ import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
 
 class DownloadsRepository {
 
+    private static final int TRUE_THIS_IS_CLEARER_NOW = 1;
+
     private final SystemFacade systemFacade;
     private final ContentResolver contentResolver;
     private final DownloadInfoCreator downloadInfoCreator;
@@ -159,6 +161,12 @@ class DownloadsRepository {
 
         values.put(COLUMN_TOTAL_BYTES, totalBytes);
         contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
+    }
+
+    public void deleteDownload(Uri downloadUri) {
+        ContentValues values = new ContentValues(1);
+        values.put(DownloadContract.Downloads.COLUMN_DELETED, TRUE_THIS_IS_CLEARER_NOW);
+        contentResolver.update(downloadUri, values, null, null);
     }
 
     interface DownloadInfoCreator {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -68,6 +68,26 @@ class DownloadsRepository {
         }
     }
 
+    /**
+     * Query and return status of requested download.
+     */
+    public int getDownloadStatus(long id) {
+        final Cursor cursor = contentResolver.query(
+                ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id),
+                new String[]{DownloadContract.Downloads.COLUMN_STATUS}, null, null, null);
+        try {
+            if (cursor.moveToFirst()) {
+                return cursor.getInt(0);
+            } else {
+                // TODO: increase strictness of value returned for unknown
+                // downloads; this is safe default for now.
+                return DownloadStatus.PENDING;
+            }
+        } finally {
+            cursor.close();
+        }
+    }
+
     public void moveDownloadsStatusTo(List<Long> ids, int status) {
         if (ids.isEmpty()) {
             return;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -169,6 +169,12 @@ class DownloadsRepository {
         contentResolver.update(downloadUri, values, null, null);
     }
 
+    public void setDownloadSubmitted(FileDownloadInfo info) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.SUBMITTED);
+        contentResolver.update(info.getAllDownloadsUri(), contentValues, null, null);
+    }
+
     interface DownloadInfoCreator {
 
         DownloadInfoCreator NON_FUNCTIONAL = new NonFunctional();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -14,7 +14,7 @@ import com.novoda.notils.string.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_STATUS;
+import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
 
 class DownloadsRepository {
 
@@ -127,6 +127,14 @@ class DownloadsRepository {
         ContentValues contentValues = new ContentValues(1);
         contentValues.put(COLUMN_STATUS, DownloadStatus.RUNNING);
         contentResolver.update(downloadInfo.getAllDownloadsUri(), contentValues, null, null);
+    }
+
+    public void pauseDownloadWithSize(FileDownloadInfo downloadInfo, long currentBytes, long totalBytes) {
+        ContentValues values = new ContentValues();
+        values.put(COLUMN_STATUS, DownloadStatus.PAUSED_BY_APP);
+        values.put(COLUMN_CURRENT_BYTES, currentBytes);
+        values.put(COLUMN_TOTAL_BYTES, totalBytes);
+        contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
     }
 
     interface DownloadInfoCreator {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -14,6 +14,7 @@ import com.novoda.notils.string.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.novoda.downloadmanager.lib.Constants.UNKNOWN_BYTE_SIZE;
 import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
 
 class DownloadsRepository {
@@ -133,6 +134,29 @@ class DownloadsRepository {
         ContentValues values = new ContentValues();
         values.put(COLUMN_STATUS, DownloadStatus.PAUSED_BY_APP);
         values.put(COLUMN_CURRENT_BYTES, currentBytes);
+        values.put(COLUMN_TOTAL_BYTES, totalBytes);
+        contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
+    }
+
+    public void updateDownloadEndOfStream(FileDownloadInfo downloadInfo, long currentBytes, long contentLength) {
+        ContentValues values = new ContentValues(2);
+        values.put(COLUMN_CURRENT_BYTES, currentBytes);
+        if (contentLength == UNKNOWN_BYTE_SIZE) {
+            values.put(COLUMN_TOTAL_BYTES, currentBytes);
+        }
+        contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
+    }
+
+    public void updateDatabaseFromHeaders(FileDownloadInfo downloadInfo, String filename, String headerETag, String mimeType, long totalBytes) {
+        ContentValues values = new ContentValues(4);
+        values.put(DownloadContract.Downloads.COLUMN_DATA, filename);
+        if (headerETag != null) {
+            values.put(Constants.ETAG, headerETag);
+        }
+        if (mimeType != null) {
+            values.put(DownloadContract.Downloads.COLUMN_MIME_TYPE, mimeType);
+        }
+
         values.put(COLUMN_TOTAL_BYTES, totalBytes);
         contentResolver.update(downloadInfo.getAllDownloadsUri(), values, null, null);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -318,26 +318,6 @@ class FileDownloadInfo {
                 && scannable;
     }
 
-    /**
-     * Query and return status of requested download.
-     */
-    public static int queryDownloadStatus(ContentResolver resolver, long id, DownloadsUriProvider downloadsUriProvider) {
-        final Cursor cursor = resolver.query(
-                ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id),
-                new String[]{DownloadContract.Downloads.COLUMN_STATUS}, null, null, null);
-        try {
-            if (cursor.moveToFirst()) {
-                return cursor.getInt(0);
-            } else {
-                // TODO: increase strictness of value returned for unknown
-                // downloads; this is safe default for now.
-                return DownloadStatus.PENDING;
-            }
-        } finally {
-            cursor.close();
-        }
-    }
-
     public boolean hasTotalBytes() {
         return totalBytes != Constants.UNKNOWN_BYTE_SIZE;
     }


### PR DESCRIPTION
Moves the majority of the status updating to the `*Repository` classes

This is to prepare for simplifying the batch/download statuses in order to fix the flickering status issue