### PR TITLE
Fix for StorageManager null bug

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -180,9 +180,9 @@ class StorageManager {
                 } else if (path.startsWith(internalStorageDir.getPath())) {
                     dir = internalStorageDir;
                 } else {
-                    for (File aExternalStorageDir : externalStorageDirs) {
-                        if (aExternalStorageDir != null && path.startsWith(aExternalStorageDir.getPath()) {
-                            dir = aExternalStorageDir;
+                    for (File anExternalStorageDir : externalStorageDirs) {
+                        if (anExternalStorageDir != null && path.startsWith(anExternalStorageDir.getPath()) {
+                            dir = anExternalStorageDir;
                             break;
                         }
                     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -181,11 +181,9 @@ class StorageManager {
                     dir = internalStorageDir;
                 } else {
                     for (File aExternalStorageDir : externalStorageDirs) {
-                        if (aExternalStorageDir != null) {
-                            if (path.startsWith(aExternalStorageDir.getPath())) {
-                                dir = aExternalStorageDir;
-                                break;
-                            }
+                        if (aExternalStorageDir != null && path.startsWith(aExternalStorageDir.getPath()) {
+                            dir = aExternalStorageDir;
+                            break;
                         }
                     }
                 }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/StorageManager.java
@@ -179,11 +179,14 @@ class StorageManager {
                     dir = systemCacheDir;
                 } else if (path.startsWith(internalStorageDir.getPath())) {
                     dir = internalStorageDir;
-                }
-                for (File aExternalStorageDir : externalStorageDirs) {
-                    if (path.startsWith(aExternalStorageDir.getPath())) {
-                        dir = aExternalStorageDir;
-                        break;
+                } else {
+                    for (File aExternalStorageDir : externalStorageDirs) {
+                        if (aExternalStorageDir != null) {
+                            if (path.startsWith(aExternalStorageDir.getPath())) {
+                                dir = aExternalStorageDir;
+                                break;
+                            }
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
Added null check to verifySpace(int destination, String path, long length)

My last pull request introduced a new bug. It was possible that there is a null File within the array. The new code checks for this.