### PR TITLE
Android Oreo Notification Channel

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -4,14 +4,16 @@ import android.app.Notification;
 import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
-import com.novoda.notils.logger.simple.Log;
 import com.novoda.downloadmanager.DownloadBatchTitle;
 import com.novoda.downloadmanager.NotificationCreator;
 import com.novoda.downloadmanager.NotificationInformation;
+import com.novoda.notils.logger.simple.Log;
 
 public class CustomNotificationCreator implements NotificationCreator {
+
     private static final int ID = 1;
     private static final boolean NOT_INDETERMINATE = false;
+    private static final String CHANNEL = "download_manager";
 
     private final Context context;
     private final int iconDrawable;
@@ -31,7 +33,7 @@ public class CustomNotificationCreator implements NotificationCreator {
 
         Log.v("Create notification for " + title + ", " + content);
 
-        Notification notification = new NotificationCompat.Builder(context)
+        Notification notification = new NotificationCompat.Builder(context, CHANNEL)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                 .setSmallIcon(iconDrawable)
                 .setContentTitle(title)

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
 import com.novoda.downloadmanager.DownloadBatchTitle;
+import com.novoda.downloadmanager.NotificationChannelCreator;
 import com.novoda.downloadmanager.NotificationCreator;
 import com.novoda.downloadmanager.NotificationInformation;
 import com.novoda.notils.logger.simple.Log;
@@ -13,7 +14,6 @@ public class CustomNotificationCreator implements NotificationCreator {
 
     private static final int ID = 1;
     private static final boolean NOT_INDETERMINATE = false;
-    private static final String CHANNEL = "download_manager";
 
     private final Context context;
     private final int iconDrawable;
@@ -33,12 +33,15 @@ public class CustomNotificationCreator implements NotificationCreator {
 
         Log.v("Create notification for " + title + ", " + content);
 
-        Notification notification = new NotificationCompat.Builder(context, CHANNEL)
+        String notificationChannel = NotificationChannelCreator.createDownloadNotificationChannel(context);
+
+        Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                 .setSmallIcon(iconDrawable)
                 .setContentTitle(title)
                 .setContentText(content)
                 .build();
+
         return new CustomNotificationInformation(ID, notification);
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
 import com.novoda.downloadmanager.DownloadBatchTitle;
-import com.novoda.downloadmanager.NotificationChannelCreator;
+import com.novoda.downloadmanager.DownloadNotificationChannelCreator;
 import com.novoda.downloadmanager.NotificationCreator;
 import com.novoda.downloadmanager.NotificationInformation;
 import com.novoda.notils.logger.simple.Log;
@@ -33,7 +33,7 @@ public class CustomNotificationCreator implements NotificationCreator {
 
         Log.v("Create notification for " + title + ", " + content);
 
-        String notificationChannel = NotificationChannelCreator.createDownloadNotificationChannel(context);
+        String notificationChannel = DownloadNotificationChannelCreator.createDownloadNotificationChannel(context);
 
         Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
 import com.novoda.downloadmanager.DownloadBatchTitle;
-import com.novoda.downloadmanager.DownloadNotificationChannelCreator;
+import com.novoda.downloadmanager.NotificationChannelCreator;
 import com.novoda.downloadmanager.NotificationCreator;
 import com.novoda.downloadmanager.NotificationInformation;
 import com.novoda.notils.logger.simple.Log;
@@ -17,10 +17,12 @@ public class CustomNotificationCreator implements NotificationCreator {
 
     private final Context context;
     private final int iconDrawable;
+    private final NotificationChannelCreator notificationChannelCreator;
 
-    public CustomNotificationCreator(Context context, int iconDrawable) {
+    public CustomNotificationCreator(Context context, int iconDrawable, NotificationChannelCreator notificationChannelCreator) {
         this.context = context;
         this.iconDrawable = iconDrawable;
+        this.notificationChannelCreator = notificationChannelCreator;
     }
 
     @Override
@@ -33,7 +35,7 @@ public class CustomNotificationCreator implements NotificationCreator {
 
         Log.v("Create notification for " + title + ", " + content);
 
-        String notificationChannel = DownloadNotificationChannelCreator.createDownloadNotificationChannel(context);
+        String notificationChannel = notificationChannelCreator.createDownloadNotificationChannel(context);
 
         Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -26,7 +26,7 @@ public class CustomNotificationCreator implements NotificationCreator {
     }
 
     @Override
-    public NotificationInformation createNotification(DownloadBatchTitle downloadBatchTitle,
+    public NotificationInformation createNotification(String notificationChannelName, DownloadBatchTitle downloadBatchTitle,
                                                       int percentageDownloaded,
                                                       int bytesFileSize,
                                                       int bytesDownloaded) {
@@ -35,7 +35,7 @@ public class CustomNotificationCreator implements NotificationCreator {
 
         Log.v("Create notification for " + title + ", " + content);
 
-        String notificationChannel = notificationChannelCreator.createDownloadNotificationChannel(context);
+        String notificationChannel = notificationChannelCreator.getNotificationChannelName();
 
         Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -11,25 +11,22 @@ class DownloadBatchNotification implements NotificationCreator {
 
     private final Context context;
     private final int iconDrawable;
-    private final NotificationChannelCreator notificationChannelCreator;
 
-    DownloadBatchNotification(Context context, @DrawableRes int iconDrawable, NotificationChannelCreator notificationChannelCreator) {
+    DownloadBatchNotification(Context context, @DrawableRes int iconDrawable) {
         this.context = context.getApplicationContext();
         this.iconDrawable = iconDrawable;
-        this.notificationChannelCreator = notificationChannelCreator;
     }
 
     @Override
-    public NotificationInformation createNotification(DownloadBatchTitle downloadBatchTitle,
+    public NotificationInformation createNotification(String notificationChannelName,
+                                                      DownloadBatchTitle downloadBatchTitle,
                                                       int percentageDownloaded,
                                                       int bytesFileSize,
                                                       int bytesDownloaded) {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
-        String notificationChannel = notificationChannelCreator.createDownloadNotificationChannel(context);
-
-        Notification notification = new NotificationCompat.Builder(context, notificationChannel)
+        Notification notification = new NotificationCompat.Builder(context, notificationChannelName)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                 .setSmallIcon(iconDrawable)
                 .setContentTitle(title)

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -8,7 +8,6 @@ import android.support.v4.app.NotificationCompat;
 class DownloadBatchNotification implements NotificationCreator {
 
     private static final boolean NOT_INDETERMINATE = false;
-    private static final String CHANNEL_ID = "download_manager";
 
     private final Context context;
     private final int iconDrawable;
@@ -26,7 +25,9 @@ class DownloadBatchNotification implements NotificationCreator {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
-        Notification notification = new NotificationCompat.Builder(context, CHANNEL_ID)
+        String notificationChannel = NotificationChannelCreator.createDownloadNotificationChannel(context);
+
+        Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                 .setSmallIcon(iconDrawable)
                 .setContentTitle(title)

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -11,10 +11,12 @@ class DownloadBatchNotification implements NotificationCreator {
 
     private final Context context;
     private final int iconDrawable;
+    private final NotificationChannelCreator notificationChannelCreator;
 
-    DownloadBatchNotification(Context context, @DrawableRes int iconDrawable) {
+    DownloadBatchNotification(Context context, @DrawableRes int iconDrawable, NotificationChannelCreator notificationChannelCreator) {
         this.context = context.getApplicationContext();
         this.iconDrawable = iconDrawable;
+        this.notificationChannelCreator = notificationChannelCreator;
     }
 
     @Override
@@ -25,7 +27,7 @@ class DownloadBatchNotification implements NotificationCreator {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
-        String notificationChannel = DownloadNotificationChannelCreator.createDownloadNotificationChannel(context);
+        String notificationChannel = notificationChannelCreator.createDownloadNotificationChannel(context);
 
         Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -25,7 +25,7 @@ class DownloadBatchNotification implements NotificationCreator {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
-        String notificationChannel = NotificationChannelCreator.createDownloadNotificationChannel(context);
+        String notificationChannel = DownloadNotificationChannelCreator.createDownloadNotificationChannel(context);
 
         Notification notification = new NotificationCompat.Builder(context, notificationChannel)
                 .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -1,5 +1,6 @@
 package com.novoda.downloadmanager;
 
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.ComponentName;
 import android.content.Context;
@@ -61,7 +62,10 @@ public final class DownloadManagerBuilder {
         FileSizeRequester fileSizeRequester = new NetworkFileSizeRequester(httpClient, requestCreator);
         FileDownloader fileDownloader = new NetworkFileDownloader(httpClient, requestCreator);
 
-        DownloadBatchNotification downloadBatchNotification = new DownloadBatchNotification(context, notificationIcon);
+        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationChannelCreator notificationChannelCreator = new DownloadNotificationChannelCreator(notificationManager);
+
+        DownloadBatchNotification downloadBatchNotification = new DownloadBatchNotification(context, notificationIcon, notificationChannelCreator);
 
         ConnectionType connectionTypeAllowed = ConnectionType.ALL;
         boolean allowNetworkRecovery = true;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
@@ -2,35 +2,38 @@ package com.novoda.downloadmanager;
 
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
-import android.content.Context;
+import android.content.res.Resources;
 import android.os.Build;
 
 class DownloadNotificationChannelCreator implements NotificationChannelCreator {
 
-    private final NotificationManager notificationManager;
+    private final Resources resources;
 
-    DownloadNotificationChannelCreator(NotificationManager notificationManager) {
-        this.notificationManager = notificationManager;
+    DownloadNotificationChannelCreator(Resources resources) {
+        this.resources = resources;
     }
-
-    private static String CHANNEL_ID;
 
     @Override
-    public String createDownloadNotificationChannel(Context context) {
-        if (CHANNEL_ID == null) {
-            CHANNEL_ID = "download-manager";
-            createNotificationChannelForAndroidOreo(context);
+    public Optional<NotificationChannel> createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(channelName(), channelDescription(), NotificationManager.IMPORTANCE_HIGH);
+            return Optional.of(channel);
         }
 
-        return CHANNEL_ID;
+        return Optional.absent();
     }
 
-    private void createNotificationChannelForAndroidOreo(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            String channelName = "Download Manager Notification Service";
-            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_HIGH);
-            notificationManager.createNotificationChannel(channel);
-        }
+    private String channelName() {
+        return resources.getString(R.string.notification_channel_name);
+    }
+
+    private String channelDescription() {
+        return resources.getString(R.string.notification_channel_description);
+    }
+
+    @Override
+    public String getNotificationChannelName() {
+        return channelName();
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
@@ -16,7 +16,7 @@ class DownloadNotificationChannelCreator implements NotificationChannelCreator {
     @Override
     public Optional<NotificationChannel> createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(channelName(), channelDescription(), NotificationManager.IMPORTANCE_HIGH);
+            NotificationChannel channel = new NotificationChannel(channelName(), channelDescription(), NotificationManager.IMPORTANCE_LOW);
             return Optional.of(channel);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
@@ -5,9 +5,18 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 
-public class DownloadNotificationChannelCreator {
+class DownloadNotificationChannelCreator implements NotificationChannelCreator {
 
-    public static String createDownloadNotificationChannel(Context context) {
+    private final NotificationManager notificationManager;
+
+    DownloadNotificationChannelCreator(NotificationManager notificationManager) {
+        this.notificationManager = notificationManager;
+    }
+
+    private static String CHANNEL_ID;
+
+    @Override
+    public String createDownloadNotificationChannel(Context context) {
         if (CHANNEL_ID == null) {
             CHANNEL_ID = "download-manager";
             createNotificationChannelForAndroidOreo(context);
@@ -16,15 +25,12 @@ public class DownloadNotificationChannelCreator {
         return CHANNEL_ID;
     }
 
-    private static void createNotificationChannelForAndroidOreo(Context context) {
+    private void createNotificationChannelForAndroidOreo(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             String channelName = "Download Manager Notification Service";
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_HIGH);
-            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
             notificationManager.createNotificationChannel(channel);
         }
     }
-
-    private static String CHANNEL_ID;
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadNotificationChannelCreator.java
@@ -5,7 +5,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 
-public class NotificationChannelCreator {
+public class DownloadNotificationChannelCreator {
 
     public static String createDownloadNotificationChannel(Context context) {
         if (CHANNEL_ID == null) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -16,6 +16,7 @@ class LiteDownloadManagerDownloader {
     private final FileOperations fileOperations;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final DownloadsFilePersistence downloadsFilePersistence;
+    private final NotificationChannelCreator notificationChannelCreator;
     private final NotificationCreator notificationCreator;
     private final List<DownloadBatchCallback> callbacks;
     private final CallbackThrottleCreator callbackThrottleCreator;
@@ -28,6 +29,7 @@ class LiteDownloadManagerDownloader {
                                   FileOperations fileOperations,
                                   DownloadsBatchPersistence downloadsBatchPersistence,
                                   DownloadsFilePersistence downloadsFilePersistence,
+                                  NotificationChannelCreator notificationChannelCreator,
                                   NotificationCreator notificationCreator,
                                   List<DownloadBatchCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {
@@ -37,6 +39,7 @@ class LiteDownloadManagerDownloader {
         this.fileOperations = fileOperations;
         this.downloadsBatchPersistence = downloadsBatchPersistence;
         this.downloadsFilePersistence = downloadsFilePersistence;
+        this.notificationChannelCreator = notificationChannelCreator;
         this.notificationCreator = notificationCreator;
         this.callbacks = callbacks;
         this.callbackThrottleCreator = callbackThrottleCreator;
@@ -126,6 +129,7 @@ class LiteDownloadManagerDownloader {
 
     private void updateNotification(DownloadBatchStatus liteDownloadBatchStatus, DownloadService downloadService) {
         NotificationInformation notificationInformation = notificationCreator.createNotification(
+                notificationChannelCreator.getNotificationChannelName(),
                 liteDownloadBatchStatus.getDownloadBatchTitle(),
                 liteDownloadBatchStatus.percentageDownloaded(),
                 (int) liteDownloadBatchStatus.bytesTotalSize(),

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
@@ -1,0 +1,9 @@
+package com.novoda.downloadmanager;
+
+import android.content.Context;
+
+public interface NotificationChannelCreator {
+
+    String createDownloadNotificationChannel(Context context);
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
@@ -1,0 +1,30 @@
+package com.novoda.downloadmanager;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.os.Build;
+
+class NotificationChannelCreator {
+
+    static String createDownloadNotificationChannel(Context context) {
+        if (CHANNEL_ID == null) {
+            CHANNEL_ID = "download-manager";
+            createNotificationChannelForAndroidOreo(context);
+        }
+
+        return CHANNEL_ID;
+    }
+
+    private static void createNotificationChannelForAndroidOreo(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            String channelName = "Download Manager Notification Service";
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_HIGH);
+            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            notificationManager.createNotificationChannel(channel);
+        }
+    }
+
+    private static String CHANNEL_ID;
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
@@ -1,9 +1,11 @@
 package com.novoda.downloadmanager;
 
-import android.content.Context;
+import android.app.NotificationChannel;
 
 public interface NotificationChannelCreator {
 
-    String createDownloadNotificationChannel(Context context);
+    Optional<NotificationChannel> createNotificationChannel();
+
+    String getNotificationChannelName();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationChannelCreator.java
@@ -5,9 +5,9 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 
-class NotificationChannelCreator {
+public class NotificationChannelCreator {
 
-    static String createDownloadNotificationChannel(Context context) {
+    public static String createDownloadNotificationChannel(Context context) {
         if (CHANNEL_ID == null) {
             CHANNEL_ID = "download-manager";
             createNotificationChannelForAndroidOreo(context);

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -2,7 +2,8 @@ package com.novoda.downloadmanager;
 
 public interface NotificationCreator {
 
-    NotificationInformation createNotification(DownloadBatchTitle downloadBatchTitle,
+    NotificationInformation createNotification(String notificationChannelName,
+                                               DownloadBatchTitle downloadBatchTitle,
                                                int percentageDownloaded,
                                                int bytesFileSize,
                                                int bytesDownloaded);

--- a/library/src/main/java/com/novoda/downloadmanager/Optional.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Optional.java
@@ -1,0 +1,62 @@
+package com.novoda.downloadmanager;
+
+public final class Optional<T> {
+
+    @SuppressWarnings("unchecked")  // Type erasure has us covered here, we don't care
+    private static final Optional ABSENT = new Optional(null);
+
+    private final T data;
+
+    @SuppressWarnings("unchecked")  // Type erasure has us covered here, we don't care
+    public static <T> Optional<T> absent() {
+        return ABSENT;
+    }
+
+    public static <T> Optional<T> of(T data) {
+        if (data == null) {
+            throw new IllegalArgumentException("Data cannot be null. Use Optional.fromNullable(maybeNullData).");
+        }
+        return new Optional<>(data);
+    }
+
+    private Optional(T data) {
+        this.data = data;
+    }
+
+    public boolean isPresent() {
+        return data != null;
+    }
+
+    public T get() {
+        if (!isPresent()) {
+            throw new IllegalStateException("You must check if data is present before using get()");
+        }
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Optional<?> optional = (Optional<?>) o;
+
+        return data != null ? data.equals(optional.data) : optional.data == null;
+    }
+
+    @Override
+    public int hashCode() {
+        return data != null ? data.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Optional{" +
+                "data=" + data +
+                '}';
+    }
+}

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
   <string name="app_name">Lite DownloadManager</string>
+  <string name="notification_channel_name">download-manager</string>
+  <string name="notification_channel_description">Download Manager Notification Service</string>
 </resources>


### PR DESCRIPTION
### Problem
`download-manager` v2 crashes 😱  under the following scenario:


1. Start the demo application
2. Start a download
3. Application crash on API 27, check logs
4. Application does not show a notification on API 26, there is a warning on the usage of the channel

### Solution
Add a Notification Channel for the standard download notifications that are sent by the `download-manager`.