### PR TITLE
Moves more notification code to package

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Constants.java
@@ -42,29 +42,9 @@ class Constants {
     public static final String ACTION_RETRY = "android.intent.action.DOWNLOAD_WAKEUP";
 
     /**
-     * the intent that gets sent when clicking a successful download
-     */
-    public static final String ACTION_OPEN = "android.intent.action.DOWNLOAD_OPEN";
-
-    /**
-     * the intent that gets sent when clicking an incomplete/failed download
-     */
-    public static final String ACTION_LIST = "android.intent.action.DOWNLOAD_LIST";
-
-    /**
-     * the intent that gets sent when deleting the notification of a completed download
-     */
-    public static final String ACTION_HIDE = "android.intent.action.DOWNLOAD_HIDE";
-
-    /**
      * the intent that gets sent when cancelling a download via a notification action
      */
     public static final String ACTION_CANCEL = "android.intent.action.DOWNLOAD_CANCEL";
-
-    /**
-     * the intent that gets sent when deleting a download via a notification action
-     */
-    public static final String ACTION_DELETE = "android.intent.action.DOWNLOAD_DELETE";
 
     /**
      * The default base name for downloaded files if we can't get one at the HTTP level

--- a/library/src/main/java/com/novoda/downloadmanager/lib/CursorTranslator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/CursorTranslator.java
@@ -15,9 +15,9 @@ import java.io.File;
  */
 class CursorTranslator extends CursorWrapper {
     private final Uri baseUri;
-    private final StatusTranslator statusTranslator;
+    private final PublicFacingStatusTranslator statusTranslator;
 
-    public CursorTranslator(Cursor cursor, Uri baseUri, StatusTranslator statusTranslator) {
+    public CursorTranslator(Cursor cursor, Uri baseUri, PublicFacingStatusTranslator statusTranslator) {
         super(cursor);
         this.baseUri = baseUri;
         this.statusTranslator = statusTranslator;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadManager.java
@@ -646,7 +646,7 @@ public class DownloadManager {
         if (underlyingCursor == null) {
             return null;
         }
-        StatusTranslator statusTranslator = new StatusTranslator();
+        PublicFacingStatusTranslator statusTranslator = new PublicFacingStatusTranslator();
         return new CursorTranslator(underlyingCursor, downloadsUriProvider.getDownloadsByBatchUri(), statusTranslator);
     }
 
@@ -665,7 +665,7 @@ public class DownloadManager {
             return null;
         }
 
-        StatusTranslator statusTranslator = new StatusTranslator();
+        PublicFacingStatusTranslator statusTranslator = new PublicFacingStatusTranslator();
         return new CursorTranslator(cursor, downloadsUriProvider.getBatchesUri(), statusTranslator);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -28,6 +28,7 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.novoda.downloadmanager.lib.logger.LLog;
+import com.novoda.downloadmanager.notifications.DownloadNotifier;
 
 import java.io.Closeable;
 import java.io.File;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsUriProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsUriProvider.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager.lib;
 
 import android.net.Uri;
 
-class DownloadsUriProvider {
+public class DownloadsUriProvider {
 
     private final Uri publiclyAccessibleDownloadsUri;
     private final Uri downloadsByBatchUri;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/NotifierWriter.java
@@ -4,6 +4,8 @@ import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.os.SystemClock;
 
+import com.novoda.downloadmanager.notifications.DownloadNotifier;
+
 import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.COLUMN_CURRENT_BYTES;
 
 class NotifierWriter implements DataWriter {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingDownloadMarshaller.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingDownloadMarshaller.java
@@ -2,7 +2,13 @@ package com.novoda.downloadmanager.lib;
 
 import com.novoda.downloadmanager.Download;
 
-class PublicFacingDownloadMarshaller {
+/**
+ * The idea is we don't want to expose DownloadBatch on the public api methods,
+ * so we always convert to a `Download` before passing externally
+ *
+ * This allows us to keep a private api for DownloadBatch and change it as we please
+ */
+public class PublicFacingDownloadMarshaller {
 
     public Download marshall(DownloadBatch downloadBatch) {
         long batchId = downloadBatch.getBatchId();

--- a/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager.lib;
 
-class StatusTranslator {
+public class PublicFacingStatusTranslator {
 
     public int translate(int status) {
         switch (status) {

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifier.java
@@ -1,0 +1,13 @@
+package com.novoda.downloadmanager.notifications;
+
+import com.novoda.downloadmanager.lib.DownloadBatch;
+
+import java.util.Collection;
+
+public interface DownloadNotifier {
+    void cancelAll();
+
+    void notifyDownloadSpeed(long id, long bytesPerSecond);
+
+    void updateWith(Collection<DownloadBatch> batches);
+}

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifierFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifierFactory.java
@@ -1,0 +1,44 @@
+package com.novoda.downloadmanager.notifications;
+
+import android.app.NotificationManager;
+import android.content.Context;
+import android.content.res.Resources;
+
+import com.novoda.downloadmanager.lib.DownloadManagerModules;
+import com.novoda.downloadmanager.lib.DownloadsUriProvider;
+import com.novoda.downloadmanager.lib.PublicFacingDownloadMarshaller;
+import com.novoda.downloadmanager.lib.PublicFacingStatusTranslator;
+
+public class DownloadNotifierFactory {
+
+    public DownloadNotifier getDownloadNotifier(Context context,
+                                                DownloadManagerModules modules,
+                                                PublicFacingDownloadMarshaller downloadMarshaller,
+                                                PublicFacingStatusTranslator statusTranslator) {
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        Resources resources = context.getResources();
+        NotificationDisplayer notificationDisplayer = new NotificationDisplayer(
+                context,
+                notificationManager,
+                modules.getNotificationImageRetriever(),
+                resources,
+                DownloadsUriProvider.getInstance(),
+                createNotificationCustomiser(modules),
+                statusTranslator,
+                downloadMarshaller
+        );
+
+        return new SynchronisedDownloadNotifier(context, notificationDisplayer);
+    }
+
+    private NotificationCustomiser createNotificationCustomiser(DownloadManagerModules downloadManagerModules) {
+        QueuedNotificationCustomiser queued = downloadManagerModules.getQueuedNotificationCustomiser();
+        DownloadingNotificationCustomiser downloading = downloadManagerModules.getDownloadingNotificationCustomiser();
+        CompleteNotificationCustomiser complete = downloadManagerModules.getCompleteNotificationCustomiser();
+        CancelledNotificationCustomiser cancelled = downloadManagerModules.getCancelledNotificationCustomiser();
+        FailedNotificationCustomiser failed = downloadManagerModules.getFailedNotificationCustomiser();
+
+        return new NotificationCustomiser(queued, downloading, complete, cancelled, failed);
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -1,4 +1,4 @@
-package com.novoda.downloadmanager.lib;
+package com.novoda.downloadmanager.notifications;
 
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -17,28 +17,45 @@ import android.text.format.DateUtils;
 
 import com.novoda.downloadmanager.Download;
 import com.novoda.downloadmanager.R;
-import com.novoda.downloadmanager.notifications.NotificationCustomiser;
-import com.novoda.downloadmanager.notifications.NotificationImageRetriever;
+import com.novoda.downloadmanager.lib.DownloadBatch;
+import com.novoda.downloadmanager.lib.DownloadManager;
+import com.novoda.downloadmanager.lib.DownloadReceiver;
+import com.novoda.downloadmanager.lib.DownloadsUriProvider;
+import com.novoda.downloadmanager.lib.PublicFacingDownloadMarshaller;
+import com.novoda.downloadmanager.lib.PublicFacingStatusTranslator;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-class NotificationDisplayer {
+public class NotificationDisplayer {
+
+    /**
+     * the intent that gets sent when deleting the notification of a completed download
+     */
+    public static final String ACTION_HIDE = "android.intent.action.DOWNLOAD_HIDE";
+    /**
+     * the intent that gets sent when clicking an incomplete/failed download
+     */
+    public static final String ACTION_LIST = "android.intent.action.DOWNLOAD_LIST";
+    /**
+     * the intent that gets sent when clicking a successful download
+     */
+    public static final String ACTION_OPEN = "android.intent.action.DOWNLOAD_OPEN";
+
     private final Context context;
     private final NotificationManager notificationManager;
     private final NotificationImageRetriever imageRetriever;
     private final Resources resources;
     private final DownloadsUriProvider downloadsUriProvider;
-
     /**
-     * Current speed of active downloads, mapped from {@link FileDownloadInfo#batchId}
+     * Current speed of active downloads, mapped from {@link DownloadBatch#batchId}
      * to speed in bytes per second.
      */
     private final LongSparseArray<Long> downloadSpeed = new LongSparseArray<>();
     private final NotificationCustomiser notificationCustomiser;
-    private final StatusTranslator statusTranslator;
+    private final PublicFacingStatusTranslator statusTranslator;
     private final PublicFacingDownloadMarshaller downloadMarshaller;
 
     public NotificationDisplayer(
@@ -48,7 +65,7 @@ class NotificationDisplayer {
             Resources resources,
             DownloadsUriProvider downloadsUriProvider,
             NotificationCustomiser notificationCustomiser,
-            StatusTranslator statusTranslator,
+            PublicFacingStatusTranslator statusTranslator,
             PublicFacingDownloadMarshaller downloadMarshaller) {
         this.context = context;
         this.notificationManager = notificationManager;
@@ -75,7 +92,7 @@ class NotificationDisplayer {
 
     /**
      * Return the cluster type of the given as created by
-     * {@link DownloadNotifier#buildNotificationTag(DownloadBatch)}.
+     * {@link SynchronisedDownloadNotifier#buildNotificationTag(DownloadBatch)}.
      */
     private int getNotificationTagType(String tag) {
         return Integer.parseInt(tag.substring(0, tag.indexOf(':')));
@@ -83,14 +100,14 @@ class NotificationDisplayer {
 
     private void buildIcon(int type, NotificationCompat.Builder builder) {
         switch (type) {
-            case DownloadNotifier.TYPE_ACTIVE:
+            case SynchronisedDownloadNotifier.TYPE_ACTIVE:
                 builder.setSmallIcon(android.R.drawable.stat_sys_download);
                 break;
-            case DownloadNotifier.TYPE_WAITING:
-            case DownloadNotifier.TYPE_FAILED:
+            case SynchronisedDownloadNotifier.TYPE_WAITING:
+            case SynchronisedDownloadNotifier.TYPE_FAILED:
                 builder.setSmallIcon(android.R.drawable.stat_sys_warning);
                 break;
-            case DownloadNotifier.TYPE_SUCCESS:
+            case SynchronisedDownloadNotifier.TYPE_SUCCESS:
                 builder.setSmallIcon(android.R.drawable.stat_sys_download_done);
                 break;
             default:
@@ -103,24 +120,24 @@ class NotificationDisplayer {
         DownloadBatch batch = cluster.iterator().next();
         long batchId = batch.getBatchId();
         int batchStatus = batch.getStatus();
-        if (type == DownloadNotifier.TYPE_ACTIVE || type == DownloadNotifier.TYPE_WAITING) {
+        if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE || type == SynchronisedDownloadNotifier.TYPE_WAITING) {
             // build a synthetic uri for intent identification purposes
             Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
 
-            Intent clickIntent = createClickIntent(Constants.ACTION_LIST, batchId, batchStatus, uri);
+            Intent clickIntent = createClickIntent(ACTION_LIST, batchId, batchStatus, uri);
             builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             builder.setOngoing(true);
-        } else if (type == DownloadNotifier.TYPE_SUCCESS || type == DownloadNotifier.TYPE_CANCELLED) {
-            FileDownloadInfo fileDownloadInfo = batch.getDownloads().get(0);
-            Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), fileDownloadInfo.getId());
+        } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS || type == SynchronisedDownloadNotifier.TYPE_CANCELLED) {
+            long firstDownloadBatchId = batch.getFirstDownloadBatchId(); // TODO why can't we just use getBatchId()?
+            Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), firstDownloadBatchId);
 
-            Intent hideIntent = new Intent(Constants.ACTION_HIDE, uri, context, DownloadReceiver.class);
+            Intent hideIntent = new Intent(ACTION_HIDE, uri, context, DownloadReceiver.class);
             hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
             builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, hideIntent, 0));
 
             builder.setAutoCancel(true);
 
-            String action = DownloadStatus.isError(batch.getStatus()) ? Constants.ACTION_LIST : Constants.ACTION_OPEN;
+            String action = batch.isError() ? ACTION_LIST : ACTION_OPEN;
             Intent clickIntent = createClickIntent(action, batchId, batchStatus, uri);
             builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         }
@@ -131,19 +148,19 @@ class NotificationDisplayer {
     private void customiseNotification(int type, NotificationCompat.Builder builder, DownloadBatch batch) {
         Download download = downloadMarshaller.marshall(batch);
         switch (type) {
-            case DownloadNotifier.TYPE_WAITING:
+            case SynchronisedDownloadNotifier.TYPE_WAITING:
                 notificationCustomiser.customiseQueued(download, builder);
                 break;
-            case DownloadNotifier.TYPE_ACTIVE:
+            case SynchronisedDownloadNotifier.TYPE_ACTIVE:
                 notificationCustomiser.customiseDownloading(download, builder);
                 break;
-            case DownloadNotifier.TYPE_SUCCESS:
+            case SynchronisedDownloadNotifier.TYPE_SUCCESS:
                 notificationCustomiser.customiseComplete(download, builder);
                 break;
-            case DownloadNotifier.TYPE_CANCELLED:
+            case SynchronisedDownloadNotifier.TYPE_CANCELLED:
                 notificationCustomiser.customiseCancelled(download, builder);
                 break;
-            case DownloadNotifier.TYPE_FAILED:
+            case SynchronisedDownloadNotifier.TYPE_FAILED:
                 notificationCustomiser.customiseFailed(download, builder);
                 break;
             default:
@@ -165,35 +182,29 @@ class NotificationDisplayer {
     private Notification buildTitlesAndDescription(int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
         String remainingText = null;
         String percentText = null;
-        if (type == DownloadNotifier.TYPE_ACTIVE) {
-            long currentBytes = 0;
-            long totalBytes = 0;
-            long totalBytesPerSecond = 0;
+        if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE) {
+            int totalPercent = 0;
+            long remainingMillis = 0;
             synchronized (downloadSpeed) {
-                for (DownloadBatch batch : cluster) {
-                    for (FileDownloadInfo info : batch.getDownloads()) {
-                        if (info.hasTotalBytes()) {
-                            currentBytes += info.getCurrentBytes();
-                            totalBytes += info.getTotalBytes();
-                            Long bytesPerSecond = downloadSpeed.get(info.getId());
-                            if (bytesPerSecond != null) {
-                                totalBytesPerSecond += bytesPerSecond;
-                            }
-                        }
-                    }
+                if (cluster.size() > 1) {
+                    throw new IllegalStateException("is this ever over 1? reading this in the log means yes");
                 }
+                for (DownloadBatch batch : cluster) {
+                    DownloadBatch.Statistics statistics = batch.getLiveStatistics(downloadSpeed);
+                    totalPercent += statistics.getPercentComplete();
+                    remainingMillis += statistics.getTimeRemaining();
+                }
+                totalPercent /= cluster.size();
             }
 
-            if (totalBytes > 0) {
-                int percent = (int) ((currentBytes * 100) / totalBytes);
-                percentText = context.getString(R.string.dl__download_percent, percent);
+            if (totalPercent > 0) {
+                percentText = context.getString(R.string.dl__download_percent, totalPercent);
 
-                if (totalBytesPerSecond > 0) {
-                    long remainingMillis = ((totalBytes - currentBytes) * 1000) / totalBytesPerSecond;
+                if (remainingMillis > 0) {
                     remainingText = context.getString(R.string.dl__duration, formatDuration(remainingMillis));
                 }
 
-                builder.setProgress(100, percent, false);
+                builder.setProgress(100, totalPercent, false);
             } else {
                 builder.setProgress(100, 0, true);
             }
@@ -207,7 +218,6 @@ class NotificationDisplayer {
         if (currentBatches.size() == 1) {
             DownloadBatch batch = currentBatches.iterator().next();
             return buildSingleNotification(type, builder, batch, remainingText, percentText);
-
         } else {
             return buildStackedNotification(type, builder, currentBatches, remainingText, percentText);
         }
@@ -220,17 +230,17 @@ class NotificationDisplayer {
             String percentText) {
 
         NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle();
-        String imageUrl = batch.getInfo().getBigPictureUrl();
+        String imageUrl = batch.getBigPictureUrl();
         if (!TextUtils.isEmpty(imageUrl)) {
             Bitmap bitmap = imageRetriever.retrieveImage(imageUrl);
             style.bigPicture(bitmap);
         }
-        CharSequence title = getDownloadTitle(batch.getInfo());
+        CharSequence title = getDownloadTitle(batch);
         builder.setContentTitle(title);
         style.setBigContentTitle(title);
 
-        if (type == DownloadNotifier.TYPE_ACTIVE) {
-            String description = batch.getInfo().getDescription();
+        if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE) {
+            String description = batch.getDescription();
             if (TextUtils.isEmpty(description)) {
                 setSecondaryNotificationText(builder, style, remainingText);
             } else {
@@ -238,14 +248,14 @@ class NotificationDisplayer {
             }
             builder.setContentInfo(percentText);
 
-        } else if (type == DownloadNotifier.TYPE_WAITING) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_WAITING) {
             setSecondaryNotificationText(builder, style, context.getString(R.string.dl__download_size_requires_wifi));
 
-        } else if (type == DownloadNotifier.TYPE_SUCCESS) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS) {
             setSecondaryNotificationText(builder, style, context.getString(R.string.dl__download_complete));
-        } else if (type == DownloadNotifier.TYPE_FAILED) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_FAILED) {
             setSecondaryNotificationText(builder, style, context.getString(R.string.dl__download_unsuccessful));
-        } else if (type == DownloadNotifier.TYPE_CANCELLED) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_CANCELLED) {
             setSecondaryNotificationText(builder, style, context.getString(R.string.dl__download_cancelled));
         }
 
@@ -255,7 +265,7 @@ class NotificationDisplayer {
         return builder.build();
     }
 
-    private CharSequence getDownloadTitle(BatchInfo batch) {
+    private CharSequence getDownloadTitle(DownloadBatch batch) {
         String title = batch.getTitle();
         if (TextUtils.isEmpty(title)) {
             return context.getString(R.string.dl__title_unknown);
@@ -279,21 +289,21 @@ class NotificationDisplayer {
         final NotificationCompat.InboxStyle inboxStyle = new NotificationCompat.InboxStyle(builder);
 
         for (DownloadBatch batch : currentBatches) {
-            inboxStyle.addLine(getDownloadTitle(batch.getInfo()));
+            inboxStyle.addLine(getDownloadTitle(batch));
         }
 
-        if (type == DownloadNotifier.TYPE_ACTIVE) {
+        if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE) {
             builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_active, currentBatches.size(), currentBatches.size()));
             builder.setContentInfo(percentText);
             setSecondaryNotificationText(builder, inboxStyle, remainingText);
-        } else if (type == DownloadNotifier.TYPE_WAITING) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_WAITING) {
             builder.setContentTitle(resources.getQuantityString(R.plurals.dl__notif_summary_waiting, currentBatches.size(), currentBatches.size()));
             setSecondaryNotificationText(builder, inboxStyle, context.getString(R.string.dl__download_size_requires_wifi));
-        } else if (type == DownloadNotifier.TYPE_SUCCESS) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS) {
             setSecondaryNotificationText(builder, inboxStyle, context.getString(R.string.dl__download_complete));
-        } else if (type == DownloadNotifier.TYPE_FAILED) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_FAILED) {
             setSecondaryNotificationText(builder, inboxStyle, context.getString(R.string.dl__download_unsuccessful));
-        } else if (type == DownloadNotifier.TYPE_CANCELLED) {
+        } else if (type == SynchronisedDownloadNotifier.TYPE_CANCELLED) {
             setSecondaryNotificationText(builder, inboxStyle, context.getString(R.string.dl__download_cancelled));
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/SynchronisedDownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/SynchronisedDownloadNotifier.java
@@ -120,6 +120,8 @@ class SynchronisedDownloadNotifier implements DownloadNotifier {
      * {@link Notification}.
      */
     private String buildNotificationTag(DownloadBatch batch) {
+        // TODO this method and NotificationDisplayer.#getNotificationTagType have an inherent contract
+        // If we pulled out a `NotificationTag` value object this would fix it
         if (batch.isQueuedForWifi()) {
             return TYPE_WAITING + ":" + context.getPackageName();
         } else if (batch.isRunning() && batch.shouldShowActiveItem()) {

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/SynchronisedDownloadNotifier.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/SynchronisedDownloadNotifier.java
@@ -14,28 +14,26 @@
  * limitations under the License.
  */
 
-package com.novoda.downloadmanager.lib;
+package com.novoda.downloadmanager.notifications;
 
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
-import android.support.annotation.NonNull;
 import android.support.v4.util.SimpleArrayMap;
 
-import com.novoda.downloadmanager.lib.logger.LLog;
-import com.novoda.downloadmanager.notifications.NotificationVisibility;
+import com.novoda.downloadmanager.lib.DownloadBatch;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 /**
- * Update {@link NotificationManager} to reflect current {@link FileDownloadInfo}
- * states. Collapses similar downloads into a single notification, and builds
+ * Update {@link NotificationManager} to reflect current {@link DownloadBatch} states.
+ * Collapses similar downloads into a single notification, and builds
  * {@link PendingIntent} that launch towards {DownloadReceiver}.
  */
-class DownloadNotifier {
+class SynchronisedDownloadNotifier implements DownloadNotifier {
 
     static final int TYPE_ACTIVE = 1;
     static final int TYPE_WAITING = 2;
@@ -55,11 +53,12 @@ class DownloadNotifier {
 
     private final NotificationDisplayer notificationDisplayer;
 
-    public DownloadNotifier(Context context, NotificationDisplayer notificationDisplayer) {
+    public SynchronisedDownloadNotifier(Context context, NotificationDisplayer notificationDisplayer) {
         this.context = context;
         this.notificationDisplayer = notificationDisplayer;
     }
 
+    @Override
     public void cancelAll() {
         notificationDisplayer.cancelAll();
     }
@@ -68,14 +67,16 @@ class DownloadNotifier {
      * Notify the current speed of an active download, used for calculating
      * estimated remaining time.
      */
+    @Override
     public void notifyDownloadSpeed(long id, long bytesPerSecond) {
         notificationDisplayer.notifyDownloadSpeed(id, bytesPerSecond);
     }
 
     /**
-     * Update {@link NotificationManager} to reflect the given set of
-     * {@link FileDownloadInfo}, adding, collapsing, and removing as needed.
+     * Update Notifications to reflect the given set of
+     * {@link DownloadBatch}, adding, collapsing, and removing as needed.
      */
+    @Override
     public void updateWith(Collection<DownloadBatch> batches) {
         synchronized (activeNotifications) {
             SimpleArrayMap<String, Collection<DownloadBatch>> clusters = getClustersByNotificationTag(batches);
@@ -102,7 +103,6 @@ class DownloadNotifier {
         return firstShown;
     }
 
-    @NonNull
     private SimpleArrayMap<String, Collection<DownloadBatch>> getClustersByNotificationTag(Collection<DownloadBatch> batches) {
         SimpleArrayMap<String, Collection<DownloadBatch>> clustered = new SimpleArrayMap<>();
 
@@ -116,39 +116,26 @@ class DownloadNotifier {
     }
 
     /**
-     * Build tag used for collapsing several {@link FileDownloadInfo} into a single
+     * Build tag used for collapsing several {@link DownloadBatch} into a single
      * {@link Notification}.
      */
     private String buildNotificationTag(DownloadBatch batch) {
-        int status = batch.getStatus();
-        int visibility = batch.getInfo().getVisibility();
-        if (status == DownloadStatus.QUEUED_FOR_WIFI) {
+        if (batch.isQueuedForWifi()) {
             return TYPE_WAITING + ":" + context.getPackageName();
-        } else if (status == DownloadStatus.RUNNING && shouldShowActiveItem(visibility)) {
+        } else if (batch.isRunning() && batch.shouldShowActiveItem()) {
             return TYPE_ACTIVE + ":" + context.getPackageName();
-        } else if (DownloadStatus.isError(status) && !DownloadStatus.isCancelled(status)
-                && shouldShowCompletedItem(visibility)) {
+        } else if (batch.isError() && !batch.isCancelled() && batch.shouldShowCompletedItem()) {
             // Failed downloads always have unique notifications
             return TYPE_FAILED + ":" + batch.getBatchId();
-        } else if (DownloadStatus.isCancelled(status) && shouldShowCompletedItem(visibility)) {
+        } else if (batch.isCancelled() && batch.shouldShowCompletedItem()) {
             // Cancelled downloads always have unique notifications
             return TYPE_CANCELLED + ":" + batch.getBatchId();
-        } else if (DownloadStatus.isSuccess(status) && shouldShowCompletedItem(visibility)) {
+        } else if (batch.isSuccess() && batch.shouldShowCompletedItem()) {
             // Complete downloads always have unique notifications
             return TYPE_SUCCESS + ":" + batch.getBatchId();
         } else {
             return null;
         }
-    }
-
-    private boolean shouldShowActiveItem(int visibility) {
-        return visibility == NotificationVisibility.ONLY_WHEN_ACTIVE
-                || visibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
-    }
-
-    private boolean shouldShowCompletedItem(int visibility) {
-        return visibility == NotificationVisibility.ONLY_WHEN_COMPLETE
-                || visibility == NotificationVisibility.ACTIVE_OR_COMPLETE;
     }
 
     private void addBatchToCluster(String tag, SimpleArrayMap<String, Collection<DownloadBatch>> cluster, DownloadBatch batch) {
@@ -182,7 +169,4 @@ class DownloadNotifier {
         return staleTags;
     }
 
-    public void dumpSpeeds() {
-        LLog.e("dump at speed");
-    }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/notifications/DownloadNotifierTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/notifications/DownloadNotifierTest.java
@@ -1,7 +1,13 @@
-package com.novoda.downloadmanager.lib;
+package com.novoda.downloadmanager.notifications;
 
 import android.content.Context;
 
+import com.novoda.downloadmanager.lib.BatchInfo;
+import com.novoda.downloadmanager.lib.DownloadBatch;
+import com.novoda.downloadmanager.lib.DownloadStatus;
+import com.novoda.downloadmanager.lib.FileDownloadInfo;
+import com.novoda.downloadmanager.notifications.DownloadNotifier;
+import com.novoda.downloadmanager.notifications.NotificationDisplayer;
 import com.novoda.downloadmanager.notifications.NotificationVisibility;
 
 import java.util.ArrayList;
@@ -29,17 +35,17 @@ public class DownloadNotifierTest {
     public void whenRemovingStaleNotificationsThenItDoesNotCrash() {
         Collection<DownloadBatch> batches = new ArrayList<>();
 
-        DownloadBatch batchQueuedForWifi = getDownloadBatchWith(DownloadStatus.QUEUED_FOR_WIFI);
-        DownloadBatch batchRunning = getDownloadBatchWith(DownloadStatus.RUNNING);
+        DownloadBatch batchQueuedForWifi = getDownloadBatchWith(196); // Queued for Wifi
+        DownloadBatch batchRunning = getDownloadBatchWith(192); // Running
 
         batches.add(batchQueuedForWifi);
         batches.add(batchRunning);
 
         Collection<DownloadBatch> updatedBatches = new ArrayList<>();
-        DownloadBatch batchQueuedForWifiUpdated = getDownloadBatchWith(DownloadStatus.QUEUED_FOR_WIFI);
+        DownloadBatch batchQueuedForWifiUpdated = getDownloadBatchWith(192); // Queued for Wifi
         updatedBatches.add(batchQueuedForWifiUpdated);
 
-        DownloadNotifier downloadNotifier = new DownloadNotifier(mockContext, mockNotificationDisplayer);
+        DownloadNotifier downloadNotifier = new SynchronisedDownloadNotifier(mockContext, mockNotificationDisplayer);
         downloadNotifier.updateWith(batches);
         downloadNotifier.updateWith(updatedBatches);
     }

--- a/library/src/test/java/com/novoda/downloadmanager/notifications/DownloadNotifierTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/notifications/DownloadNotifierTest.java
@@ -2,13 +2,7 @@ package com.novoda.downloadmanager.notifications;
 
 import android.content.Context;
 
-import com.novoda.downloadmanager.lib.BatchInfo;
 import com.novoda.downloadmanager.lib.DownloadBatch;
-import com.novoda.downloadmanager.lib.DownloadStatus;
-import com.novoda.downloadmanager.lib.FileDownloadInfo;
-import com.novoda.downloadmanager.notifications.DownloadNotifier;
-import com.novoda.downloadmanager.notifications.NotificationDisplayer;
-import com.novoda.downloadmanager.notifications.NotificationVisibility;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -17,6 +11,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class DownloadNotifierTest {
@@ -35,14 +31,14 @@ public class DownloadNotifierTest {
     public void whenRemovingStaleNotificationsThenItDoesNotCrash() {
         Collection<DownloadBatch> batches = new ArrayList<>();
 
-        DownloadBatch batchQueuedForWifi = getDownloadBatchWith(196); // Queued for Wifi
-        DownloadBatch batchRunning = getDownloadBatchWith(192); // Running
+        DownloadBatch batchQueuedForWifi = getQueuedForWifiDownloadBatch();
+        DownloadBatch batchRunning = getRunningDownloadBatch();
 
         batches.add(batchQueuedForWifi);
         batches.add(batchRunning);
 
         Collection<DownloadBatch> updatedBatches = new ArrayList<>();
-        DownloadBatch batchQueuedForWifiUpdated = getDownloadBatchWith(192); // Queued for Wifi
+        DownloadBatch batchQueuedForWifiUpdated = getQueuedForWifiDownloadBatch();
         updatedBatches.add(batchQueuedForWifiUpdated);
 
         DownloadNotifier downloadNotifier = new SynchronisedDownloadNotifier(mockContext, mockNotificationDisplayer);
@@ -50,13 +46,17 @@ public class DownloadNotifierTest {
         downloadNotifier.updateWith(updatedBatches);
     }
 
-    private DownloadBatch getDownloadBatchWith(int status) {
-        return new DownloadBatch(
-                1,
-                new BatchInfo("", "", "", NotificationVisibility.ACTIVE_OR_COMPLETE, ""),
-                new ArrayList<FileDownloadInfo>(),
-                status,
-                1,
-                1);
+    private DownloadBatch getQueuedForWifiDownloadBatch() {
+        DownloadBatch downloadBatch = mock(DownloadBatch.class);
+        when(downloadBatch.shouldShowActiveItem()).thenReturn(true);
+        when(downloadBatch.isQueuedForWifi()).thenReturn(true);
+        return downloadBatch;
+    }
+
+    private DownloadBatch getRunningDownloadBatch() {
+        DownloadBatch downloadBatch = mock(DownloadBatch.class);
+        when(downloadBatch.shouldShowActiveItem()).thenReturn(true);
+        when(downloadBatch.isRunning()).thenReturn(true);
+        return downloadBatch;
     }
 }


### PR DESCRIPTION
Moves behaviour onto the DownloadBatch so that it is not showing its innards

Moves the actions specifically used for notifications to that package.

Renames status translator to the `PublicFacing` pattern, not ideal but matches other code for now.

Removes unused code.

Creates a factory for the `DownloaNotifier` so that we can create it all in 1 package.

Still more to do, refactoring towards a complete notification package, but this is starting to give our download manager more flexibility.

(merging into https://github.com/novoda/download-manager/pull/162)