### PR TITLE
Add completed batches to DownloadManager

### DIFF
--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
       android:name="com.novoda.downloadmanager.demo.extended.extra_data.ExtraDataActivity"
       android:label="@string/extra_data_activity_title" />
 
+    <activity android:name=".extended.CompletedDownloadsActivity"
+      android:label="@string/completed_downloads_activity_title" />
+
     <meta-data
       android:name="com.novoda.downloadmanager.MaxConcurrentDownloads"
       android:value="@integer/max_concurrent_downloads" />

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/CompletedDownloadsActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/CompletedDownloadsActivity.java
@@ -1,0 +1,45 @@
+package com.novoda.downloadmanager.demo.extended;
+
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
+import android.view.View;
+
+import com.novoda.downloadmanager.DownloadManagerBuilder;
+import com.novoda.downloadmanager.demo.R;
+import com.novoda.downloadmanager.lib.DownloadManager;
+import com.novoda.downloadmanager.lib.Request;
+import com.novoda.downloadmanager.lib.RequestBatch;
+
+public class CompletedDownloadsActivity extends AppCompatActivity {
+
+    private static final Uri REQUEST_URI = Uri.parse("https://raw.githubusercontent.com/novoda/download-manager/master/RELEASE-NOTES.md");
+    private DownloadManager downloadManager;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_completed_downloads);
+        downloadManager = DownloadManagerBuilder.from(CompletedDownloadsActivity.this)
+                .build();
+
+        findViewById(R.id.add_completed_batch).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                RequestBatch requestBatch = new RequestBatch.Builder()
+                        .withTitle("Completed download")
+                        .withDescription("This download has already been downloaded, but will appear in the download manager API")
+                        .build();
+                Request request = new Request(REQUEST_URI)
+                        .setTitle("Download Manager release notes")
+                        .setDescription("This file has already been downloaded")
+                        .setMimeType("text/plain")
+                        .setDestinationInExternalFilesDir(null, "this-doesn't-really-exist.txt");
+                requestBatch.addRequest(request);
+                downloadManager.addCompletedBatch(requestBatch);
+            }
+        });
+    }
+}

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/CompletedDownloadsActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/CompletedDownloadsActivity.java
@@ -4,7 +4,6 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
-import android.util.Log;
 import android.view.View;
 
 import com.novoda.downloadmanager.DownloadManagerBuilder;
@@ -25,21 +24,23 @@ public class CompletedDownloadsActivity extends AppCompatActivity {
         downloadManager = DownloadManagerBuilder.from(CompletedDownloadsActivity.this)
                 .build();
 
-        findViewById(R.id.add_completed_batch).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                RequestBatch requestBatch = new RequestBatch.Builder()
-                        .withTitle("Completed download")
-                        .withDescription("This download has already been downloaded, but will appear in the download manager API")
-                        .build();
-                Request request = new Request(REQUEST_URI)
-                        .setTitle("Download Manager release notes")
-                        .setDescription("This file has already been downloaded")
-                        .setMimeType("text/plain")
-                        .setDestinationInExternalFilesDir(null, "this-doesn't-really-exist.txt");
-                requestBatch.addRequest(request);
-                downloadManager.addCompletedBatch(requestBatch);
-            }
-        });
+        findViewById(R.id.add_completed_batch).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        RequestBatch requestBatch = new RequestBatch.Builder()
+                                .withTitle("Completed download")
+                                .withDescription("This download has already been downloaded, but will appear in the download manager API")
+                                .build();
+                        Request request = new Request(REQUEST_URI)
+                                .setTitle("Download Manager release notes")
+                                .setDescription("This file has already been downloaded")
+                                .setMimeType("text/plain")
+                                .setDestinationInExternalFilesDir(null, "this-doesn't-really-exist.txt");
+                        requestBatch.addRequest(request);
+                        downloadManager.addCompletedBatch(requestBatch);
+                    }
+                }
+        );
     }
 }

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
@@ -39,6 +39,14 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
+        findViewById(R.id.completed_downloads_button).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, CompletedDownloadsActivity.class));
+                    }
+                });
+
         findViewById(R.id.extra_data_button).setOnClickListener(
                 new View.OnClickListener() {
                     @Override

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/MainActivity.java
@@ -18,26 +18,32 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        findViewById(R.id.pause_resume_button).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(MainActivity.this, PauseResumeActivity.class));
-            }
-        });
+        findViewById(R.id.pause_resume_button).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, PauseResumeActivity.class));
+                    }
+                }
+        );
 
-        findViewById(R.id.delete_button).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(MainActivity.this, DeleteActivity.class));
-            }
-        });
+        findViewById(R.id.delete_button).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, DeleteActivity.class));
+                    }
+                }
+        );
 
-        findViewById(R.id.batches_button).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                startActivity(new Intent(MainActivity.this, BatchDownloadsActivity.class));
-            }
-        });
+        findViewById(R.id.batches_button).setOnClickListener(
+                new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        startActivity(new Intent(MainActivity.this, BatchDownloadsActivity.class));
+                    }
+                }
+        );
 
         findViewById(R.id.completed_downloads_button).setOnClickListener(
                 new View.OnClickListener() {
@@ -45,7 +51,8 @@ public class MainActivity extends AppCompatActivity {
                     public void onClick(View v) {
                         startActivity(new Intent(MainActivity.this, CompletedDownloadsActivity.class));
                     }
-                });
+                }
+        );
 
         findViewById(R.id.extra_data_button).setOnClickListener(
                 new View.OnClickListener() {
@@ -53,7 +60,8 @@ public class MainActivity extends AppCompatActivity {
                     public void onClick(View v) {
                         startActivity(new Intent(MainActivity.this, ExtraDataActivity.class));
                     }
-                });
+                }
+        );
     }
 
 }

--- a/demo-extended/src/main/res/layout/activity_completed_downloads.xml
+++ b/demo-extended/src/main/res/layout/activity_completed_downloads.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/add_completed_batch"
+        android:id="@+id/add_completed_batch" />
+
+</LinearLayout>

--- a/demo-extended/src/main/res/layout/activity_main.xml
+++ b/demo-extended/src/main/res/layout/activity_main.xml
@@ -32,4 +32,10 @@
     android:layout_height="wrap_content"
     android:text="@string/extra_data_button" />
 
+  <Button
+    android:id="@+id/completed_downloads_button"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:text="@string/completed_downloads_button" />
+
 </LinearLayout>

--- a/demo-extended/src/main/res/values/strings.xml
+++ b/demo-extended/src/main/res/values/strings.xml
@@ -35,4 +35,7 @@
   <string name="live">Live</string>
   <string name="extra_data_button">Add extra data example</string>
   <string name="extra_data_description">This demo shows how you can pass extra information into the download manager for each download, and retrieve it out the other side.</string>
+  <string name="completed_downloads_button">Add completed downloads</string>
+  <string name="completed_downloads_activity_title">Completed downloads</string>
+  <string name="add_completed_batch">Add new completed batch</string>
 </resources>

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -823,8 +823,10 @@ public class DownloadManager {
      * @param showNotification        true if a notification is to be sent, false otherwise
      * @return an ID for the download entry added to the downloads app, unique across the system
      * This ID is used to make future calls related to this download.
+     * @deprecated Individual downloads should be added as a batch using {@link DownloadManager#insertBatchAsCompleted(RequestBatch)}
      */
     // TODO: Add batch to request
+    @Deprecated
     public long addCompletedDownload(String title, String description,
                                      boolean isMediaScannerScannable, String mimeType, String path, long length,
                                      boolean showNotification) {
@@ -844,17 +846,43 @@ public class DownloadManager {
                 .setMimeType(mimeType)
                 .setNotificationVisibility((showNotification) ? NotificationVisibility.ONLY_WHEN_COMPLETE : NotificationVisibility.HIDDEN);
 
+        if (isMediaScannerScannable) {
+            request.allowScanningByMediaScanner();
+        }
+
+        return insertRequestAsCompletedDownload(path, length, request);
+    }
+
+    private long insertRequestAsCompletedDownload(String path, long length, Request request) {
         ContentValues values = request.toContentValues();
         values.put(DownloadContract.Downloads.COLUMN_DESTINATION, DownloadsDestination.DESTINATION_NON_DOWNLOADMANAGER_DOWNLOAD);
         values.put(DownloadContract.Downloads.COLUMN_DATA, path);
         values.put(DownloadContract.Downloads.COLUMN_STATUS, DownloadStatus.SUCCESS);
         values.put(DownloadContract.Downloads.COLUMN_TOTAL_BYTES, length);
-        values.put(DownloadContract.Downloads.COLUMN_MEDIA_SCANNED, (isMediaScannerScannable) ? Request.SCANNABLE_VALUE_YES : Request.SCANNABLE_VALUE_NO);
         Uri downloadUri = contentResolver.insert(downloadsUriProvider.getContentUri(), values);
         if (downloadUri == null) {
             return -1;
         }
         return ContentUris.parseId(downloadUri);
+    }
+
+    public long addCompletedBatch(RequestBatch requestBatch) {
+        long completedBatchId = insertBatchAsCompleted(requestBatch);
+        for (Request request : requestBatch.getRequests()) {
+            request.setBatchId(completedBatchId);
+            File file = new File(request.getDestinationPath());
+            long length = file.exists() ? file.length() : 0;
+            insertRequestAsCompletedDownload(request.getDestinationPath(), length, request);
+        }
+        return completedBatchId;
+    }
+
+    private long insertBatchAsCompleted(RequestBatch batch) {
+        ContentValues values = batch.toContentValues();
+        values.put(DownloadContract.Batches.COLUMN_STATUS, DownloadStatus.SUCCESS);
+        values.put(DownloadContract.Batches.COLUMN_LAST_MODIFICATION, systemFacade.currentTimeMillis());
+        Uri batchUri = contentResolver.insert(downloadsUriProvider.getBatchesUri(), values);
+        return ContentUris.parseId(batchUri);
     }
 
     private static final String NON_DOWNLOADMANAGER_DOWNLOAD =

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -509,4 +509,8 @@ public class Request {
         requestBatch.addRequest(this);
         return requestBatch;
     }
+
+    String getDestinationPath() {
+        return destinationUri.toString();
+    }
 }


### PR DESCRIPTION
Previously, you could add a completed download to the DownloadManager database so it could be read. This probably broke when we introduced the batching mechanism as it didn't associate a completed download with a batch.

We needed to be able to add complete *batches* into the download manager, rather than just downloads. This PR adds this functionality, and deprecates the old, unsupported method. We also delegate a few checks which were done manually when they didn't need to be.

This GIF shows the completed download showing up in both the downloads UI and the batches UI. 

![device-2015-09-07-174912](https://cloud.githubusercontent.com/assets/666285/9720715/da31fa48-5588-11e5-86ca-c6b25970addf.gif)
