### PR TITLE
Ensure localFileUri is not a duplicate before inserting to db

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DatabaseInteraction.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DatabaseInteraction.java
@@ -112,14 +112,14 @@ class DatabaseInteraction {
     }
 
     public void submitRequest(DownloadRequest downloadRequest) {
+        ensureLocalFileUriIsUniqueForAllFilesIn(downloadRequest);
+
         ContentValues values = new ContentValues();
         long downloadId = downloadRequest.getId().asLong();
         DB.Download.setDownloadId((int) downloadId, values);
         DB.Download.setDownloadStage(DownloadStage.QUEUED.name(), values);
         DB.Download.setDownloadIdentifier(downloadRequest.getExternalId().asString(), values);
         contentResolver.insert(Provider.DOWNLOAD, values);
-
-        ensureLocalFileUriIsUniqueForAllFilesIn(downloadRequest);
 
         ContentValues[] fileValues = createFileValues(downloadRequest.getFiles(), downloadId);
         contentResolver.bulkInsert(Provider.FILE, fileValues);


### PR DESCRIPTION
Fixes #228

We do a check after we've already inserted stuff into the database. If the check fails, we throw an exception.

We should check before dirtying the database instead.