### PR TITLE
Adds a static text for downloading so that it can be overwritten

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -214,7 +214,7 @@ public class NotificationDisplayer {
 
         if (currentBatches.size() == 1) {
             DownloadBatch batch = currentBatches.iterator().next();
-            return buildSingleNotification(type, builder, batch, remainingText, percentText);
+            return buildSingleNotification(type, builder, batch, percentText);
         } else {
             return buildStackedNotification(type, builder, currentBatches, remainingText, percentText);
         }
@@ -223,7 +223,7 @@ public class NotificationDisplayer {
     private Notification buildSingleNotification(
             int type,
             NotificationCompat.Builder builder,
-            DownloadBatch batch, String remainingText,
+            DownloadBatch batch,
             String percentText) {
 
         NotificationCompat.BigPictureStyle style = new NotificationCompat.BigPictureStyle();
@@ -239,7 +239,7 @@ public class NotificationDisplayer {
         if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE) {
             String description = batch.getDescription();
             if (TextUtils.isEmpty(description)) {
-                setSecondaryNotificationText(builder, style, remainingText);
+                setSecondaryNotificationText(builder, style, context.getString(R.string.dl__downloading));
             } else {
                 setSecondaryNotificationText(builder, style, description);
             }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="dl__cancel">Cancel</string>
+  <string name="dl__downloading">Downloading.</string>
   <string name="dl__download_cancelled">Download cancelled.</string>
   <string name="dl__download_unsuccessful">Download unsuccessful.</string>
   <string name="dl__download_complete">Download complete.</string>


### PR DESCRIPTION
If the client doesn't provide a description with the request for a download, it used to show a text with the remaining time, the problem being that it could not be changed from the client (from the customiser).

Using a static resource allows us to change it via resource overriding. This is not the ideal solution but it's good enough for now.