### PR TITLE
Fix status mapping

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -345,7 +345,7 @@ public class DownloadService extends Service {
                 continue;
             }
 
-            if (!isActive && downloadReadyChecker.canDownload(downloadBatch)) {
+            if (downloadReadyChecker.canDownload(downloadBatch) && !isActive) {
                 boolean isBatchStartingForTheFirstTime = batchRepository.isBatchStartingForTheFirstTime(downloadBatch.getBatchId());
                 if (isBatchStartingForTheFirstTime) {
                     handleBatchStartingForTheFirstTime(downloadBatch);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -345,7 +345,7 @@ public class DownloadService extends Service {
                 continue;
             }
 
-            if (downloadReadyChecker.canDownload(downloadBatch) && !isActive) {
+            if (!isActive && downloadReadyChecker.canDownload(downloadBatch)) {
                 boolean isBatchStartingForTheFirstTime = batchRepository.isBatchStartingForTheFirstTime(downloadBatch.getBatchId());
                 if (isBatchStartingForTheFirstTime) {
                     handleBatchStartingForTheFirstTime(downloadBatch);

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -325,6 +325,7 @@ class DownloadTask implements Runnable {
             cleanupDestination(state, finalStatus);
 
             notifyDownloadCompleted(state, finalStatus, errorMsg, numFailed);
+            hackToForceClientsRefreshRulesIfConnectionDropped(finalStatus);
 
             LLog.i("Download " + originalDownloadInfo.getId() + " finished with status " + DownloadStatus.statusToString(finalStatus));
 
@@ -333,6 +334,16 @@ class DownloadTask implements Runnable {
             }
         }
         storageManager.incrementNumDownloadsSoFar();
+    }
+
+    private void hackToForceClientsRefreshRulesIfConnectionDropped(int finalStatus) {
+        if (DownloadStatus.WAITING_FOR_NETWORK == finalStatus) {
+            try {
+                checkClientRules();
+            } catch (StopRequestException e) {
+                e.printStackTrace();
+            }
+        }
     }
 
     /**

--- a/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
@@ -6,14 +6,14 @@ public class PublicFacingStatusTranslator {
         switch (status) {
             case DownloadStatus.SUBMITTED:
             case DownloadStatus.PENDING:
-                return DownloadManager.STATUS_PENDING;
-            case DownloadStatus.RUNNING:
-                return DownloadManager.STATUS_RUNNING;
             case DownloadStatus.QUEUED_DUE_CLIENT_RESTRICTIONS:
-            case DownloadStatus.PAUSED_BY_APP:
             case DownloadStatus.WAITING_TO_RETRY:
             case DownloadStatus.WAITING_FOR_NETWORK:
             case DownloadStatus.QUEUED_FOR_WIFI:
+                return DownloadManager.STATUS_PENDING;
+            case DownloadStatus.RUNNING:
+                return DownloadManager.STATUS_RUNNING;
+            case DownloadStatus.PAUSED_BY_APP:
                 return DownloadManager.STATUS_PAUSED;
             case DownloadStatus.PAUSING:
                 return DownloadManager.STATUS_PAUSING;


### PR DESCRIPTION
### Some context ###
In the a previous commit: https://github.com/novoda/download-manager/commit/b6d286a2d052971e0e71935b3ea86839cdec0690 we are now throwing an exception every time an error occurs when transferring data independently if the download is paused, queued, etc, which is right. But know we get "paused" status when is internally "waiting for network".

### Problem description ###
The download mapper,  was wrong since we were mapping "queued" to "paused" where it needs to be: "pending".
The other problems occurs when the `DownloadService` restarts the downloads when the network resumes after a disconnection. In this case, we are not calling `downloadReadyChecker.canDownload()` method and therefore we are not propagating that "event" to the client.

### Solution implemented ###
For the first sub-problem: Fix the mapper.
For the second: Force the downloadTask to trigger the check rules on the clients to send them that "event"