### PR TITLE
Allow downloads to SD card

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadService.java
@@ -139,9 +139,14 @@ public class DownloadService extends Service {
         ContentResolver contentResolver = getContentResolver();
         File downloadDataDir = StorageManager.getDownloadDataDirectory(this);
         File externalStorageDir = Environment.getExternalStorageDirectory();
+        File[] externalStorageDirs = new File[0];
+        if (android.os.Build.VERSION.SDK_INT >= 19 )
+        {
+            externalStorageDirs = this.getExternalFilesDirs(null);
+        }
         File internalStorageDir = Environment.getDataDirectory();
         File systemCacheDir = Environment.getDownloadCacheDirectory();
-        storageManager = new StorageManager(contentResolver, externalStorageDir, internalStorageDir, systemCacheDir, downloadDataDir, downloadsUriProvider);
+        storageManager = new StorageManager(contentResolver, externalStorageDir, externalStorageDirs, internalStorageDir, systemCacheDir, downloadDataDir, downloadsUriProvider);
 
         downloadScanner = new DownloadScanner(getContentResolver(), this, downloadsUriProvider);
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -55,6 +55,11 @@ class StorageManager {
      */
     private final File externalStorageDir;
 
+     /**
+     * see {@link Context#getExternalFilesDirs(String)}
+     */
+    private final File[] externalStorageDirs;
+    
     /**
      * see {@link android.os.Environment#getDataDirectory()}
      */
@@ -87,13 +92,15 @@ class StorageManager {
 
     StorageManager(
             ContentResolver contentResolver, 
-            File externalStorageDir, 
+            File externalStorageDir,
+            File externalStorageDirs,
             File internalStorageDir, 
             File systemCacheDir, 
             File downloadDataDir, 
             DownloadsUriProvider downloadsUriProvider) {
         this.contentResolver = contentResolver;
         this.externalStorageDir = externalStorageDir;
+        this.externalStorageDirs = externalStorageDirs;
         this.internalStorageDir = internalStorageDir;
         this.systemCacheDir = systemCacheDir;
         this.downloadDataDir = downloadDataDir;
@@ -172,6 +179,13 @@ class StorageManager {
                     dir = systemCacheDir;
                 } else if (path.startsWith(internalStorageDir.getPath())) {
                     dir = internalStorageDir;
+                }
+                for (File aExternalStorageDir : externalStorageDirs)
+                {
+                    if (path.startsWith(aExternalStorageDir.getPath())) {
+                        dir = aExternalStorageDir;
+                        break;
+                    }
                 }
                 break;
         }


### PR DESCRIPTION
These changes allow the download manager to download to a directory retrieved from context.getExternalFilesDirs(null);

This fixes the problem I had in issue #201 