### PR TITLE
Fix batch failure and locked to pause

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -281,7 +281,7 @@ class DownloadTask implements Runnable {
             finalizeDestinationFile(state);
             finalStatus = DownloadStatus.SUCCESS;
 
-            if (batchHasPausedFiles(originalDownloadBatch.getBatchId())) { // check if a file is paused by app and set PAUSED_BY_APP to finalStatus
+            if (batchHasPausedFiles(originalDownloadBatch.getBatchId())) {
                 finalStatus = DownloadStatus.PAUSED_BY_APP;
             }
         } catch (StopRequestException error) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -281,9 +281,7 @@ class DownloadTask implements Runnable {
             finalizeDestinationFile(state);
             finalStatus = DownloadStatus.SUCCESS;
 
-            // check if a file is paused by app and set PAUSED_BY_APP to finalStatus
-
-            if (batchHasPausedFiles(originalDownloadBatch.getBatchId())) {
+            if (batchHasPausedFiles(originalDownloadBatch.getBatchId())) { // check if a file is paused by app and set PAUSED_BY_APP to finalStatus
                 finalStatus = DownloadStatus.PAUSED_BY_APP;
             }
         } catch (StopRequestException error) {
@@ -346,10 +344,9 @@ class DownloadTask implements Runnable {
     }
 
     private boolean batchHasPausedFiles(long batchId) {
-        List<FileDownloadInfo> allDownloads = downloadsRepository.getAllDownloads();
-
+        List<FileDownloadInfo> allDownloads = downloadsRepository.getAllDownloadsFor(batchId);
         for (FileDownloadInfo file : allDownloads) {
-            if (file.getBatchId() == batchId && file.isPaused()) {
+            if (file.isPaused()) {
                 return true;
             }
         }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadTask.java
@@ -279,10 +279,11 @@ class DownloadTask implements Runnable {
             executeDownload(state);
 
             finalizeDestinationFile(state);
-            finalStatus = DownloadStatus.SUCCESS;
 
             if (batchHasPausedFiles(originalDownloadBatch.getBatchId())) {
                 finalStatus = DownloadStatus.PAUSED_BY_APP;
+            } else {
+                finalStatus = DownloadStatus.SUCCESS;
             }
         } catch (StopRequestException error) {
             // remove the cause before printing, in case it contains PII
@@ -597,11 +598,13 @@ class DownloadTask implements Runnable {
     private void transferData(State state, InputStream in, OutputStream out) throws StopRequestException {
         StorageSpaceVerifier spaceVerifier = new StorageSpaceVerifier(storageManager, originalDownloadInfo.getDestination(), state.filename);
         DataWriter checkedWriter = new CheckedWriter(spaceVerifier, out);
-        DataWriter dataWriter = new NotifierWriter(getContentResolver(),
+        DataWriter dataWriter = new NotifierWriter(
+                getContentResolver(),
                 checkedWriter,
                 downloadNotifier,
                 originalDownloadInfo,
-                checkOnWrite);
+                checkOnWrite
+        );
 
         DataTransferer dataTransferer;
         if (originalDownloadInfo.shouldAllowTarUpdate(state.mimeType)) {
@@ -696,7 +699,8 @@ class DownloadTask implements Runnable {
                 state.mimeType,
                 originalDownloadInfo.getDestination(),
                 state.contentLength,
-                storageManager);
+                storageManager
+        );
 
         updateDownloadInfoFieldsFrom(state);
         downloadsRepository.updateDatabaseFromHeaders(originalDownloadInfo, state.filename, state.headerETag, state.mimeType, state.totalBytes);
@@ -863,7 +867,8 @@ class DownloadTask implements Runnable {
 
     private void notifyThroughDatabase(State state, int finalStatus, String errorMsg, int numFailed) {
         downloadsRepository.updateDownload(originalDownloadInfo, state.filename,
-                state.mimeType, state.retryAfter, state.requestUri, finalStatus, errorMsg, numFailed);
+                                           state.mimeType, state.retryAfter, state.requestUri, finalStatus, errorMsg, numFailed
+        );
 
         updateBatchStatus(originalDownloadInfo.getBatchId(), originalDownloadInfo.getId());
     }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -40,7 +40,7 @@ class DownloadsRepository {
         Cursor downloadsCursor = contentResolver.query(
                 downloadsUriProvider.getAllDownloadsUri(),
                 null,
-                batchId == NO_BATCH_ID ? null : DownloadContract.Batches._ID + " = ?",
+                batchId == NO_BATCH_ID ? null : DownloadContract.Downloads.COLUMN_BATCH_ID + " = ?",
                 batchId == NO_BATCH_ID ? null : new String[] { String.valueOf(batchId) },
                 DownloadContract.Batches._ID + " ASC"
         );

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -21,6 +21,7 @@ import static com.novoda.downloadmanager.lib.DownloadContract.Downloads.*;
 class DownloadsRepository {
 
     private static final int TRUE_THIS_IS_CLEARER_NOW = 1;
+    private static final long NO_BATCH_ID = -1;
 
     private final SystemFacade systemFacade;
     private final ContentResolver contentResolver;
@@ -35,12 +36,12 @@ class DownloadsRepository {
         this.downloadsUriProvider = downloadsUriProvider;
     }
 
-    public List<FileDownloadInfo> getAllDownloads() {
+    public List<FileDownloadInfo> getAllDownloadsFor(long batchId) {
         Cursor downloadsCursor = contentResolver.query(
                 downloadsUriProvider.getAllDownloadsUri(),
                 null,
-                null,
-                null,
+                batchId == NO_BATCH_ID ? null : DownloadContract.Batches._ID + " = ?",
+                batchId == NO_BATCH_ID ? null : new String[] { String.valueOf(batchId) },
                 DownloadContract.Batches._ID + " ASC"
         );
 
@@ -56,6 +57,10 @@ class DownloadsRepository {
         } finally {
             downloadsCursor.close();
         }
+    }
+
+    public List<FileDownloadInfo> getAllDownloads() {
+        return getAllDownloadsFor(NO_BATCH_ID);
     }
 
     public FileDownloadInfo getDownloadFor(long id) {

--- a/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/FileDownloadInfo.java
@@ -184,6 +184,10 @@ class FileDownloadInfo {
         return deleted;
     }
 
+    public boolean isPaused() {
+        return control == DownloadsControl.CONTROL_PAUSED;
+    }
+
     public String getMediaProviderUri() {
         return mediaProviderUri;
     }


### PR DESCRIPTION
### Problem
We have spotted two issues:
1. Sometimes when a download is in progress and we lose connection slowly, the full batch is marked as failed. But if we regain connection the download should just continue.
2. When pausing a download, sometimes the batch stays stuck in `queued` mode and the download don't continue. The download should be paused and we should be able to resume it.

### Solution
1. We have analysed the error status when the batch is marked as failure. There is a connection and the response status code is 404. We have added 404 to the list of retriable statuses and this fixes the issue. All retriable downloads will finally fail after a few trials. This is a one line change fix.

2. The `paused by application` status is checked once every second in order to do not hammer the client at every written chunk. It could be possible that the user clicks on pause, the check is inside one second (so that isn't executed) and in the write the file finishes to download. In this case two things happens:
 1. The pause has marked all the files to control = 1 (paused) immediately
 2. The file has finished with 200, the batch is marked as pending for the next iteration to restart
The next iteration grabs the pending queue, but because the file is marked as paused, the batch is stuck.

The solution has been to check if there is any file paused when the file finishes completely with success. If that's the case, the final status is going to be paused, instead of success.

Paired with @takecare 