### PR TITLE
Migrate fields in Request to java.net.URI

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -92,7 +92,6 @@ public class Request {
     /**
      * @param uri the HTTP URI to download.
      */
-    @Deprecated
     public Request(URI uri) {
         validateUriScheme(uri.toString(), uri.getScheme());
         this.uri = uri;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Request.java
@@ -83,6 +83,7 @@ public class Request {
 
     /**
      * @param uri the HTTP Uri to download.
+     * @deprecated use {@link #Request(java.net.URI)}
      */
     @Deprecated
     public Request(Uri uri) {
@@ -121,6 +122,8 @@ public class Request {
      * may be deleted by the system at any time to reclaim space.
      *
      * @return this object
+     *
+     * @deprecated use {@link #setDestinationUri(java.net.URI)}
      */
     @Deprecated
     public Request setDestinationUri(Uri uri) {


### PR DESCRIPTION
#### Problem

`Request`s cannot be used in tests because of `android.net.Uri` dependency

#### Solution
I decided to migrate to `java.net.URI` instead, and deprecate the previous constructor and setter.


Thanks @ouchadam for testing again the change on all4 😂 