### PR TITLE
Use the 'HIDDEN' state when hiding a notification

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReceiver.java
@@ -165,7 +165,7 @@ public class DownloadReceiver extends BroadcastReceiver { // TODO split this int
                 if ((DownloadStatus.isCancelled(status) || DownloadStatus.isCompleted(status))
                         && (visibility == ACTIVE_OR_COMPLETE || visibility == ONLY_WHEN_COMPLETE)) {
                     ContentValues values = new ContentValues(1);
-                    values.put(DownloadContract.Batches.COLUMN_VISIBILITY, NotificationVisibility.ONLY_WHEN_ACTIVE);
+                    values.put(DownloadContract.Batches.COLUMN_VISIBILITY, NotificationVisibility.HIDDEN);
                     context.getContentResolver().update(uri, values, null, null);
                 }
             } else {


### PR DESCRIPTION
This prevents notifications from reappearing when you kill the app after dismissing a notification and start the app again.

#### Steps to reproduce

 - Download something
 - When download completes or fails, dismiss the notification by swiping it
 - Kill the app
 - Start the app again

#### Before

 - The notification would reappear

#### After

 - No notification reappears