### PR TITLE
Uses FLAG_CANCEL_CURRENT instead of FLAG_UPDATE_CURRENT for the clicks

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -123,7 +123,7 @@ public class NotificationDisplayer {
         }
 
         Intent clickIntent = createClickIntent(batchId, batchStatus);
-        builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_UPDATE_CURRENT));
+        builder.setContentIntent(PendingIntent.getBroadcast(context, 0, clickIntent, PendingIntent.FLAG_CANCEL_CURRENT));
 
         customiseNotification(type, builder, batch);
     }


### PR DESCRIPTION
We've observed that in some devices (running KitKat) clicking on a downloading notification doesn't fire the `Intent` therefore the `DownloadReceiver` doesn't get notified that the user clicked, resulting on unhandled click events.

After some research it seems like this is a known issue:

https://code.google.com/p/android/issues/detail?id=63236
https://code.google.com/p/android/issues/detail?id=61850

And the workaround is to cancel the PendingIntent and redo it instead of update the existing one.

QA said this works fine now in both KitKat, pre-KitKat and Lollipop devices :boom: 