### PR TITLE
Batch download status goes back to PENDING between files.

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -44,6 +44,7 @@ public class BatchQuery {
 
         private static final String ORDER_BY_LIVENESS = "CASE " + DownloadContract.Batches.COLUMN_STATUS + " "
                 + "WHEN " + DownloadStatus.RUNNING + " THEN 1 "
+                + "WHEN " + DownloadStatus.BATCH_RUNNING + " THEN 2 "
                 + "WHEN " + DownloadStatus.PENDING + " THEN 2 "
                 + "WHEN " + DownloadStatus.PAUSED_BY_APP + " THEN 3 "
                 + "WHEN " + DownloadStatus.BATCH_FAILED + " THEN 4 "
@@ -159,6 +160,9 @@ public class BatchQuery {
                         .or()
                         .withSelection(DownloadContract.Batches.COLUMN_STATUS, Criteria.Wildcard.EQUALS)
                         .withArgument(String.valueOf(DownloadStatus.SUBMITTED))
+                        .or()
+                        .withSelection(DownloadContract.Batches.COLUMN_STATUS, Criteria.Wildcard.EQUALS)
+                        .withArgument(String.valueOf(DownloadStatus.BATCH_RUNNING))
                         .build();
                 criteriaList.add(pendingCriteria);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchQuery.java
@@ -45,11 +45,11 @@ public class BatchQuery {
         private static final String ORDER_BY_LIVENESS = "CASE " + DownloadContract.Batches.COLUMN_STATUS + " "
                 + "WHEN " + DownloadStatus.RUNNING + " THEN 1 "
                 + "WHEN " + DownloadStatus.BATCH_RUNNING + " THEN 2 "
-                + "WHEN " + DownloadStatus.PENDING + " THEN 2 "
-                + "WHEN " + DownloadStatus.PAUSED_BY_APP + " THEN 3 "
-                + "WHEN " + DownloadStatus.BATCH_FAILED + " THEN 4 "
-                + "WHEN " + DownloadStatus.SUCCESS + " THEN 5 "
-                + "ELSE 6 "
+                + "WHEN " + DownloadStatus.PENDING + " THEN 3 "
+                + "WHEN " + DownloadStatus.PAUSED_BY_APP + " THEN 4 "
+                + "WHEN " + DownloadStatus.BATCH_FAILED + " THEN 5 "
+                + "WHEN " + DownloadStatus.SUCCESS + " THEN 6 "
+                + "ELSE 7 "
                 + "END, " + DownloadContract.Batches._ID + " ASC";
 
         private Criteria.Builder criteriaIdBuilder;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/BatchStatusRepository.java
@@ -75,6 +75,10 @@ class BatchStatusRepository {
             return DownloadStatus.RUNNING;
         }
 
+        if (statuses.hasOnlyCompleteAndSubmittedOrPendingStatuses()) {
+            return DownloadStatus.BATCH_RUNNING;
+        }
+
         return statuses.getFirstStatusByPriority();
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadReadyChecker.java
@@ -47,6 +47,7 @@ class DownloadReadyChecker {
             case DownloadStatus.PENDING: // download is explicit marked as ready to start
             case DownloadStatus.RUNNING: // download interrupted (process killed etc) while
                 // running, without a chance to update the database
+            case DownloadStatus.BATCH_RUNNING: // same as RUNNING
                 return true;
 
             case DownloadStatus.WAITING_FOR_NETWORK:

--- a/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/DownloadStatus.java
@@ -32,6 +32,10 @@ public final class DownloadStatus {
      */
     public static final int PENDING = 190;
     /**
+     * This batch has started
+     */
+    public static final int BATCH_RUNNING = 191;
+    /**
      * This download has started
      */
     public static final int RUNNING = 192;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/PublicFacingStatusTranslator.java
@@ -12,6 +12,7 @@ public class PublicFacingStatusTranslator {
             case DownloadStatus.QUEUED_FOR_WIFI:
                 return DownloadManager.STATUS_PENDING;
             case DownloadStatus.RUNNING:
+            case DownloadStatus.BATCH_RUNNING:
                 return DownloadManager.STATUS_RUNNING;
             case DownloadStatus.PAUSED_BY_APP:
                 return DownloadManager.STATUS_PAUSED;

--- a/library/src/main/java/com/novoda/downloadmanager/lib/Statuses.java
+++ b/library/src/main/java/com/novoda/downloadmanager/lib/Statuses.java
@@ -40,6 +40,19 @@ class Statuses {
             DownloadStatus.PENDING
     );
 
+    private static final List<Integer> STATUSES_EXCEPT_SUCCESS_SUBMITTED_AND_PENDING = Arrays.asList(
+            DownloadStatus.CANCELED,
+            DownloadStatus.PAUSED_BY_APP,
+            DownloadStatus.RUNNING,
+            DownloadStatus.DELETING,
+
+            // Paused statuses
+            DownloadStatus.QUEUED_DUE_CLIENT_RESTRICTIONS,
+            DownloadStatus.WAITING_TO_RETRY,
+            DownloadStatus.WAITING_FOR_NETWORK,
+            DownloadStatus.QUEUED_FOR_WIFI
+    );
+
     private static final int NO_ERROR_STATUS = 0;
 
     private final SparseArrayCompat<Integer> statusCounts = new SparseArrayCompat<>(PRIORITISED_STATUSES.size());
@@ -79,6 +92,15 @@ class Statuses {
         boolean hasNotOtherItems = hasNoItemsWithStatuses(STATUSES_EXCEPT_SUCCESS_SUBMITTED);
 
         return hasCompleteItems && hasSubmittedItems && hasNotOtherItems;
+    }
+
+    boolean hasOnlyCompleteAndSubmittedOrPendingStatuses() {
+        boolean hasCompleteItems = hasCountFor(DownloadStatus.SUCCESS);
+        boolean hasSubmittedOrPendingItems = hasCountFor(DownloadStatus.SUBMITTED) ||
+                hasCountFor(DownloadStatus.PENDING);
+        boolean hasNotOtherItems = hasNoItemsWithStatuses(STATUSES_EXCEPT_SUCCESS_SUBMITTED_AND_PENDING);
+
+        return hasCompleteItems && hasSubmittedOrPendingItems && hasNotOtherItems;
     }
 
     boolean hasErrorStatus() {

--- a/library/src/test/java/com/novoda/downloadmanager/lib/BatchQueryTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/lib/BatchQueryTest.java
@@ -40,8 +40,9 @@ public class BatchQueryTest {
 
         assertThat(query.getSelection()).isEqualTo(
                 "(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
-                        +DownloadContract.Batches.COLUMN_STATUS + "=?)");
-        assertThatSelectionArgumentAreEqualTo(query.getSelectionArguments(), new Integer[]{DownloadStatus.PENDING, DownloadStatus.SUBMITTED});
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=?)");
+        assertThatSelectionArgumentAreEqualTo(query.getSelectionArguments(), new Integer[]{DownloadStatus.PENDING, DownloadStatus.SUBMITTED, DownloadStatus.BATCH_RUNNING});
     }
 
     @Test
@@ -135,10 +136,12 @@ public class BatchQueryTest {
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=?)");
         Integer[] expectedArguments = {
                 DownloadStatus.PENDING,
                 DownloadStatus.SUBMITTED,
+                DownloadStatus.BATCH_RUNNING,
                 DownloadStatus.RUNNING,
                 DownloadStatus.PAUSED_BY_APP,
                 DownloadStatus.WAITING_TO_RETRY,
@@ -147,7 +150,6 @@ public class BatchQueryTest {
                 DownloadStatus.QUEUED_DUE_CLIENT_RESTRICTIONS
         };
         assertThatSelectionArgumentAreEqualTo(query.getSelectionArguments(), expectedArguments);
-
     }
 
     @Test
@@ -169,11 +171,13 @@ public class BatchQueryTest {
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=?)");
 
         Integer[] expectedArguments = {
                 DownloadStatus.PENDING,
                 DownloadStatus.SUBMITTED,
+                DownloadStatus.BATCH_RUNNING,
                 DownloadStatus.RUNNING,
                 DownloadStatus.PAUSED_BY_APP,
                 DownloadStatus.WAITING_TO_RETRY,
@@ -208,12 +212,14 @@ public class BatchQueryTest {
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + "(" + DownloadContract.Batches.COLUMN_STATUS + ">=? AND "
                         + DownloadContract.Batches.COLUMN_STATUS + "<?))");
 
         Integer[] expectedArguments = {
                 DownloadStatus.PENDING,
                 DownloadStatus.SUBMITTED,
+                DownloadStatus.BATCH_RUNNING,
                 DownloadStatus.RUNNING,
                 DownloadStatus.PAUSED_BY_APP,
                 DownloadStatus.WAITING_TO_RETRY,
@@ -254,6 +260,7 @@ public class BatchQueryTest {
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + "(" + DownloadContract.Batches.COLUMN_STATUS + ">=? AND "
                         + DownloadContract.Batches.COLUMN_STATUS + "<?))");
 
@@ -261,6 +268,7 @@ public class BatchQueryTest {
                 id,
                 DownloadStatus.PENDING,
                 DownloadStatus.SUBMITTED,
+                DownloadStatus.BATCH_RUNNING,
                 DownloadStatus.RUNNING,
                 DownloadStatus.PAUSED_BY_APP,
                 DownloadStatus.WAITING_TO_RETRY,
@@ -327,11 +335,13 @@ public class BatchQueryTest {
                 "(" + DownloadContract.Batches._ID + "=?) AND "
                         + "(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                        + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                         + DownloadContract.Batches.COLUMN_STATUS + "=?)");
         Integer[] expectedArguments = {
                 thirdId,
                 DownloadStatus.PENDING,
                 DownloadStatus.SUBMITTED,
+                DownloadStatus.BATCH_RUNNING,
                 DownloadStatus.RUNNING};
         assertThatSelectionArgumentAreEqualTo(query.getSelectionArguments(), expectedArguments);
 
@@ -346,6 +356,7 @@ public class BatchQueryTest {
                 .build();
 
         assertThat(query.getSelection()).isEqualTo("(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                                                           + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                                                            + DownloadContract.Batches.COLUMN_STATUS + "=?)");
         assertThat(query.getSortOrder()).isEqualTo(sortColumn + " ASC ");
     }
@@ -359,6 +370,7 @@ public class BatchQueryTest {
                 .build();
 
         assertThat(query.getSelection()).isEqualTo("(" + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
+                                                           + DownloadContract.Batches.COLUMN_STATUS + "=? OR "
                                                            + DownloadContract.Batches.COLUMN_STATUS + "=?)");
         assertThat(query.getSortOrder()).isEqualTo(sortColumn + " DESC ");
     }
@@ -369,11 +381,12 @@ public class BatchQueryTest {
 
         assertThat(query.getSortOrder()).isEqualTo("CASE batch_status " +
                 "WHEN 192 THEN 1 " +
-                "WHEN 190 THEN 2 " +
-                "WHEN 193 THEN 3 " +
-                "WHEN 498 THEN 4 " +
-                "WHEN 200 THEN 5 " +
-                "ELSE 6 END, _id ASC");
+                "WHEN 191 THEN 2 " +
+                "WHEN 190 THEN 3 " +
+                "WHEN 193 THEN 4 " +
+                "WHEN 498 THEN 5 " +
+                "WHEN 200 THEN 6 " +
+                "ELSE 7 END, _id ASC");
     }
 
     private void assertThatSelectionArgumentAreEqualTo(Object[] firstArray, Object[] secondArray) {


### PR DESCRIPTION
When creating a batch with a lot of small download files, we can see that for each file, the batch status goes back to PENDING before going to RUNNING when the current file is actually downloading.

That means that displaying the batch status flickers between Queued and Downloading.

To prevent that effect I have added a BATCH_RUNNING status which means that the batch is running, even if its current download is pending.

Screen capture before the changes:

Before | After
---|---
![download_before](https://user-images.githubusercontent.com/11037060/32754277-337c35ac-c89e-11e7-8211-b8b4c630012d.gif) | ![download_after](https://user-images.githubusercontent.com/11037060/32754290-3bd0ee82-c89e-11e7-9e12-3a8572045b6b.gif)
