### PR TITLE
Propagate error upwards instead of swallowing

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -509,12 +509,11 @@ class DownloadTask implements Runnable {
         } catch (StopRequestException exception) {
             if (exception.getFinalStatus() == DownloadStatus.PAUSED_BY_APP) {
                 notifyThroughDatabase(state, DownloadStatus.PAUSING, exception.getMessage(), 0);
-
-                // We still have to throw the exception, otherwise the parent
-                // thinks that the download has been completed OK, when is not
-                // We should remove exceptions as a flow control in order to avoid this
-                throw exception;
             }
+            // We still have to throw the exception, otherwise the parent
+            // thinks that the download has been completed OK, when is not
+            // We should remove exceptions as a flow control in order to avoid this
+            throw exception;
         } finally {
 //            if (drmClient != null) {
 //                drmClient.release();


### PR DESCRIPTION
Fixes the bug where downloads were considered successful even though they weren't

The comment says we should have thrown it but looks like it was mistakenly put inside the condition.

Can reproduce this by turning airplane mode on in the middle of a download, and turning it back off so the download resumes. The download will "complete" successfully, but it's not downloaded anymore.