### PR TITLE
Makes notifications uniques by setting different data on each of them

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/notifications/NotificationDisplayer.java
@@ -131,7 +131,12 @@ public class NotificationDisplayer {
     private Intent createNotificationDismissedIntent(long batchId) {
         Intent hideIntent = new Intent(ACTION_NOTIFICATION_DISMISSED, Uri.EMPTY, context, DownloadReceiver.class);
         hideIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
+        hideIntent.setData(createUniqueUri(hideIntent));
         return hideIntent;
+    }
+
+    private Uri createUniqueUri(Intent intent) {
+        return Uri.parse(intent.toUri(Intent.URI_INTENT_SCHEME));
     }
 
     private Intent createClickIntent(long batchId, int batchStatus) {
@@ -142,6 +147,7 @@ public class NotificationDisplayer {
         clickIntent.putExtra(DownloadReceiver.EXTRA_BATCH_ID, batchId);
         int status = statusTranslator.translate(batchStatus);
         clickIntent.putExtra(DownloadManager.EXTRA_NOTIFICATION_CLICK_DOWNLOAD_STATUSES, new int[]{status});
+        clickIntent.setData(createUniqueUri(clickIntent));
 
         return clickIntent;
     }


### PR DESCRIPTION
So it turns out the real issue with notifications reappearing after being dismissed was the intents weren't unique. I thought it had to do with the flags we use or the way we handle the notification visibility in the DB, and maybe it did initially but now the problem was the uniqueness of the intents. So the bug could only be reproduced when having multiple failed/completed notifications, with just one it worked fine, that made it harder to pin point.

Anyway this is fixed by making each intent used for the notifications unique as mentioned here http://stackoverflow.com/a/15456633/1180029 and the problem is fixed.

I've done this for both the intent used for dismissing a notification and for the intent used for clicking a notification and it all works fine. See gifs below (the `Before` one shows how 2 notifications for previously cancelled downloads reappear after I dismiss them and start another download):

Before | After
--- | ---
![before](https://cloud.githubusercontent.com/assets/1626673/10664233/e04825cc-78c1-11e5-8555-322be326a63d.gif) | ![after](https://cloud.githubusercontent.com/assets/1626673/10664234/e1a97808-78c1-11e5-9257-6a880b84c4e3.gif)
