### PR TITLE
Fix maven publication tasks

### DIFF
--- a/code-quality/android-code-quality.gradle
+++ b/code-quality/android-code-quality.gradle
@@ -4,6 +4,10 @@ task staticAnalysis {
     group 'Verification'
 }
 
+tasks.withType(Javadoc) {
+    options.addBooleanOption('Xdoclint:none', true)
+}
+
 check.dependsOn staticAnalysis
 
 apply from: "$project.rootDir/code-quality/checkstyle.gradle"


### PR DESCRIPTION
### Problem ####

When doing a maven publication the build fails given some lint warnings / errors in the javadoc of the library. Following a truncated stacktrace for `publishToMavenLocal`:

```
Note: /Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
:library:mavenAndroidJavadocs
...
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:334: warning: no @param for description
    public Request setDescription(CharSequence description) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:369: warning: no @param for mimeType
    public Request setMimeType(String mimeType) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:379: error: self-closing element not allowed
     * <p/>
       ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:398: error: self-closing element not allowed
     * <p/>
       ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:402: error: self-closing element not allowed
     * <p/>
       ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:446: warning: no @param for allow
    public Request setAllowedOverMetered(boolean allow) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:446: warning: no @return
    public Request setAllowedOverMetered(boolean allow) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:466: warning: no @return
    public Request setNotificationExtra(String extra) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:474: warning: no @return
    public Request setExtraData(String extra) {
                   ^
/Users/juankysoriano/Documents/Work/novoda/download-manager/library/src/main/java/com/novoda/downloadmanager/lib/Request.java:19: error: self-closing element not allowed
 * <p/>
   ^
26 errors
60 warnings
:library:mavenAndroidJavadocs FAILED
```

### Solution ###

Many of this javadocs that are not correct are being port from the AOSP; actually a third of the library is ported from the AOSP. Therefore it doesn't make sense to fix all the javadoc manually as it is a lot and we should maintain a low level of changes with regards what's on the AOSP to make any upgrade easier. 

Given that the solution is to suppress javadoc lint during build time. 