### PR TITLE
Add a broadcast for batch failure

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchTerminationBroadcaster.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchTerminationBroadcaster.java
@@ -3,21 +3,30 @@ package com.novoda.downloadmanager.lib;
 import android.content.Context;
 import android.content.Intent;
 
-class BatchCompletionBroadcaster {
+class BatchTerminationBroadcaster {
 
     static final String ACTION_BATCH_COMPLETE = "com.novoda.downloadmanager.action.BATCH_COMPLETE";
+    static final String ACTION_BATCH_FAILED = "com.novoda.downloadmanager.action.BATCH_FAILED";
+
     static final String EXTRA_BATCH_ID = DownloadReceiver.EXTRA_BATCH_ID;
 
     private final Context context;
     private final String packageName;
 
-    BatchCompletionBroadcaster(Context context, String packageName) {
+    BatchTerminationBroadcaster(Context context, String packageName) {
         this.context = context;
         this.packageName = packageName;
     }
 
     public void notifyBatchCompletedFor(long batchId) {
         Intent intent = new Intent(ACTION_BATCH_COMPLETE);
+        intent.setPackage(packageName);
+        intent.putExtra(EXTRA_BATCH_ID, batchId);
+        context.sendBroadcast(intent);
+    }
+
+    public void notifyBatchFailedFor(long batchId) {
+        Intent intent = new Intent(ACTION_BATCH_FAILED);
         intent.setPackage(packageName);
         intent.putExtra(EXTRA_BATCH_ID, batchId);
         context.sendBroadcast(intent);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -306,7 +306,13 @@ public class DownloadManager {
      * Broadcast intent action sent by the download manager when a batch completes. The
      * batch's ID is specified in the intent's data.
      */
-    public static final String ACTION_BATCH_COMPLETE = BatchCompletionBroadcaster.ACTION_BATCH_COMPLETE;
+    public static final String ACTION_BATCH_COMPLETE = BatchTerminationBroadcaster.ACTION_BATCH_COMPLETE;
+
+    /**
+     * Broadcast intent action sent by the download manager when a batch failed. The
+     * batch's ID is specified in the intent's data.
+     */
+    public static final String ACTION_BATCH_FAILED = BatchTerminationBroadcaster.ACTION_BATCH_FAILED;
 
     /**
      * Broadcast intent action sent by the download manager when a download wasn't started due to insufficient space
@@ -332,7 +338,7 @@ public class DownloadManager {
      * Intent extra included with {@link #ACTION_BATCH_COMPLETE} intents, indicating the ID (as a
      * long) of the batch that just completed.
      */
-    public static final String EXTRA_BATCH_ID = BatchCompletionBroadcaster.EXTRA_BATCH_ID;
+    public static final String EXTRA_BATCH_ID = BatchTerminationBroadcaster.EXTRA_BATCH_ID;
 
     /**
      * Intent extra included with {@link #ACTION_DOWNLOAD_COMPLETE} intents, indicating the status code of the download that just completed.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -83,7 +83,7 @@ public class DownloadService extends Service {
     private DownloadDeleter downloadDeleter;
     private DownloadReadyChecker downloadReadyChecker;
     private DownloadsUriProvider downloadsUriProvider;
-    private BatchCompletionBroadcaster batchCompletionBroadcaster;
+    private BatchTerminationBroadcaster batchTerminationBroadcaster;
     private NetworkChecker networkChecker;
 
     /**
@@ -129,7 +129,7 @@ public class DownloadService extends Service {
         this.downloadReadyChecker = new DownloadReadyChecker(this.systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
 
         String applicationPackageName = getApplicationContext().getPackageName();
-        this.batchCompletionBroadcaster = new BatchCompletionBroadcaster(this, applicationPackageName);
+        this.batchTerminationBroadcaster = new BatchTerminationBroadcaster(this, applicationPackageName);
 
         alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         ContentResolver contentResolver = getContentResolver();
@@ -414,7 +414,7 @@ public class DownloadService extends Service {
         DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(info);
         DownloadTask downloadTask = new DownloadTask(
                 this, systemFacade, info, downloadBatch, storageManager, downloadNotifier,
-                batchCompletionBroadcaster, batchRepository, downloadsUriProvider,
+                batchTerminationBroadcaster, batchRepository, downloadsUriProvider,
                 controlReader, networkChecker, downloadReadyChecker, new Clock(),
                 downloadsRepository);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -207,6 +207,13 @@ final class DownloadStatus {
     }
 
     /**
+     * Returns whether the download has failed
+     */
+    public static boolean isFailure(int batchStatus) {
+        return isError(batchStatus) && !isCancelled(batchStatus);
+    }
+
+    /**
      * Returns whether the download has been cancelled.
      */
     public static boolean isCancelled(int status) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -80,7 +80,7 @@ class DownloadTask implements Runnable {
     private final SystemFacade systemFacade;
     private final StorageManager storageManager;
     private final DownloadNotifier downloadNotifier;
-    private final BatchCompletionBroadcaster batchCompletionBroadcaster;
+    private final BatchTerminationBroadcaster batchTerminationBroadcaster;
     private final BatchRepository batchRepository;
     private final DownloadsUriProvider downloadsUriProvider;
     private final FileDownloadInfo.ControlStatus.Reader controlReader;
@@ -95,7 +95,7 @@ class DownloadTask implements Runnable {
                         DownloadBatch originalDownloadBatch,
                         StorageManager storageManager,
                         DownloadNotifier downloadNotifier,
-                        BatchCompletionBroadcaster batchCompletionBroadcaster,
+                        BatchTerminationBroadcaster batchTerminationBroadcaster,
                         BatchRepository batchRepository,
                         DownloadsUriProvider downloadsUriProvider,
                         FileDownloadInfo.ControlStatus.Reader controlReader,
@@ -109,7 +109,7 @@ class DownloadTask implements Runnable {
         this.originalDownloadBatch = originalDownloadBatch;
         this.storageManager = storageManager;
         this.downloadNotifier = downloadNotifier;
-        this.batchCompletionBroadcaster = batchCompletionBroadcaster;
+        this.batchTerminationBroadcaster = batchTerminationBroadcaster;
         this.batchRepository = batchRepository;
         this.downloadsUriProvider = downloadsUriProvider;
         this.controlReader = controlReader;
@@ -835,8 +835,9 @@ class DownloadTask implements Runnable {
             batchRepository.setBatchItemsCancelled(batchId);
         } else if (DownloadStatus.isError(batchStatus)) {
             batchRepository.setBatchItemsFailed(batchId, downloadId);
+            batchTerminationBroadcaster.notifyBatchFailedFor(batchId);
         } else if (DownloadStatus.isSuccess(batchStatus)) {
-            batchCompletionBroadcaster.notifyBatchCompletedFor(batchId);
+            batchTerminationBroadcaster.notifyBatchCompletedFor(batchId);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -833,7 +833,7 @@ class DownloadTask implements Runnable {
 
         if (DownloadStatus.isCancelled(batchStatus)) {
             batchRepository.setBatchItemsCancelled(batchId);
-        } else if (DownloadStatus.isError(batchStatus)) {
+        } else if (DownloadStatus.isFailure(batchStatus)) {
             batchRepository.setBatchItemsFailed(batchId, downloadId);
             batchTerminationBroadcaster.notifyBatchFailedFor(batchId);
         } else if (DownloadStatus.isSuccess(batchStatus)) {


### PR DESCRIPTION
### Broadcast batch failure 

The broadcast is only done in case of error. (won't be triggered if a download is cancelled for example)

* Rename the BatchCompletionBroadcaster into BatchTerminationBroadcaster
* extend its API to send a broadcast if a failure occured while downloading.