### PR TITLE
Add "download-manager" subdirectory for the used cache dir

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -294,7 +294,7 @@ class StorageManager {
     }
 
     public static File getDownloadDataDirectory(Context context) {
-        return context.getCacheDir();
+        return new File(context.getCacheDir().toString() + "/download-manager/");
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -83,6 +83,8 @@ class StorageManager {
     private final ContentResolver contentResolver;
     private final DownloadsUriProvider downloadsUriProvider;
 
+    private final static String FILE_SEPARATOR = File.separator;
+
     StorageManager(
             ContentResolver contentResolver, 
             File externalStorageDir, 
@@ -294,7 +296,7 @@ class StorageManager {
     }
 
     public static File getDownloadDataDirectory(Context context) {
-        return new File(context.getCacheDir().toString() + "/download-manager/");
+        return new File(context.getCacheDir().getPath() + FILE_SEPARATOR + "download-manager" + FILE_SEPARATOR);
     }
 
     /**


### PR DESCRIPTION
### Bug description ###

We have noticed that client's content inside the `getCacheDir()` is removed when a download starts

### Solution implemented ###

When the download manager instance is instantiated, goes through a process of cleaning up invalid files, calling the method `removeSpuriousFiles` https://github.com/novoda/download-manager/blob/master/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java#L350, this method gets **all** the files inside the `getCacheDir()` and deletes them all (line https://github.com/novoda/download-manager/blob/master/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java#L391)

There is a commented code that tries to discover the process owner of the file in order to prevent this bug but:
- It is commented (the library used is not available and there is an alternative library `Os.lstat().st_uid` but it is only available above Lollipop)
- It won't work if you include this library inside your project, the library runs in the same process as the client (or could potentially do)

The solution is to ensure that the files are stored inside a subdirectory `download-manager` instead of using the root one 