### PR TITLE
Flickering on network recovery

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -56,9 +56,8 @@ class DownloadBatch {
         totalBatchSizeBytes = getTotalSize(downloadFiles);
 
         if (totalBatchSizeBytes <= ZERO_BYTES) {
-            DownloadError downloadError = new DownloadError();
-            downloadError.setError(DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE);
-            downloadBatchStatus.markAsError(downloadError);
+            DownloadError downloadError = new DownloadError(DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE);
+            downloadBatchStatus.markAsError(downloadError, downloadsBatchPersistence);
             notifyCallback(downloadBatchStatus);
             return;
         }
@@ -72,7 +71,7 @@ class DownloadBatch {
                 downloadBatchStatus.update(currentBytesDownloaded, totalBatchSizeBytes);
 
                 if (downloadFileStatus.isMarkedAsError()) {
-                    downloadBatchStatus.markAsError(downloadFileStatus.getError());
+                    downloadBatchStatus.markAsError(downloadFileStatus.getError(), downloadsBatchPersistence);
                 }
 
                 callbackThrottle.update(downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -23,12 +23,10 @@ final class DownloadBatchFactory {
         for (String fileUrl : fileUrls) {
             InternalFileSize fileSize = InternalFileSizeCreator.UNKNOWN;
             DownloadFileId downloadFileId = DownloadFileId.from(batch);
-            DownloadError downloadError = new DownloadError();
             DownloadFileStatus downloadFileStatus = new DownloadFileStatus(
                     downloadFileId,
                     DownloadFileStatus.Status.QUEUED,
-                    fileSize,
-                    downloadError
+                    fileSize
             );
             FileName fileName = LiteFileName.from(batch, fileUrl);
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.Nullable;
+
 import java.security.InvalidParameterException;
 
 public interface DownloadBatchStatus {
@@ -40,5 +42,9 @@ public interface DownloadBatchStatus {
 
     Status status();
 
+    /**
+     * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
+     */
+    @Nullable
     DownloadError.Error getDownloadErrorType();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -8,7 +8,7 @@ class DownloadError {
         FILE_CANNOT_BE_WRITTEN,
         STORAGE_UNAVAILABLE,
         NETWORK_ERROR_CANNOT_DOWNLOAD_FILE,
-        UNKNOWN;
+        UNKNOWN
     }
 
     private final Error error;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -8,16 +8,12 @@ class DownloadError {
         FILE_CANNOT_BE_WRITTEN,
         STORAGE_UNAVAILABLE,
         NETWORK_ERROR_CANNOT_DOWNLOAD_FILE,
-        UNKNOWN
+        UNKNOWN;
     }
 
-    private Error error;
+    private final Error error;
 
-    DownloadError() {
-        this.error = Error.UNKNOWN;
-    }
-
-    void setError(Error error) {
+    DownloadError(Error error) {
         this.error = error;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileStatus.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.Nullable;
+
 class DownloadFileStatus {
 
     enum Status {
@@ -13,15 +15,14 @@ class DownloadFileStatus {
 
     private final DownloadFileId downloadFileId;
 
-    private DownloadError downloadError;
     private FileSize fileSize;
     private Status status;
+    private DownloadError downloadError;
 
-    DownloadFileStatus(DownloadFileId downloadFileId, DownloadFileStatus.Status status, FileSize fileSize, DownloadError downloadError) {
+    DownloadFileStatus(DownloadFileId downloadFileId, Status status, FileSize fileSize) {
         this.downloadFileId = downloadFileId;
         this.status = status;
         this.fileSize = fileSize;
-        this.downloadError = downloadError;
     }
 
     void update(FileSize fileSize) {
@@ -57,7 +58,7 @@ class DownloadFileStatus {
     }
 
     boolean isMarkedAsError() {
-        return status == Status.ERROR;
+        return status == Status.ERROR && downloadError != null;
     }
 
     void markAsQueued() {
@@ -70,9 +71,10 @@ class DownloadFileStatus {
 
     void markAsError(DownloadError.Error error) {
         status = Status.ERROR;
-        downloadError.setError(error);
+        downloadError = new DownloadError(error);
     }
 
+    @Nullable
     DownloadError getError() {
         return downloadError;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -102,17 +102,6 @@ public final class DownloadManagerBuilder {
         this.callbackThrottleCreatorType = callbackThrottleCreatorType;
     }
 
-    public DownloadManagerBuilder withNetworkDownloader() {
-        OkHttpClient httpClient = new OkHttpClient();
-        httpClient.setConnectTimeout(5, TimeUnit.SECONDS);
-        httpClient.setWriteTimeout(5, TimeUnit.SECONDS);
-        httpClient.setReadTimeout(5, TimeUnit.SECONDS);
-
-        fileSizeRequester = new NetworkFileSizeRequester(httpClient);
-        fileDownloader = new NetworkFileDownloader(httpClient);
-        return this;
-    }
-
     public DownloadManagerBuilder withFilePersistenceInternal() {
         filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
         return this;
@@ -149,8 +138,8 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder withNetworkRecovery(boolean enabled) {
-        allowNetworkRecovery = enabled;
+    public DownloadManagerBuilder withoutNetworkRecovery() {
+        allowNetworkRecovery = false;
         return this;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
@@ -54,8 +54,7 @@ class DownloadsFilePersistence {
             DownloadFileStatus downloadFileStatus = new DownloadFileStatus(
                     downloadFileId,
                     getFileStatusFrom(batchStatus),
-                    fileSize,
-                    new DownloadError()
+                    fileSize
             );
 
             FileSizeRequester fileSizeRequester = fileOperations.fileSizeRequester();

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -12,7 +12,7 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markForDeletion();
 
-    void markAsError(DownloadError downloadError);
+    void markAsError(DownloadError downloadError, DownloadsBatchStatusPersistence persistence);
 
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -112,6 +112,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         persistence.updateStatusAsync(downloadBatchId, status);
     }
 
+    @Nullable
     @Override
     public DownloadError.Error getDownloadErrorType() {
         if (downloadError != null) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.Nullable;
+
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private static final long ZERO_BYTES = 0;
@@ -10,8 +12,10 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     private long bytesDownloaded;
     private long totalBatchSizeBytes;
     private int percentageDownloaded;
-    private DownloadError downloadError;
     private Status status;
+
+    @Nullable
+    private DownloadError downloadError;
 
     LiteDownloadBatchStatus(DownloadBatchId downloadBatchId, DownloadBatchTitle downloadBatchTitle, Status status) {
         this.downloadBatchTitle = downloadBatchTitle;
@@ -92,9 +96,10 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     }
 
     @Override
-    public void markAsError(DownloadError downloadError) {
+    public void markAsError(DownloadError downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
+        updateStatus(status, persistence);
     }
 
     @Override
@@ -109,6 +114,10 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     @Override
     public DownloadError.Error getDownloadErrorType() {
-        return downloadError.error();
+        if (downloadError != null) {
+            return downloadError.error();
+        } else {
+            return null;
+        }
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -95,12 +95,10 @@ class LiteDownloadManagerDownloader {
 
     private void executeDownload(final DownloadBatch downloadBatch) {
         InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
-        if (downloadBatchStatus.status() == DOWNLOADED) {
-            return;
+        if (downloadBatchStatus.status() != DOWNLOADED) {
+            updateStatusToQueuedIfNeeded(downloadBatchStatus);
+            downloadService.download(downloadBatch, downloadBatchCallback());
         }
-
-        updateStatusToQueuedIfNeeded(downloadBatchStatus);
-        downloadService.download(downloadBatch, downloadBatchCallback());
     }
 
     private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -6,8 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
 
 class LiteDownloadManagerDownloader {
 
@@ -95,15 +94,18 @@ class LiteDownloadManagerDownloader {
     }
 
     private void executeDownload(final DownloadBatch downloadBatch) {
-        updateStatusToQueuedIfNeeded(downloadBatch);
+        InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
+        if (downloadBatchStatus.status() == DOWNLOADED) {
+            return;
+        }
+
+        updateStatusToQueuedIfNeeded(downloadBatchStatus);
         downloadService.download(downloadBatch, downloadBatchCallback());
     }
 
-    private void updateStatusToQueuedIfNeeded(DownloadBatch downloadBatch) {
-        InternalDownloadBatchStatus liteDownloadBatchStatus = downloadBatch.status();
-
-        if (liteDownloadBatchStatus.status() != PAUSED) {
-            liteDownloadBatchStatus.markAsQueued(downloadsBatchPersistence);
+    private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {
+        if (downloadBatchStatus.status() != PAUSED) {
+            downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
         }
     }
 


### PR DESCRIPTION
## Problem
When there is a network error with the first download batch and network recovery is in operation then the second completed batch flickers between `DOWNLOADED` and `QUEUED`.

`DownloadError` is created and passed through the constructor of some objects as `UNKNOWN`. It seems that `UNKNOWN` is used to represent a missing error 🤔  this should instead be an `Optional` or `@Nullable` field.

## Solution
When queueing downloads ignore all items that are already `DOWNLOADED`. Made `DownloadError` `@Nullable` wherever it is currently used.