### PR TITLE
There's no need to enforce WRITE_EXTERNAL_STORAGE permission for internal downloads. (try #2)

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -408,10 +408,12 @@ public final class DownloadProvider extends ContentProvider {
                 dest = DownloadsDestination.DESTINATION_CACHE_PARTITION;
             }
             if (dest == DownloadsDestination.DESTINATION_FILE_URI) {
-                getContext().enforcePermission(
-                        android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Binder.getCallingPid(), Binder.getCallingUid(),
-                        "need WRITE_EXTERNAL_STORAGE permission to use DESTINATION_FILE_URI");
-                checkFileUriDestination(values);
+                if (!getFileUriDestinationPath(values).contains("/" + getContext().getPackageName() + "/")) {
+                    // external, not internal storage
+                    getContext().enforcePermission(
+                            android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Binder.getCallingPid(), Binder.getCallingUid(),
+                            "need WRITE_EXTERNAL_STORAGE permission to use DESTINATION_FILE_URI");
+                }
             } else if (dest == DownloadsDestination.DESTINATION_SYSTEMCACHE_PARTITION) {
                 getContext().enforcePermission(
                         "android.permission.ACCESS_CACHE_FILESYSTEM", Binder.getCallingPid(), Binder.getCallingUid(),
@@ -526,9 +528,9 @@ public final class DownloadProvider extends ContentProvider {
     }
 
     /**
-     * Check that the file URI provided for DESTINATION_FILE_URI is valid.
+     * Retrieve the file path for DESTINATION_FILE_URI if the URI is valid
      */
-    private void checkFileUriDestination(ContentValues values) {
+    private String getFileUriDestinationPath(ContentValues values) {
         String fileUri = values.getAsString(DownloadContract.Downloads.COLUMN_FILE_NAME_HINT);
         if (fileUri == null) {
             throw new IllegalArgumentException(
@@ -543,6 +545,7 @@ public final class DownloadProvider extends ContentProvider {
         if (path == null) {
             throw new IllegalArgumentException("Invalid file URI: " + uri);
         }
+        return path;
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadProvider.java
@@ -408,7 +408,7 @@ public final class DownloadProvider extends ContentProvider {
                 dest = DownloadsDestination.DESTINATION_CACHE_PARTITION;
             }
             if (dest == DownloadsDestination.DESTINATION_FILE_URI) {
-                if (!getFileUriDestinationPath(values).contains("/" + getContext().getPackageName() + "/")) {
+                if (!getFileUriDestinationPath(values).startsWith(Environment.getDataDirectory() + "/")) {
                     // external, not internal storage
                     getContext().enforcePermission(
                             android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Binder.getCallingPid(), Binder.getCallingUid(),


### PR DESCRIPTION
This is a second try for closed PR #181.
 
The problem: Currently, DownloadProvider.insertDownload() enforces WRITE_EXTERNAL_STORAGE permission for all downloads using a DESTINATION_FILE_URI, and throws a SecurityException if that permission is missing. However, that permission isn't actually required if the download is destined for internal storage.

The solution: Check to see if the file path begins with Environment.getDataDirectory(). If it does, it's using internal storage and there's no need for WRITE_EXTERNAL_STORAGE permission; therefore, waive enforcement of that permission.

@amlcurran, thanks for the suggestion - I think this will do it.

![image](https://cloud.githubusercontent.com/assets/3358559/13159730/6d28e3d0-d661-11e5-8d8d-4a119ae5525b.png)
