### PR TITLE
Send broadcast when the download was cancelled as well as successful

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -241,7 +241,8 @@ public class BatchQuery {
         }
 
         private boolean isNotLast(Criteria.Builder criteriaBuilder, List<Criteria.Builder> criteriaBuilders) {
-            return criteriaBuilders.indexOf(criteriaBuilder) != (criteriaBuilders.size() - 1);
+            int lastIndex = criteriaBuilders.size() - 1;
+            return criteriaBuilders.indexOf(criteriaBuilder) != lastIndex;
         }
 
         private List<Criteria.Builder> combineCriteriaBuilders() {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -1099,8 +1099,7 @@ public class DownloadManager {
         }
 
         private long getErrorCode(int status) {
-            if (400 <= status && status < DownloadStatus.MIN_ARTIFICIAL_ERROR_STATUS
-                    || 500 <= status && status < 600) {
+            if (isHttpClientError(status) || isHttpServerError(status)) {
                 // HTTP status code
                 return status;
             }
@@ -1134,6 +1133,14 @@ public class DownloadManager {
                 default:
                     return ERROR_UNKNOWN;
             }
+        }
+
+        private boolean isHttpClientError(int status) {
+            return 400 <= status && status < DownloadStatus.MIN_ARTIFICIAL_ERROR_STATUS;
+        }
+
+        private boolean isHttpServerError(int status) {
+            return 500 <= status && status < 600;
         }
 
         private int translateStatus(int status) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -871,7 +871,7 @@ public class DownloadManager {
                 .setTitle(title)
                 .setDescription(description)
                 .setMimeType(mimeType)
-                .setNotificationVisibility((showNotification) ? NotificationVisibility.ONLY_WHEN_COMPLETE : NotificationVisibility.HIDDEN);
+                .setNotificationVisibility(showNotification ? NotificationVisibility.ONLY_WHEN_COMPLETE : NotificationVisibility.HIDDEN);
 
         if (isMediaScannerScannable) {
             request.allowScanningByMediaScanner();
@@ -1099,8 +1099,8 @@ public class DownloadManager {
         }
 
         private long getErrorCode(int status) {
-            if ((400 <= status && status < DownloadStatus.MIN_ARTIFICIAL_ERROR_STATUS)
-                    || (500 <= status && status < 600)) {
+            if (400 <= status && status < DownloadStatus.MIN_ARTIFICIAL_ERROR_STATUS
+                    || 500 <= status && status < 600) {
                 // HTTP status code
                 return status;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotificationDisplayer.java
@@ -114,17 +114,15 @@ class NotificationDisplayer {
             hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
             builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, hideIntent, 0));
 
-            if (type == DownloadNotifier.TYPE_SUCCESS) {
-                builder.setAutoCancel(true);
+            builder.setAutoCancel(true);
 
-                String action = DownloadStatus.isError(batch.getStatus()) ? Constants.ACTION_LIST : Constants.ACTION_OPEN;
+            String action = DownloadStatus.isError(batch.getStatus()) ? Constants.ACTION_LIST : Constants.ACTION_OPEN;
 
-                Intent clickIntent = new Intent(action, uri, context, DownloadReceiver.class);
-                clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, new long[]{batchId});
-                clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES, new int[]{batchStatus});
-                clickIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
-                builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
-            }
+            Intent clickIntent = new Intent(action, uri, context, DownloadReceiver.class);
+            clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, new long[]{batchId});
+            clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES, new int[]{batchStatus});
+            clickIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
+            builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         }
     }
 


### PR DESCRIPTION
Title ^

The code modified is inside another `if-else` that says if the download is`TYPE_SUCCESS || TYPE_CANCELLED` then create the notification, but then we would only fire a broadcast event for `SUCCESS`, now we do both.

Before | After
--- | ---
![before](https://cloud.githubusercontent.com/assets/1626673/10457241/baa3d9ea-71c5-11e5-8380-780283eb136c.gif) | ![after](https://cloud.githubusercontent.com/assets/1626673/10457244/be4e3ce8-71c5-11e5-9c04-9e1d95cc41a0.gif)

