### PR TITLE
Track batch first time start

### DIFF
--- a/demo-extended/src/main/AndroidManifest.xml
+++ b/demo-extended/src/main/AndroidManifest.xml
@@ -59,7 +59,15 @@
         <action android:name="com.novoda.downloadmanager.action.BATCH_COMPLETE" />
       </intent-filter>
     </receiver>
-    
+
+    <receiver
+      android:name="com.novoda.downloadmanager.demo.extended.DownloadBatchStartedReceiver"
+      android:exported="false">
+      <intent-filter>
+        <action android:name="com.novoda.downloadmanager.action.BATCH_FIRST_TIME_START" />
+      </intent-filter>
+    </receiver>
+
     <receiver android:name="com.novoda.downloadmanager.demo.extended.NotificationReceiver"
       android:exported="false">
       <intent-filter>

--- a/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DownloadBatchStartedReceiver.java
+++ b/demo-extended/src/main/java/com/novoda/downloadmanager/demo/extended/DownloadBatchStartedReceiver.java
@@ -1,0 +1,24 @@
+package com.novoda.downloadmanager.demo.extended;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.novoda.downloadmanager.lib.DownloadManager;
+
+public class DownloadBatchStartedReceiver extends BroadcastReceiver {
+
+    private static final int UNKNOWN_BATCH_ID = -1;
+    private static final String TAG = DownloadBatchStartedReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(@NonNull Context context, @NonNull Intent intent) {
+        long batchId = intent.getLongExtra(DownloadManager.EXTRA_BATCH_ID, UNKNOWN_BATCH_ID);
+        Toast.makeText(context, "Batch started with id: " + batchId, Toast.LENGTH_SHORT).show();
+        Log.d(TAG, "Batch started: " + batchId);
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchInformationBroadcaster.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchInformationBroadcaster.java
@@ -3,17 +3,18 @@ package com.novoda.downloadmanager.lib;
 import android.content.Context;
 import android.content.Intent;
 
-class BatchTerminationBroadcaster {
+class BatchInformationBroadcaster {
 
     static final String ACTION_BATCH_COMPLETE = "com.novoda.downloadmanager.action.BATCH_COMPLETE";
     static final String ACTION_BATCH_FAILED = "com.novoda.downloadmanager.action.BATCH_FAILED";
+    static final String ACTION_BATCH_STARTED_FOR_FIRST_TIME = "com.novoda.downloadmanager.action.BATCH_FIRST_TIME_START";
 
     static final String EXTRA_BATCH_ID = DownloadReceiver.EXTRA_BATCH_ID;
 
     private final Context context;
     private final String packageName;
 
-    BatchTerminationBroadcaster(Context context, String packageName) {
+    BatchInformationBroadcaster(Context context, String packageName) {
         this.context = context;
         this.packageName = packageName;
     }
@@ -32,4 +33,10 @@ class BatchTerminationBroadcaster {
         context.sendBroadcast(intent);
     }
 
+    public void notifyBatchStartedFor(long batchId) {
+        Intent intent = new Intent(ACTION_BATCH_STARTED_FOR_FIRST_TIME);
+        intent.setPackage(packageName);
+        intent.putExtra(EXTRA_BATCH_ID, batchId);
+        context.sendBroadcast(intent);
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -170,7 +170,7 @@ class BatchRepository {
             }
         }
 
-        return hasStarted == DownloadContract.Batches.BATCH_HAS_STARTED ? false : true;
+        return hasStarted != DownloadContract.Batches.BATCH_HAS_STARTED;
     }
 
     public DownloadBatch retrieveBatchFor(FileDownloadInfo download) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchRepository.java
@@ -146,7 +146,7 @@ class BatchRepository {
         return DownloadStatus.UNKNOWN_ERROR;
     }
 
-    boolean isBatchDownloadStartingForTheFirstTime(long batchId) {
+    boolean isBatchStartingForTheFirstTime(long batchId) {
         Cursor cursor = null;
         int hasStarted = 0;
         try {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -20,7 +20,7 @@ final class DatabaseHelper extends SQLiteOpenHelper {
     /**
      * Current database version
      */
-    private static final int DB_VERSION = 1;
+    private static final int DB_VERSION = 2;
 
     /**
      * columns to request from DownloadProvider.
@@ -108,7 +108,17 @@ final class DatabaseHelper extends SQLiteOpenHelper {
      */
     @Override
     public void onUpgrade(@NonNull SQLiteDatabase db, int oldVersion, final int newVersion) {
-        // no upgrade path yet
+        if (oldVersion == 1 && newVersion == 2) {
+            try {
+                db.execSQL(
+                        "ALTER TABLE " + DownloadContract.Batches.BATCHES_TABLE_NAME
+                                + "ADD " + DownloadContract.Batches.COLUMN_HAS_STARTED + " BOOLEAN NOT NULL DEFAULT 0;"
+                );
+            } catch (SQLException ex) {
+                LLog.e("couldn't update table in downloads database");
+                throw ex;
+            }
+        }
     }
 
     /**
@@ -197,7 +207,8 @@ final class DatabaseHelper extends SQLiteOpenHelper {
                         + DownloadContract.Batches.COLUMN_VISIBILITY + " INTEGER,"
                         + DownloadContract.Batches.COLUMN_DELETED + " BOOLEAN NOT NULL DEFAULT 0,"
                         + DownloadContract.Batches.COLUMN_EXTRA_DATA + " TEXT,"
-                        + DownloadContract.Batches.COLUMN_LAST_MODIFICATION + " TEXT"
+                        + DownloadContract.Batches.COLUMN_LAST_MODIFICATION + " TEXT,"
+                        + DownloadContract.Batches.COLUMN_HAS_STARTED + " BOOLEAN NOT NULL DEFAULT 0"
                         + ");"
         );
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DatabaseHelper.java
@@ -22,6 +22,11 @@ final class DatabaseHelper extends SQLiteOpenHelper {
      */
     private static final int DB_VERSION = 2;
 
+    private static final String VERSION_ONE_TO_VERSION_TWO_MIGRATION_SCRIPT = "ALTER TABLE "
+            + DownloadContract.Batches.BATCHES_TABLE_NAME
+            + "ADD "
+            + DownloadContract.Batches.COLUMN_HAS_STARTED + " BOOLEAN NOT NULL DEFAULT 0;";
+
     /**
      * columns to request from DownloadProvider.
      */
@@ -109,15 +114,16 @@ final class DatabaseHelper extends SQLiteOpenHelper {
     @Override
     public void onUpgrade(@NonNull SQLiteDatabase db, int oldVersion, final int newVersion) {
         if (oldVersion == 1 && newVersion == 2) {
-            try {
-                db.execSQL(
-                        "ALTER TABLE " + DownloadContract.Batches.BATCHES_TABLE_NAME
-                                + "ADD " + DownloadContract.Batches.COLUMN_HAS_STARTED + " BOOLEAN NOT NULL DEFAULT 0;"
-                );
-            } catch (SQLException ex) {
-                LLog.e("couldn't update table in downloads database");
-                throw ex;
-            }
+            upgradeFromVersionOneToVersionTwo(db);
+        }
+    }
+
+    private void upgradeFromVersionOneToVersionTwo(@NonNull SQLiteDatabase db) {
+        try {
+            db.execSQL(VERSION_ONE_TO_VERSION_TWO_MIGRATION_SCRIPT);
+        } catch (SQLException ex) {
+            LLog.e("couldn't update table in downloads database");
+            throw ex;
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadContract.java
@@ -331,10 +331,23 @@ final class DownloadContract {
         public static final String COLUMN_LAST_MODIFICATION = "last_modified_timestamp";
 
         /**
+         * Store whether this specific batch was ever started.
+         * <P>Type: BOOLEAN</P>
+         * <P>Owner can Read</P>
+         */
+        public static final String COLUMN_HAS_STARTED = "batch_has_started";
+
+        /**
          * One of the values taken by {@link DownloadContract.Batches#COLUMN_DELETED}.
          * This value is used when the batch is marked as deleted and will be actually removed soon.
          */
         public static final int BATCH_DELETED = 1;
+
+        /**
+         * One of the values taken by {@link DownloadContract.Batches#COLUMN_HAS_STARTED}.
+         * This value is used when the batch is starting for the first tme.
+         */
+        public static final int BATCH_HAS_STARTED = 1;
 
         private Batches() {
             // non-instantiable class

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -315,6 +315,12 @@ public class DownloadManager {
     public static final String ACTION_BATCH_FAILED = BatchInformationBroadcaster.ACTION_BATCH_FAILED;
 
     /**
+     * Broadcast intent action sent by the download manager when a batch has started. The
+     * batch's ID is specified in the intent's data.
+     */
+    public static final String ACTION_BATCH_STARTED = BatchInformationBroadcaster.ACTION_BATCH_STARTED_FOR_FIRST_TIME;
+
+    /**
      * Broadcast intent action sent by the download manager when a download wasn't started due to insufficient space
      */
     public static final String ACTION_DOWNLOAD_INSUFFICIENT_SPACE = "com.novoda.downloadmanager.DOWNLOAD_INSUFFICIENT_SPACE";

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -306,13 +306,13 @@ public class DownloadManager {
      * Broadcast intent action sent by the download manager when a batch completes. The
      * batch's ID is specified in the intent's data.
      */
-    public static final String ACTION_BATCH_COMPLETE = BatchTerminationBroadcaster.ACTION_BATCH_COMPLETE;
+    public static final String ACTION_BATCH_COMPLETE = BatchInformationBroadcaster.ACTION_BATCH_COMPLETE;
 
     /**
      * Broadcast intent action sent by the download manager when a batch failed. The
      * batch's ID is specified in the intent's data.
      */
-    public static final String ACTION_BATCH_FAILED = BatchTerminationBroadcaster.ACTION_BATCH_FAILED;
+    public static final String ACTION_BATCH_FAILED = BatchInformationBroadcaster.ACTION_BATCH_FAILED;
 
     /**
      * Broadcast intent action sent by the download manager when a download wasn't started due to insufficient space
@@ -338,7 +338,7 @@ public class DownloadManager {
      * Intent extra included with {@link #ACTION_BATCH_COMPLETE} intents, indicating the ID (as a
      * long) of the batch that just completed.
      */
-    public static final String EXTRA_BATCH_ID = BatchTerminationBroadcaster.EXTRA_BATCH_ID;
+    public static final String EXTRA_BATCH_ID = BatchInformationBroadcaster.EXTRA_BATCH_ID;
 
     /**
      * Intent extra included with {@link #ACTION_DOWNLOAD_COMPLETE} intents, indicating the status code of the download that just completed.

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -83,7 +83,7 @@ public class DownloadService extends Service {
     private DownloadDeleter downloadDeleter;
     private DownloadReadyChecker downloadReadyChecker;
     private DownloadsUriProvider downloadsUriProvider;
-    private BatchTerminationBroadcaster batchTerminationBroadcaster;
+    private BatchInformationBroadcaster batchInformationBroadcaster;
     private NetworkChecker networkChecker;
 
     /**
@@ -129,7 +129,7 @@ public class DownloadService extends Service {
         this.downloadReadyChecker = new DownloadReadyChecker(this.systemFacade, networkChecker, downloadClientReadyChecker, downloadMarshaller);
 
         String applicationPackageName = getApplicationContext().getPackageName();
-        this.batchTerminationBroadcaster = new BatchTerminationBroadcaster(this, applicationPackageName);
+        this.batchInformationBroadcaster = new BatchInformationBroadcaster(this, applicationPackageName);
 
         alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         ContentResolver contentResolver = getContentResolver();
@@ -350,6 +350,11 @@ public class DownloadService extends Service {
             }
 
             if (!isActive && downloadReadyChecker.canDownload(downloadBatch)) {
+                boolean isBatchStartingForTheFirstTime = batchRepository.isBatchDownloadStartingForTheFirstTime(downloadBatch.getBatchId());
+                if (isBatchStartingForTheFirstTime) {
+                    handleBatchStartingForTheFirstTime(downloadBatch);
+                }
+
                 downloadOrContinueBatch(downloadBatch.getDownloads());
                 isActive = true;
             } else if (downloadBatch.scanCompletedMediaIfReady(downloadScanner)) {
@@ -377,6 +382,11 @@ public class DownloadService extends Service {
         }
 
         return isActive;
+    }
+
+    private void handleBatchStartingForTheFirstTime(DownloadBatch downloadBatch) {
+        batchRepository.markBatchHasStarted(downloadBatch.getBatchId());
+        batchInformationBroadcaster.notifyBatchStartedFor(downloadBatch.getBatchId());
     }
 
     private void moveSubmittedTasksToBatchStatusIfNecessary() {
@@ -414,7 +424,7 @@ public class DownloadService extends Service {
         DownloadBatch downloadBatch = batchRepository.retrieveBatchFor(info);
         DownloadTask downloadTask = new DownloadTask(
                 this, systemFacade, info, downloadBatch, storageManager, downloadNotifier,
-                batchTerminationBroadcaster, batchRepository, downloadsUriProvider,
+                batchInformationBroadcaster, batchRepository, downloadsUriProvider,
                 controlReader, networkChecker, downloadReadyChecker, new Clock(),
                 downloadsRepository);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -350,7 +350,7 @@ public class DownloadService extends Service {
             }
 
             if (!isActive && downloadReadyChecker.canDownload(downloadBatch)) {
-                boolean isBatchStartingForTheFirstTime = batchRepository.isBatchDownloadStartingForTheFirstTime(downloadBatch.getBatchId());
+                boolean isBatchStartingForTheFirstTime = batchRepository.isBatchStartingForTheFirstTime(downloadBatch.getBatchId());
                 if (isBatchStartingForTheFirstTime) {
                     handleBatchStartingForTheFirstTime(downloadBatch);
                 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -80,7 +80,7 @@ class DownloadTask implements Runnable {
     private final SystemFacade systemFacade;
     private final StorageManager storageManager;
     private final DownloadNotifier downloadNotifier;
-    private final BatchTerminationBroadcaster batchTerminationBroadcaster;
+    private final BatchInformationBroadcaster batchInformationBroadcaster;
     private final BatchRepository batchRepository;
     private final DownloadsUriProvider downloadsUriProvider;
     private final FileDownloadInfo.ControlStatus.Reader controlReader;
@@ -95,7 +95,7 @@ class DownloadTask implements Runnable {
                         DownloadBatch originalDownloadBatch,
                         StorageManager storageManager,
                         DownloadNotifier downloadNotifier,
-                        BatchTerminationBroadcaster batchTerminationBroadcaster,
+                        BatchInformationBroadcaster batchInformationBroadcaster,
                         BatchRepository batchRepository,
                         DownloadsUriProvider downloadsUriProvider,
                         FileDownloadInfo.ControlStatus.Reader controlReader,
@@ -109,7 +109,7 @@ class DownloadTask implements Runnable {
         this.originalDownloadBatch = originalDownloadBatch;
         this.storageManager = storageManager;
         this.downloadNotifier = downloadNotifier;
-        this.batchTerminationBroadcaster = batchTerminationBroadcaster;
+        this.batchInformationBroadcaster = batchInformationBroadcaster;
         this.batchRepository = batchRepository;
         this.downloadsUriProvider = downloadsUriProvider;
         this.controlReader = controlReader;
@@ -835,9 +835,9 @@ class DownloadTask implements Runnable {
             batchRepository.setBatchItemsCancelled(batchId);
         } else if (DownloadStatus.isFailure(batchStatus)) {
             batchRepository.setBatchItemsFailed(batchId, downloadId);
-            batchTerminationBroadcaster.notifyBatchFailedFor(batchId);
+            batchInformationBroadcaster.notifyBatchFailedFor(batchId);
         } else if (DownloadStatus.isSuccess(batchStatus)) {
-            batchTerminationBroadcaster.notifyBatchCompletedFor(batchId);
+            batchInformationBroadcaster.notifyBatchCompletedFor(batchId);
         }
     }
 


### PR DESCRIPTION
### Track and broacast when a batch starts for the first time

Need to be able to detect when a batch starts for the first time so that external app can react on this. 

* add a new column to the Batch table, default to zero
* Up the DB version to 2 and handle migration

* when a batch download starts, check the column
 * if value is zero, mark batch has started and broadcast an event

* expose the broadcast ACTION so that app using the lib can listen for it