### PR TITLE
Uses multiple actions for click events on notifications so they can be handled differently

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -65,9 +65,13 @@ public class DownloadReceiver extends BroadcastReceiver { // TODO split this int
             case CONNECTIVITY_ACTION:
                 checkConnectivityToStartService(context);
                 break;
-            case NotificationDisplayer.ACTION_OPEN:
-            case NotificationDisplayer.ACTION_LIST:
-            case NotificationDisplayer.ACTION_HIDE:
+            case NotificationDisplayer.ACTION_DOWNLOAD_CANCELLED_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_FAILED_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_SUCCESS_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_RUNNING_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_SUBMITTED_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_OTHER_CLICK:
+            case NotificationDisplayer.ACTION_NOTIFICATION_DISMISSED:
             case ACTION_CANCEL:
                 handleSystemNotificationAction(context, intent);
                 break;
@@ -102,31 +106,33 @@ public class DownloadReceiver extends BroadcastReceiver { // TODO split this int
     }
 
     private void handleNotificationBroadcast(Context context, Intent intent) {
-        String action = intent.getAction();
         long[] ids = intent.getLongArrayExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS);
         int[] statuses = intent.getIntArrayExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES);
         long batchId = getBatchId(intent);
+
+        String action = intent.getAction();
         switch (action) {
-            case NotificationDisplayer.ACTION_LIST:
-                sendNotificationClickedIntent(context, ids, statuses);
-                if (DownloadStatus.isFailure(statuses[0])) {
-                    hideNotification(context, batchId);
-                }
-                break;
-            case NotificationDisplayer.ACTION_OPEN: {
+            case NotificationDisplayer.ACTION_DOWNLOAD_CANCELLED_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_FAILED_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_SUCCESS_CLICK:
                 sendNotificationClickedIntent(context, ids, statuses);
                 hideNotification(context, batchId);
                 break;
-            }
-            case NotificationDisplayer.ACTION_HIDE: {
+            case NotificationDisplayer.ACTION_DOWNLOAD_RUNNING_CLICK:
+            case NotificationDisplayer.ACTION_DOWNLOAD_SUBMITTED_CLICK:
+                sendNotificationClickedIntent(context, ids, statuses);
+                break;
+            case NotificationDisplayer.ACTION_NOTIFICATION_DISMISSED:
                 hideNotification(context, batchId);
                 break;
-            }
             case ACTION_CANCEL:
                 cancelBatchThroughDatabaseState(batchId);
                 break;
+            case NotificationDisplayer.ACTION_DOWNLOAD_OTHER_CLICK:
+                // no need for now, implement if needed
+                break;
             default:
-                // no need to handle any other cases
+                // shouldn't happen - other cases should be handled in ACTION_DOWNLOAD_OTHER_CLICK
                 break;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -129,7 +129,8 @@ public class DownloadReceiver extends BroadcastReceiver { // TODO split this int
                 cancelBatchThroughDatabaseState(batchId);
                 break;
             case NotificationDisplayer.ACTION_DOWNLOAD_OTHER_CLICK:
-                // no need for now, implement if needed
+                // not sure - but seems sensible to just dismiss the notification
+                hideNotification(context, batchId);
                 break;
             default:
                 // shouldn't happen - other cases should be handled in ACTION_DOWNLOAD_OTHER_CLICK

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -10,7 +10,7 @@ package com.novoda.downloadmanager.lib;
  * 4xx: client errors<br>
  * 5xx: server errors
  */
-final class DownloadStatus {
+public final class DownloadStatus {
     /**
      * This download cannot proceed because the client does not allow it yet
      */

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsUriProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsUriProvider.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager.lib;
 
 import android.net.Uri;
 
-public class DownloadsUriProvider {
+public class DownloadsUriProvider { // Why is this a singleton if all fields are final?
 
     private final Uri publiclyAccessibleDownloadsUri;
     private final Uri downloadsByBatchUri;

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifierFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/DownloadNotifierFactory.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.novoda.downloadmanager.lib.DownloadManagerModules;
-import com.novoda.downloadmanager.lib.DownloadsUriProvider;
 import com.novoda.downloadmanager.lib.PublicFacingDownloadMarshaller;
 import com.novoda.downloadmanager.lib.PublicFacingStatusTranslator;
 
@@ -22,7 +21,6 @@ public class DownloadNotifierFactory {
                 notificationManager,
                 modules.getNotificationImageRetriever(),
                 resources,
-                DownloadsUriProvider.getInstance(),
                 createNotificationCustomiser(modules),
                 statusTranslator,
                 downloadMarshaller

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -123,7 +123,7 @@ public class NotificationDisplayer {
         }
 
         Intent clickIntent = createClickIntent(batchId, batchStatus);
-        builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_CANCEL_CURRENT));
+        builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
 
         customiseNotification(type, builder, batch);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -3,7 +3,6 @@ package com.novoda.downloadmanager.notifications;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.ContentUris;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
@@ -20,7 +19,7 @@ import com.novoda.downloadmanager.R;
 import com.novoda.downloadmanager.lib.DownloadBatch;
 import com.novoda.downloadmanager.lib.DownloadManager;
 import com.novoda.downloadmanager.lib.DownloadReceiver;
-import com.novoda.downloadmanager.lib.DownloadsUriProvider;
+import com.novoda.downloadmanager.lib.DownloadStatus;
 import com.novoda.downloadmanager.lib.PublicFacingDownloadMarshaller;
 import com.novoda.downloadmanager.lib.PublicFacingStatusTranslator;
 
@@ -31,24 +30,18 @@ import java.util.concurrent.TimeUnit;
 
 public class NotificationDisplayer {
 
-    /**
-     * the intent that gets sent when deleting the notification of a completed download
-     */
-    public static final String ACTION_HIDE = "android.intent.action.DOWNLOAD_HIDE";
-    /**
-     * the intent that gets sent when clicking an incomplete/failed download
-     */
-    public static final String ACTION_LIST = "android.intent.action.DOWNLOAD_LIST";
-    /**
-     * the intent that gets sent when clicking a successful download
-     */
-    public static final String ACTION_OPEN = "android.intent.action.DOWNLOAD_OPEN";
+    public static final String ACTION_NOTIFICATION_DISMISSED = "com.novoda.downloadmanager.action.NOTIFICATION_DISMISSED";
+    public static final String ACTION_DOWNLOAD_FAILED_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_FAILED_CLICK";
+    public static final String ACTION_DOWNLOAD_RUNNING_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_RUNNING_CLICK";
+    public static final String ACTION_DOWNLOAD_SUCCESS_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_SUCCESS_CLICK";
+    public static final String ACTION_DOWNLOAD_CANCELLED_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_CANCELLED_CLICK";
+    public static final String ACTION_DOWNLOAD_SUBMITTED_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_SUBMITTED_CLICK";
+    public static final String ACTION_DOWNLOAD_OTHER_CLICK = "com.novoda.downloadmanager.action.DOWNLOAD_OTHER_CLICK";
 
     private final Context context;
     private final NotificationManager notificationManager;
     private final NotificationImageRetriever imageRetriever;
     private final Resources resources;
-    private final DownloadsUriProvider downloadsUriProvider;
     /**
      * Current speed of active downloads, mapped from {@link DownloadBatch#batchId}
      * to speed in bytes per second.
@@ -63,7 +56,6 @@ public class NotificationDisplayer {
             NotificationManager notificationManager,
             NotificationImageRetriever imageRetriever,
             Resources resources,
-            DownloadsUriProvider downloadsUriProvider,
             NotificationCustomiser notificationCustomiser,
             PublicFacingStatusTranslator statusTranslator,
             PublicFacingDownloadMarshaller downloadMarshaller) {
@@ -71,7 +63,6 @@ public class NotificationDisplayer {
         this.notificationManager = notificationManager;
         this.imageRetriever = imageRetriever;
         this.resources = resources;
-        this.downloadsUriProvider = downloadsUriProvider;
         this.notificationCustomiser = notificationCustomiser;
         this.statusTranslator = statusTranslator;
         this.downloadMarshaller = downloadMarshaller;
@@ -84,7 +75,7 @@ public class NotificationDisplayer {
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
         builder.setWhen(firstShown);
         buildIcon(type, builder);
-        buildActionIntents(notificationId, type, cluster, builder);
+        buildActionIntents(type, cluster, builder);
 
         Notification notification = buildTitlesAndDescription(type, cluster, builder);
         notificationManager.notify(notificationId.hashCode(), notification);
@@ -116,37 +107,58 @@ public class NotificationDisplayer {
         }
     }
 
-    private void buildActionIntents(String tag, int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
+    private void buildActionIntents(int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {
         DownloadBatch batch = cluster.iterator().next();
         long batchId = batch.getBatchId();
         int batchStatus = batch.getStatus();
 
         if (type == SynchronisedDownloadNotifier.TYPE_ACTIVE || type == SynchronisedDownloadNotifier.TYPE_WAITING) {
-            // build a synthetic uri for intent identification purposes
-            Uri uri = new Uri.Builder().scheme("active-dl").appendPath(tag).build();
-
-            Intent clickIntent = createClickIntent(ACTION_LIST, batchId, batchStatus, uri); // TODO: the Uri doesn't seem to be ever read
-            builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
             builder.setOngoing(true);
-
         } else if (type == SynchronisedDownloadNotifier.TYPE_SUCCESS
                 || type == SynchronisedDownloadNotifier.TYPE_CANCELLED
                 || type == SynchronisedDownloadNotifier.TYPE_FAILED) {
-            long firstDownloadBatchId = batch.getFirstDownloadBatchId(); // TODO why can't we just use getBatchId()?
-            Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), firstDownloadBatchId);
-
-            Intent hideIntent = new Intent(ACTION_HIDE, uri, context, DownloadReceiver.class);
-            hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
-            builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, hideIntent, 0));
-
+            Intent dismissedIntent = createNotificationDismissedIntent(batchId);
+            builder.setDeleteIntent(PendingIntent.getBroadcast(context, 0, dismissedIntent, 0));
             builder.setAutoCancel(true);
-
-            String action = batch.isError() ? ACTION_LIST : ACTION_OPEN;
-            Intent clickIntent = createClickIntent(action, batchId, batchStatus, uri);  // TODO: the Uri doesn't seem to be ever read
-            builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         }
 
+        Intent clickIntent = createClickIntent(batchId, batchStatus);
+        builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_CANCEL_CURRENT));
+
         customiseNotification(type, builder, batch);
+    }
+
+    private Intent createNotificationDismissedIntent(long batchId) {
+        Intent hideIntent = new Intent(ACTION_NOTIFICATION_DISMISSED, Uri.EMPTY, context, DownloadReceiver.class);
+        hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
+        return hideIntent;
+    }
+
+    private Intent createClickIntent(long batchId, int batchStatus) {
+        String action = getActionFrom(batchStatus);
+        Intent clickIntent = new Intent(action, Uri.EMPTY, context, DownloadReceiver.class);
+
+        clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, new long[]{batchId});
+        clickIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
+        int status = statusTranslator.translate(batchStatus);
+        clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES, new int[]{status});
+
+        return clickIntent;
+    }
+
+    private String getActionFrom(int batchStatus) {
+        if (DownloadStatus.isFailure(batchStatus)) {
+            return ACTION_DOWNLOAD_FAILED_CLICK;
+        } else if (DownloadStatus.isRunning(batchStatus)) {
+            return ACTION_DOWNLOAD_RUNNING_CLICK;
+        } else if (DownloadStatus.isSuccess(batchStatus)) {
+            return ACTION_DOWNLOAD_SUCCESS_CLICK;
+        } else if (DownloadStatus.isCancelled(batchStatus)) {
+            return ACTION_DOWNLOAD_CANCELLED_CLICK;
+        } else if (DownloadStatus.isSubmitted(batchStatus)) {
+            return ACTION_DOWNLOAD_SUBMITTED_CLICK;
+        }
+        return ACTION_DOWNLOAD_OTHER_CLICK;
     }
 
     private void customiseNotification(int type, NotificationCompat.Builder builder, DownloadBatch batch) {
@@ -170,17 +182,6 @@ public class NotificationDisplayer {
             default:
                 throw new IllegalStateException("Deal with this new type " + type);
         }
-    }
-
-    private Intent createClickIntent(String action, long batchId, int batchStatus, Uri uri) {
-        Intent clickIntent = new Intent(action, uri, context, DownloadReceiver.class);
-        clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_IDS, new long[]{batchId});
-        clickIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
-
-        int status = statusTranslator.translate(batchStatus);
-        clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES, new int[]{status});
-
-        return clickIntent;
     }
 
     private Notification buildTitlesAndDescription(int type, Collection<DownloadBatch> cluster, NotificationCompat.Builder builder) {


### PR DESCRIPTION
#### Before

We used to have generic actions (inherited from the AOSP) to handle click events - this was confusing and hard to work around it.

#### After

We can differentiate between each specific action and handle them all differently if we have to in the `DownloadReceiver`.
Also solved a bug since we were checking for the batch status but it was the translated status instead of the raw one, this was fixed with just using another action :dancer: 

Fixes #161 and #168