### PR TITLE
Covering all possible null cursor cases in this DownloadsRepository.java

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -5,6 +5,7 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.novoda.downloadmanager.lib.logger.LLog;
@@ -49,7 +50,7 @@ class DownloadsRepository {
             List<FileDownloadInfo> downloads = new ArrayList<>();
             FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
 
-            while (downloadsCursor.moveToNext()) {
+            while (downloadsCursor != null && downloadsCursor.moveToNext()) {
                 downloads.add(downloadInfoCreator.create(reader));
             }
 
@@ -65,15 +66,19 @@ class DownloadsRepository {
         return getAllDownloadsFor(NO_BATCH_ID);
     }
 
-    public FileDownloadInfo getDownloadFor(long id) {
+    public @Nullable FileDownloadInfo getDownloadFor(long id) {
         Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id);
         Cursor downloadsCursor = contentResolver.query(uri, null, null, null, null);
-        try {
-            downloadsCursor.moveToFirst();
-            FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
-            return downloadInfoCreator.create(reader);
-        } finally {
-            downloadsCursor.close();
+        if (downloadsCursor != null) {
+            try {
+                downloadsCursor.moveToFirst();
+                FileDownloadInfo.Reader reader = new FileDownloadInfo.Reader(contentResolver, downloadsCursor);
+                return downloadInfoCreator.create(reader);
+            } finally {
+                downloadsCursor.close();
+            }
+        } else {
+            return null;
         }
     }
 
@@ -86,7 +91,7 @@ class DownloadsRepository {
                 new String[]{DownloadContract.Downloads.COLUMN_STATUS}, null, null, null
         );
         try {
-            if (cursor.moveToFirst()) {
+            if (cursor != null && cursor.moveToFirst()) {
                 return cursor.getInt(0);
             } else {
                 // TODO: increase strictness of value returned for unknown
@@ -94,7 +99,9 @@ class DownloadsRepository {
                 return DownloadStatus.PENDING;
             }
         } finally {
-            cursor.close();
+            if (cursor != null) {
+                cursor.close();
+            }
         }
     }
 
@@ -288,3 +295,4 @@ class DownloadsRepository {
     }
 
 }
+

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadsRepository.java
@@ -66,7 +66,8 @@ class DownloadsRepository {
         return getAllDownloadsFor(NO_BATCH_ID);
     }
 
-    public @Nullable FileDownloadInfo getDownloadFor(long id) {
+    @Nullable
+    public FileDownloadInfo getDownloadFor(long id) {
         Uri uri = ContentUris.withAppendedId(downloadsUriProvider.getAllDownloadsUri(), id);
         Cursor downloadsCursor = contentResolver.query(uri, null, null, null, null);
         if (downloadsCursor != null) {


### PR DESCRIPTION
Hi folks - despite the null check change I submitted in https://github.com/novoda/download-manager/pull/233, the Google Play console is continuing to report lots of app crashes (I think they're actually background service crashes) originating in this class. I inspected it more carefully this time and noted that there are several places in it - not just the one I noted and fixed the first time I looked at it - where cursors might be null but are treated as if they are known to be non-null. This PR is an attempt to address all of those issues.

I'm not sure this is how you would prefer to address some of these. In particular, the method getDownloadFor() seems never to be called in the current codebase, so I just annotated it @Nullable and made it return null in case of a null cursor, but that may or may not jibe with its intended use.

Interestingly, 99.9% of our crashes for these issues are on Android 6.0 devices, according to the Google Play console. So this must all be due to some underlying curser-related bug that Google blessed us with in Marshmallow, and then fixed for 7.0. So, if you test this, use some 6.0 devices/emulators. I'm doing the same.

Thanks, folks. I should mention, this library has been a lifesaver for our products. Thanks so much for building it and opening it up.