### PR TITLE
Update bintray release plugin

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
-        classpath 'com.novoda:bintray-release:0.2.10'
+        classpath 'com.novoda:bintray-release:0.3.4'
     }
 }
 apply plugin: 'com.android.library'


### PR DESCRIPTION
To fix the following build failure:
```
Execution failed for task ':library:mavenAndroidJavadocs'.
> Javadoc generation failed.
```

Although 0.3.5 is the latest version of the plugin, it is known to have the same issue. So we should use 0.3.4