### PR TITLE
Use Uri.getPath() instead of .toString() to get destination path

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -514,6 +514,6 @@ public class Request {
     }
 
     String getDestinationPath() {
-        return destinationUri.toString();
+        return destinationUri.getPath();
     }
 }


### PR DESCRIPTION
`Uri.toString()` will return something like `"file:///Path/to.file"`, which is incorrect to use as an argument for a `new File()`.  Let me show you this snippet to better express what I mean:

```java
File file1 = new File("file:///data/user/0/com.novoda.downloadmanager.demo.extended/files/Movies/beard.shipment");
File file2 = new File("/data/user/0/com.novoda.downloadmanager.demo.extended/files/Movies/beard.shipment");
file1.exists(); // false
file2.exists(); // true
```
The correct path is the one without the schema prepended, so let's use `Uri.getPath()` instead!

Paired with @zegnus 

Thanks @ouchadam for testing this change on all4.
