### PR TITLE
Batch by batch migration

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
@@ -39,16 +39,23 @@ public class SqlDatabaseWrapper {
         }
     }
 
-    public void delete(String table, String whereClause, String selectionArgument, String... selectionArguments) {
+    public void startTransaction() {
         sqLiteDatabase.beginTransaction();
+    }
 
+    public void setTransactionSuccessful() {
+        sqLiteDatabase.setTransactionSuccessful();
+    }
+
+    public void endTransaction() {
+        sqLiteDatabase.endTransaction();
+    }
+
+    public void delete(String table, String whereClause, String selectionArgument, String... selectionArguments) {
         List<String> arguments = new ArrayList<>();
         arguments.add(selectionArgument);
         arguments.addAll(Arrays.asList(selectionArguments));
 
         sqLiteDatabase.delete(table, whereClause, arguments.toArray(new String[arguments.size()]));
-
-        sqLiteDatabase.setTransactionSuccessful();
-        sqLiteDatabase.endTransaction();
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
@@ -38,4 +38,12 @@ public class SqlDatabaseWrapper {
             outputFile.delete();
         }
     }
+
+    public void delete(String table, String whereClause, String selectionArgument, String... selectionArguments) {
+        List<String> arguments = new ArrayList<>();
+        arguments.add(selectionArgument);
+        arguments.addAll(Arrays.asList(selectionArguments));
+
+        sqLiteDatabase.delete(table, whereClause, new String[]{selectionArgument});
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
+++ b/library/src/main/java/com/novoda/downloadmanager/SqlDatabaseWrapper.java
@@ -40,10 +40,15 @@ public class SqlDatabaseWrapper {
     }
 
     public void delete(String table, String whereClause, String selectionArgument, String... selectionArguments) {
+        sqLiteDatabase.beginTransaction();
+
         List<String> arguments = new ArrayList<>();
         arguments.add(selectionArgument);
         arguments.addAll(Arrays.asList(selectionArguments));
 
-        sqLiteDatabase.delete(table, whereClause, new String[]{selectionArgument});
+        sqLiteDatabase.delete(table, whereClause, arguments.toArray(new String[arguments.size()]));
+
+        sqLiteDatabase.setTransactionSuccessful();
+        sqLiteDatabase.endTransaction();
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
@@ -14,7 +14,8 @@ class VersionOneToVersionTwoMigrator implements Migrator {
     private static final String TAG = "V1 to V2 migrator";
 
     private static final int RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK = 4096;
-    private static final String DELETE_BY_ID_QUERY = "DELETE FROM batches WHERE _id = ?";
+    private static final String TABLE_BATCHES = "batches";
+    private static final String WHERE_CLAUSE_ID = "_id = ?";
 
     private final MigrationExtractor migrationExtractor;
     private final DownloadsPersistence downloadsPersistence;
@@ -136,8 +137,8 @@ class VersionOneToVersionTwoMigrator implements Migrator {
     // TODO: See https://github.com/novoda/download-manager/issues/270
     private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
         Batch batch = migration.batch();
-        Log.d(TAG, "deleting: " + batch.getDownloadBatchId().stringValue());
-        database.delete("batches", "_id =", batch.getDownloadBatchId().stringValue());
+        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().stringValue() + ", time is " + System.nanoTime());
+        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().stringValue());
         for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
             File file = new File(metadata.originalFileLocation());
             file.delete();

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
@@ -136,7 +136,8 @@ class VersionOneToVersionTwoMigrator implements Migrator {
     // TODO: See https://github.com/novoda/download-manager/issues/270
     private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
         Batch batch = migration.batch();
-        database.rawQuery(DELETE_BY_ID_QUERY, batch.getDownloadBatchId().stringValue());
+        Log.d(TAG, "deleting: " + batch.getDownloadBatchId().stringValue());
+        database.delete("batches", "_id =", batch.getDownloadBatchId().stringValue());
         for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
             File file = new File(metadata.originalFileLocation());
             file.delete();

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrator.java
@@ -47,14 +47,16 @@ class VersionOneToVersionTwoMigrator implements Migrator {
 
         migrationCallback.onUpdate("Migrating Files");
         Log.d(TAG, "about to migrate the files, time is " + System.nanoTime());
-        migrateV1FilesToV2Location(migrations);
-        Log.d(TAG, "files are all MOVED, about to start migrating the database, time is " + System.nanoTime());
 
-        migrateV1DataToV2Database(migrations);
+        for (Migration migration : migrations) {
+            migrateV1FilesToV2Location(migration);
+            migrateV1DataToV2Database(migration);
+            deleteFrom(database, migration);
+        }
+
         Log.d(TAG, "all data migrations are COMMITTED, about to delete the old database, time is " + System.nanoTime());
 
         migrationCallback.onUpdate("Deleting Database");
-        deleteFrom(database, migrations);
         Log.d(TAG, "all traces of v1 are ERASED, time is " + System.nanoTime());
         database.close();
 
@@ -62,88 +64,82 @@ class VersionOneToVersionTwoMigrator implements Migrator {
         migrationCallback.onUpdate("Migration Complete");
     }
 
-    private void migrateV1FilesToV2Location(List<Migration> migrations) {
-        for (Migration migration : migrations) {
-            Batch batch = migration.batch();
-            for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-                FileName newFileName = LiteFileName.from(batch, fileMetadata.uri());
-                internalFilePersistence.create(newFileName, fileMetadata.fileSize());
-                FileInputStream inputStream = null;
-                try {
-                    // open the v1 file
-                    inputStream = new FileInputStream(new File(fileMetadata.originalFileLocation()));
-                    byte[] bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
+    private void migrateV1FilesToV2Location(Migration migration) {
+        Batch batch = migration.batch();
+        for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
+            FileName newFileName = LiteFileName.from(batch, fileMetadata.uri());
+            internalFilePersistence.create(newFileName, fileMetadata.fileSize());
+            FileInputStream inputStream = null;
+            try {
+                // open the v1 file
+                inputStream = new FileInputStream(new File(fileMetadata.originalFileLocation()));
+                byte[] bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
 
-                    // read the v1 file
-                    int readLast = 0;
-                    while (readLast != -1) {
-                        readLast = inputStream.read(bytes);
-                        if (readLast != 0 && readLast != -1) {
-                            // write the v1 file to the v2 location
-                            internalFilePersistence.write(bytes, 0, readLast);
-                            bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
-                        }
+                // read the v1 file
+                int readLast = 0;
+                while (readLast != -1) {
+                    readLast = inputStream.read(bytes);
+                    if (readLast != 0 && readLast != -1) {
+                        // write the v1 file to the v2 location
+                        internalFilePersistence.write(bytes, 0, readLast);
+                        bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
+                    }
+                }
+            } catch (IOException e) {
+                Log.e(getClass().getSimpleName(), e.getMessage());
+                e.printStackTrace();
+            } finally {
+                try {
+                    internalFilePersistence.close();
+                    if (inputStream != null) {
+                        inputStream.close();
                     }
                 } catch (IOException e) {
                     Log.e(getClass().getSimpleName(), e.getMessage());
                     e.printStackTrace();
-                } finally {
-                    try {
-                        internalFilePersistence.close();
-                        if (inputStream != null) {
-                            inputStream.close();
-                        }
-                    } catch (IOException e) {
-                        Log.e(getClass().getSimpleName(), e.getMessage());
-                        e.printStackTrace();
-                    }
                 }
             }
         }
     }
 
-    private void migrateV1DataToV2Database(List<Migration> migrations) {
-        for (Migration migration : migrations) {
-            Batch batch = migration.batch();
+    private void migrateV1DataToV2Database(Migration migration) {
+        Batch batch = migration.batch();
 
-            downloadsPersistence.startTransaction();
+        downloadsPersistence.startTransaction();
 
-            DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
-            DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), Status.DOWNLOADED);
-            downloadsPersistence.persistBatch(persistedBatch);
+        DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
+        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), Status.DOWNLOADED);
+        downloadsPersistence.persistBatch(persistedBatch);
 
-            for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-                String url = fileMetadata.uri();
+        for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
+            String url = fileMetadata.uri();
 
-                FileName fileName = LiteFileName.from(batch, url);
-                FilePath filePath = FilePathCreator.create(fileName.name());
-                DownloadFileId downloadFileId = DownloadFileId.from(batch);
-                DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
-                        batch.getDownloadBatchId(),
-                        downloadFileId,
-                        fileName,
-                        filePath,
-                        fileMetadata.fileSize().totalSize(),
-                        url,
-                        FilePersistenceType.INTERNAL
-                );
-                downloadsPersistence.persistFile(persistedFile);
-            }
-
-            downloadsPersistence.transactionSuccess();
-            downloadsPersistence.endTransaction();
+            FileName fileName = LiteFileName.from(batch, url);
+            FilePath filePath = FilePathCreator.create(fileName.name());
+            DownloadFileId downloadFileId = DownloadFileId.from(batch);
+            DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
+                    batch.getDownloadBatchId(),
+                    downloadFileId,
+                    fileName,
+                    filePath,
+                    fileMetadata.fileSize().totalSize(),
+                    url,
+                    FilePersistenceType.INTERNAL
+            );
+            downloadsPersistence.persistFile(persistedFile);
         }
+
+        downloadsPersistence.transactionSuccess();
+        downloadsPersistence.endTransaction();
     }
 
     // TODO: See https://github.com/novoda/download-manager/issues/270
-    private void deleteFrom(SqlDatabaseWrapper database, List<Migration> migrations) {
-        for (Migration migration : migrations) {
-            Batch batch = migration.batch();
-            database.rawQuery(DELETE_BY_ID_QUERY, batch.getDownloadBatchId().stringValue());
-            for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
-                File file = new File(metadata.originalFileLocation());
-                file.delete();
-            }
+    private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
+        Batch batch = migration.batch();
+        database.rawQuery(DELETE_BY_ID_QUERY, batch.getDownloadBatchId().stringValue());
+        for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
+            File file = new File(metadata.originalFileLocation());
+            file.delete();
         }
     }
 }


### PR DESCRIPTION
### Problem
The migration from the v1 database to the v2 database can be stopped at any point if the system runs out of resources. This can currently leave the migration process in an inconsistent state because we process in steps e.g. move files and then move the data.

### Solution
Perform the migration in batches, where the migration of a batch is performed in a transaction. If the transaction never completes the changes will be rolled back leaving the databases in a consistent state. 