### PR TITLE
Use a larger buffer to allow for less often write to disk

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -123,9 +123,14 @@ class Constants {
     public static final String MIMETYPE_APK = "application/vnd.android.package";
 
     /**
+     * The size of a tar block
+     */
+    public static final int BLOCK_SIZE = 512;
+
+    /**
      * The buffer size used to stream the data
      */
-    public static final int BUFFER_SIZE = 4096;
+    public static final int BUFFER_SIZE = 8 * BLOCK_SIZE;
 
     /**
      * The value representing the end of stream when, reading an InputStream

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -125,12 +125,12 @@ class Constants {
     /**
      * The size of a tar block
      */
-    public static final int BLOCK_SIZE = 512;
+    public static final int TAR_BLOCK_SIZE = 512;
 
     /**
      * The buffer size used to stream the data
      */
-    public static final int BUFFER_SIZE = 8 * BLOCK_SIZE;
+    public static final int BUFFER_SIZE = 8 * TAR_BLOCK_SIZE;
 
     /**
      * The value representing the end of stream when, reading an InputStream

--- a/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/TarTruncator.java
@@ -42,7 +42,7 @@ class TarTruncator implements DataTransferer {
 
     private int readBuffer(InputStream fileInputStream, byte[] buffer) throws IOException {
         int read = 0;
-        byte[] blockBuffer = new byte[Constants.BLOCK_SIZE];
+        byte[] blockBuffer = new byte[Constants.TAR_BLOCK_SIZE];
         int readLast;
         while (read < Constants.BUFFER_SIZE && (readLast = readBlock(fileInputStream, blockBuffer)) > 0 && isNotFullOfZeroes(blockBuffer)) {
             System.arraycopy(blockBuffer, 0, buffer, read, readLast);
@@ -54,8 +54,8 @@ class TarTruncator implements DataTransferer {
     private int readBlock(InputStream fileInputStream, byte[] buffer) throws IOException {
         int read = 0;
         int readLast;
-        while (read < Constants.BLOCK_SIZE) {
-            readLast = fileInputStream.read(buffer, read, Constants.BLOCK_SIZE - read);
+        while (read < Constants.TAR_BLOCK_SIZE) {
+            readLast = fileInputStream.read(buffer, read, Constants.TAR_BLOCK_SIZE - read);
             if (readLast == Constants.NO_BYTES_READ) {
                 return read;
             }

--- a/library/src/test/java/com/novoda/downloadmanager/lib/TarTruncatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/TarTruncatorTest.java
@@ -28,7 +28,7 @@ public class TarTruncatorTest {
     @Test
     public void itTruncatesProperlyTarFileThatContainsEndBlockMarker() throws Exception {
         givenATarFileWithEndBlockMarker();
-
+        
         state = tarTruncator.transferData(state, resourceAsStream);
 
         tarFileShouldHaveBeenTruncatedProperly();


### PR DESCRIPTION
When using the tar truncator the buffer used for the data transfer is really small (512  bytes) to match the tar format buffer. This allows for the tuncation but creates writes to disk too often.

This uses a double buffer in memory to allow for a buffer of the same size than the original data transfer to be used making sure there is no more writes to disk than needed.

## Benchmark on a simple test archive

### Before
```
Start at 1439216120380
Stop at 1439216120823
Total 443ms
```

### After
```
Start at 1439216197991
Stop at 1439216198146
Total 155ms
```