### PR TITLE
Handle failed notifications so that they get dismissed and click events work

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -203,14 +203,14 @@ final class DownloadStatus {
      * Returns whether the download has completed (either with success or error).
      */
     public static boolean isCompleted(int status) {
-        return isSuccess(status) || (isError(status) && !isCancelled(status));
+        return isSuccess(status) || isFailure(status);
     }
 
     /**
      * Returns whether the download has failed
      */
-    public static boolean isFailure(int batchStatus) {
-        return isError(batchStatus) && !isCancelled(batchStatus);
+    public static boolean isFailure(int status) {
+        return isError(status) && !isCancelled(status);
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -125,7 +125,7 @@ public class NotificationDisplayer {
             // build a synthetic uri for intent identification purposes
             Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
 
-            Intent clickIntent = createClickIntent(ACTION_LIST, batchId, batchStatus, uri);
+            Intent clickIntent = createClickIntent(ACTION_LIST, batchId, batchStatus, uri); // TODO: the Uri doesn't seem to be ever read
             builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             builder.setOngoing(true);
 
@@ -142,7 +142,7 @@ public class NotificationDisplayer {
             builder.setAutoCancel(true);
 
             String action = batch.isError() ? ACTION_LIST : ACTION_OPEN;
-            Intent clickIntent = createClickIntent(action, batchId, batchStatus, uri);
+            Intent clickIntent = createClickIntent(action, batchId, batchStatus, uri);  // TODO: the Uri doesn't seem to be ever read
             builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -120,6 +120,7 @@ public class NotificationDisplayer {
         DownloadBatch batch = cluster.iterator().next();
         long batchId = batch.getBatchId();
         int batchStatus = batch.getStatus();
+
         if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE || type == SynchronisedDownloadNotifier.TYPE_WAITING) {
             // build a synthetic uri for intent identification purposes
             Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
@@ -127,7 +128,10 @@ public class NotificationDisplayer {
             Intent clickIntent = createClickIntent(ACTION_LIST, batchId, batchStatus, uri);
             builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             builder.setOngoing(true);
-        } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS || type == SynchronisedDownloadNotifier.TYPE_CANCELLED) {
+
+        } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS
+                || type == SynchronisedDownloadNotifier.TYPE_CANCELLED
+                || type == SynchronisedDownloadNotifier.TYPE_FAILED) {
             long firstDownloadBatchId = batch.getFirstDownloadBatchId(); // TODO why can't we just use getBatchId()?
             Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), firstDownloadBatchId);
 


### PR DESCRIPTION
Title ^

### Before

the notifications for a failed download wouldn't fire any intent on click, and they'd reappear after being dismissed every time the DownloadService was recreated.

### After

the click works and they don't reappear after being dismissed

Fixes #51 , #143 