### PR TITLE
Dismiss notification

### DIFF
--- a/app/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/app/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -5,14 +5,12 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.facebook.stetho.Stetho;
+import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.DownloadsPersistence;
 import com.novoda.downloadmanager.FileDownloader;
 import com.novoda.downloadmanager.FileSizeRequester;
-import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
 import com.novoda.downloadmanager.NotificationCreator;
-
-import java.util.concurrent.TimeUnit;
 
 public class DemoApplication extends Application {
 
@@ -39,10 +37,7 @@ public class DemoApplication extends Application {
                 .withFilePersistenceExternal()
                 .withFilePersistenceCustom(CustomFilePersistence.class)
                 .withDownloadsPersistenceCustom(downloadsPersistence)
-                .withNotification(notificationCreator)
                 .withNetworkRecovery(false)
-                .withCallbackThrottleCustom(CustomCallbackThrottle.class)
-                .withCallbackThrottleByTime(TimeUnit.SECONDS, 3)
                 .withCallbackThrottleByProgressIncrease()
                 .build();
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -7,8 +7,8 @@ import android.support.v4.app.NotificationCompat;
 
 class DownloadBatchNotification implements NotificationCreator {
 
-    private static final int ID = 1;
     private static final boolean NOT_INDETERMINATE = false;
+    private static final String CHANNEL_ID = "download_manager";
 
     private final Context context;
     private final int iconDrawable;
@@ -26,13 +26,14 @@ class DownloadBatchNotification implements NotificationCreator {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
-        Notification notification = new NotificationCompat.Builder(context)
+        Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                 .setSmallIcon(iconDrawable)
                 .setContentTitle(title)
                 .setContentText(content)
                 .build();
-        return new DownloadBatchNotificationInformation(ID, notification);
+
+        return new DownloadBatchNotificationInformation(downloadBatchTitle.hashCode(), notification);
     }
 
     private static class DownloadBatchNotificationInformation implements NotificationInformation {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -6,5 +6,7 @@ interface DownloadService {
 
     void updateNotification(NotificationInformation notification);
 
-    void makeNotificationDismissible(NotificationInformation notificationInformation);
+    void stackNotification(NotificationInformation notificationInformation);
+
+    void dismissNotifications();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -8,5 +8,5 @@ interface DownloadService {
 
     void stackNotification(NotificationInformation notificationInformation);
 
-    void dismissNotifications();
+    void dismissNotification();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchTitle.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchTitle.java
@@ -19,4 +19,23 @@ class LiteDownloadBatchTitle implements DownloadBatchTitle {
                 "title='" + title + '\'' +
                 '}';
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LiteDownloadBatchTitle that = (LiteDownloadBatchTitle) o;
+
+        return title.equals(that.title);
+    }
+
+    @Override
+    public int hashCode() {
+        return title.hashCode();
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
 
 class LiteDownloadManagerDownloader {
 
@@ -132,11 +131,17 @@ class LiteDownloadManagerDownloader {
                 (int) liteDownloadBatchStatus.bytesDownloaded()
         );
 
-        downloadService.updateNotification(notificationInformation);
+        if (liteDownloadBatchStatus.status() == DELETION) {
+            downloadService.dismissNotifications();
+            return;
+        }
 
         if (liteDownloadBatchStatus.status() == DOWNLOADED) {
-            downloadService.makeNotificationDismissible(notificationInformation);
+            downloadService.stackNotification(notificationInformation);
+            return;
         }
+
+        downloadService.updateNotification(notificationInformation);
     }
 
     void setDownloadService(DownloadService downloadService) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
 
 class LiteDownloadManagerDownloader {
 
@@ -136,6 +135,10 @@ class LiteDownloadManagerDownloader {
 
         if (liteDownloadBatchStatus.status() != DOWNLOADING) {
             downloadService.updateNotification(notificationInformation);
+        }
+
+        if (liteDownloadBatchStatus.status() == DOWNLOADED) {
+            downloadService.makeNotificationDismissible(notificationInformation);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
 class LiteDownloadManagerDownloader {
 
@@ -132,10 +133,6 @@ class LiteDownloadManagerDownloader {
         );
 
         downloadService.updateNotification(notificationInformation);
-
-        if (liteDownloadBatchStatus.status() != DOWNLOADING) {
-            downloadService.updateNotification(notificationInformation);
-        }
 
         if (liteDownloadBatchStatus.status() == DOWNLOADED) {
             downloadService.makeNotificationDismissible(notificationInformation);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -132,7 +132,7 @@ class LiteDownloadManagerDownloader {
         );
 
         if (liteDownloadBatchStatus.status() == DELETION) {
-            downloadService.dismissNotifications();
+            downloadService.dismissNotification();
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -85,8 +85,10 @@ public class LiteDownloadService extends Service implements DownloadService {
 
     private void acquireCpuWakeLock() {
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
-        wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
-        wakeLock.acquire();
+        if (powerManager != null) {
+            wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
+            wakeLock.acquire();
+        }
     }
 
     private void releaseCpuWakeLock() {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -67,6 +67,10 @@ public class LiteDownloadService extends Service implements DownloadService {
     public void makeNotificationDismissible(NotificationInformation notificationInformation) {
         stopForeground(true);
 
+        showFinalDownloadedNotification(notificationInformation);
+    }
+
+    private void showFinalDownloadedNotification(NotificationInformation notificationInformation) {
         NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (notificationManager != null) {
             Notification notification = notificationInformation.getNotification();

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -1,12 +1,9 @@
 package com.novoda.downloadmanager;
 
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
-import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.support.annotation.Nullable;
@@ -68,9 +65,15 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void makeNotificationDismissible(NotificationInformation notificationInformation) {
+    public void stackNotification(NotificationInformation notificationInformation) {
         stopForeground(true);
         showFinalDownloadedNotification(notificationInformation);
+    }
+
+    @Override
+    public void dismissNotifications() {
+        stopForeground(true);
+        notificationManagerCompat.cancelAll();
     }
 
     private void showFinalDownloadedNotification(NotificationInformation notificationInformation) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -1,6 +1,8 @@
 package com.novoda.downloadmanager;
 
+import android.app.NotificationManager;
 import android.app.Service;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.IBinder;
@@ -13,7 +15,6 @@ import java.util.concurrent.Executors;
 public class LiteDownloadService extends Service implements DownloadService {
 
     private static final String WAKELOCK_TAG = "WakelockTag";
-    private static final boolean DO_NOT_REMOVE_NOTIFICATION = false;
 
     private ExecutorService executor;
     private IBinder binder;
@@ -62,7 +63,12 @@ public class LiteDownloadService extends Service implements DownloadService {
 
     @Override
     public void makeNotificationDismissible(NotificationInformation notificationInformation) {
-        stopForeground(DO_NOT_REMOVE_NOTIFICATION);
+        stopForeground(true);
+
+        NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        if (notificationManager != null) {
+            notificationManager.notify("download", notificationInformation.getId(), notificationInformation.getNotification());
+        }
     }
 
     private void acquireCpuWakeLock() {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -1,10 +1,12 @@
 package com.novoda.downloadmanager;
 
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.support.annotation.Nullable;
@@ -67,7 +69,13 @@ public class LiteDownloadService extends Service implements DownloadService {
 
         NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         if (notificationManager != null) {
-            notificationManager.notify("download", notificationInformation.getId(), notificationInformation.getNotification());
+            Notification notification = notificationInformation.getNotification();
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                notificationManager.notify(notification.getChannelId(), notificationInformation.getId(), notification);
+            } else {
+                notificationManager.notify(notificationInformation.getId(), notification);
+            }
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -70,15 +70,14 @@ public class LiteDownloadService extends Service implements DownloadService {
         showFinalDownloadedNotification(notificationInformation);
     }
 
-    @Override
-    public void dismissNotifications() {
-        stopForeground(true);
-        notificationManagerCompat.cancelAll();
-    }
-
     private void showFinalDownloadedNotification(NotificationInformation notificationInformation) {
         Notification notification = notificationInformation.getNotification();
         notificationManagerCompat.notify(NOTIFICATION_TAG, notificationInformation.getId(), notification);
+    }
+
+    @Override
+    public void dismissNotification() {
+        stopForeground(true);
     }
 
     private void acquireCpuWakeLock() {


### PR DESCRIPTION
### Problem
We see only a single notification per batch, each notification wipes the previous and we cannot swipe the notification away when the download is completed.

Additionally, when deleting we post a notification that has the current downloaded percentage 😬  since we don't know what we want to do with this we should prevent notification updates when the status is deleted.

### Solution
Provide a unique id for each notification along with a channel id. When a notification is completed we should remove it from the service (detach) and reattach using the `NotificationManager`. This prevents the new notification from a new batch from wiping the old one. 

- Remove the notification whenever the download status is deleted.
- Stack the notification when the download is completed. This allows another download to show a notification without deleting the previous notification.
- Update the notification for all other statuses. 

### Screen Capture

##### Lollipop
Before | After
--- | ---
![before_lollipop](https://user-images.githubusercontent.com/3380092/32667498-c9c7ad02-c632-11e7-934c-7b68160dc6b4.gif) | ![after_lollipop](https://user-images.githubusercontent.com/3380092/32667497-c9ad98ae-c632-11e7-8a6a-a00f86d8d8fd.gif)

##### Nougat
Before | After
--- | ---
![master mp4](https://user-images.githubusercontent.com/2845931/32669671-38be804a-c639-11e7-9076-b686d787c8ae.gif) | ![dm-notification mp4](https://user-images.githubusercontent.com/2845931/32669470-92021b04-c638-11e7-9744-b9a3fc34149a.gif)

