### PR TITLE
Version number 0.2.46 -> 0.3.0

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -63,7 +63,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'download-manager'
-    publishVersion = '0.2.46'
+    publishVersion = '0.3.0'
     description = 'Download manager based on AOSP DM but allowing downloading to internal private storage.'
     website = 'https://github.com/novoda/download-manager'
 }


### PR DESCRIPTION
## Problem
We can't re-use the same version number for two releases.

## Solution
Increase the version number!