### PR TITLE
Network recovery disabled crash

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsNetworkRecoveryCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsNetworkRecoveryCreator.java
@@ -6,8 +6,8 @@ class DownloadsNetworkRecoveryCreator {
 
     private static DownloadsNetworkRecovery INSTANCE;
 
-    static DownloadsNetworkRecovery createDisabled() {
-        return DownloadsNetworkRecovery.DISABLED;
+    static void createDisabled() {
+        DownloadsNetworkRecoveryCreator.INSTANCE = DownloadsNetworkRecovery.DISABLED;
     }
 
     static void createEnabled(Context context, DownloadManager downloadManager, ConnectionType connectionType) {


### PR DESCRIPTION
## Problem 
If you specify that the `DownloadManager` should not recover from network errors there is a crash 😬  it would be more appropriate to do nothing or allow the client to supply a strategy. 

```
liteDownloadManagerCommands = DownloadManagerBuilder
                .newInstance(this, handler, R.mipmap.ic_launcher_round)
                .withNetworkDownloader()
                .withFilePersistenceInternal()
                .withAllowedConnectionType(ConnectionType.UNMETERED)
                .withNetworkRecovery(false)
                .build();
```

## Solution
It seems that the `DownloadManager` was always designed to do nothing in the instance where the client requests `withNetworkRecovery(false)` we just weren't assigning to the `INSTANCE` which is why there was a crash. 