### PR TITLE
Foreground Migration Service

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -4,13 +4,14 @@ import android.app.Notification;
 import android.content.Context;
 import android.support.v4.app.NotificationCompat;
 
+import com.novoda.downloadmanager.DownloadBatchStatus;
 import com.novoda.downloadmanager.DownloadBatchTitle;
 import com.novoda.downloadmanager.NotificationChannelCreator;
 import com.novoda.downloadmanager.NotificationCreator;
 import com.novoda.downloadmanager.NotificationInformation;
 import com.novoda.notils.logger.simple.Log;
 
-public class CustomNotificationCreator implements NotificationCreator {
+public class CustomNotificationCreator implements NotificationCreator<DownloadBatchStatus> {
 
     private static final int ID = 1;
     private static final boolean NOT_INDETERMINATE = false;
@@ -26,11 +27,12 @@ public class CustomNotificationCreator implements NotificationCreator {
     }
 
     @Override
-    public NotificationInformation createNotificationWithProgress(String notificationChannelName, DownloadBatchTitle downloadBatchTitle,
-                                                                  int percentageDownloaded,
-                                                                  int bytesFileSize,
-                                                                  int bytesDownloaded) {
-        String title = downloadBatchTitle.toString();
+    public NotificationInformation createNotification(String notificationChannelName, DownloadBatchStatus downloadBatchStatus) {
+        DownloadBatchTitle downloadBatchTitle = downloadBatchStatus.getDownloadBatchTitle();
+        int percentageDownloaded = downloadBatchStatus.percentageDownloaded();
+        int bytesFileSize = (int) downloadBatchStatus.bytesTotalSize();
+        int bytesDownloaded = (int) downloadBatchStatus.bytesDownloaded();
+        String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 
         Log.v("Create notification for " + title + ", " + content);

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomNotificationCreator.java
@@ -26,10 +26,10 @@ public class CustomNotificationCreator implements NotificationCreator {
     }
 
     @Override
-    public NotificationInformation createNotification(String notificationChannelName, DownloadBatchTitle downloadBatchTitle,
-                                                      int percentageDownloaded,
-                                                      int bytesFileSize,
-                                                      int bytesDownloaded) {
+    public NotificationInformation createNotificationWithProgress(String notificationChannelName, DownloadBatchTitle downloadBatchTitle,
+                                                                  int percentageDownloaded,
+                                                                  int bytesFileSize,
+                                                                  int bytesDownloaded) {
         String title = downloadBatchTitle.toString();
         String content = percentageDownloaded + "% downloaded";
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -5,7 +5,7 @@ import android.content.Context;
 import android.support.annotation.DrawableRes;
 import android.support.v4.app.NotificationCompat;
 
-class DownloadBatchNotification implements NotificationCreator {
+class DownloadBatchNotification implements NotificationCreator<DownloadBatchStatus> {
 
     private static final boolean NOT_INDETERMINATE = false;
 
@@ -18,11 +18,11 @@ class DownloadBatchNotification implements NotificationCreator {
     }
 
     @Override
-    public NotificationInformation createNotificationWithProgress(String notificationChannelName,
-                                                                  DownloadBatchTitle downloadBatchTitle,
-                                                                  int percentageDownloaded,
-                                                                  int bytesFileSize,
-                                                                  int bytesDownloaded) {
+    public NotificationInformation createNotification(String notificationChannelName, DownloadBatchStatus downloadBatchStatus) {
+        DownloadBatchTitle downloadBatchTitle = downloadBatchStatus.getDownloadBatchTitle();
+        int percentageDownloaded = downloadBatchStatus.percentageDownloaded();
+        int bytesFileSize = (int) downloadBatchStatus.bytesTotalSize();
+        int bytesDownloaded = (int) downloadBatchStatus.bytesDownloaded();
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchNotification.java
@@ -18,11 +18,11 @@ class DownloadBatchNotification implements NotificationCreator {
     }
 
     @Override
-    public NotificationInformation createNotification(String notificationChannelName,
-                                                      DownloadBatchTitle downloadBatchTitle,
-                                                      int percentageDownloaded,
-                                                      int bytesFileSize,
-                                                      int bytesDownloaded) {
+    public NotificationInformation createNotificationWithProgress(String notificationChannelName,
+                                                                  DownloadBatchTitle downloadBatchTitle,
+                                                                  int percentageDownloaded,
+                                                                  int bytesFileSize,
+                                                                  int bytesDownloaded) {
         String title = downloadBatchTitle.asString();
         String content = percentageDownloaded + "% downloaded";
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -36,7 +36,7 @@ public final class DownloadManagerBuilder {
     private DownloadService downloadService;
     private DownloadManager downloadManager;
     private final NotificationChannelCreator notificationChannelCreator;
-    private NotificationCreator notificationCreator;
+    private NotificationCreator<DownloadBatchStatus> notificationCreator;
     private ConnectionType connectionTypeAllowed;
     private boolean allowNetworkRecovery;
     private Class<? extends CallbackThrottle> customCallbackThrottle;
@@ -65,10 +65,9 @@ public final class DownloadManagerBuilder {
         FileSizeRequester fileSizeRequester = new NetworkFileSizeRequester(httpClient, requestCreator);
         FileDownloader fileDownloader = new NetworkFileDownloader(httpClient, requestCreator);
 
-        NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         NotificationChannelCreator notificationChannelCreator = new DownloadNotificationChannelCreator(context.getResources());
 
-        DownloadBatchNotification downloadBatchNotification = new DownloadBatchNotification(context, notificationIcon);
+        NotificationCreator<DownloadBatchStatus> downloadBatchNotification = new DownloadBatchNotification(context, notificationIcon);
 
         ConnectionType connectionTypeAllowed = ConnectionType.ALL;
         boolean allowNetworkRecovery = true;
@@ -97,7 +96,7 @@ public final class DownloadManagerBuilder {
                                    FileSizeRequester fileSizeRequester,
                                    FileDownloader fileDownloader,
                                    NotificationChannelCreator notificationChannelCreator,
-                                   NotificationCreator notificationCreator,
+                                   NotificationCreator<DownloadBatchStatus> notificationCreator,
                                    ConnectionType connectionTypeAllowed,
                                    boolean allowNetworkRecovery,
                                    CallbackThrottleCreator.Type callbackThrottleCreatorType) {
@@ -140,7 +139,7 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder withNotification(NotificationCreator notificationCreator) {
+    public DownloadManagerBuilder withNotification(NotificationCreator<DownloadBatchStatus> notificationCreator) {
         this.notificationCreator = notificationCreator;
         return this;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -17,7 +17,7 @@ class LiteDownloadManagerDownloader {
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final NotificationChannelCreator notificationChannelCreator;
-    private final NotificationCreator notificationCreator;
+    private final NotificationCreator<DownloadBatchStatus> notificationCreator;
     private final List<DownloadBatchCallback> callbacks;
     private final CallbackThrottleCreator callbackThrottleCreator;
 
@@ -30,7 +30,7 @@ class LiteDownloadManagerDownloader {
                                   DownloadsBatchPersistence downloadsBatchPersistence,
                                   DownloadsFilePersistence downloadsFilePersistence,
                                   NotificationChannelCreator notificationChannelCreator,
-                                  NotificationCreator notificationCreator,
+                                  NotificationCreator<DownloadBatchStatus> notificationCreator,
                                   List<DownloadBatchCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {
         this.waitForDownloadService = waitForDownloadService;
@@ -128,12 +128,9 @@ class LiteDownloadManagerDownloader {
     }
 
     private void updateNotification(DownloadBatchStatus liteDownloadBatchStatus, DownloadService downloadService) {
-        NotificationInformation notificationInformation = notificationCreator.createNotificationWithProgress(
+        NotificationInformation notificationInformation = notificationCreator.createNotification(
                 notificationChannelCreator.getNotificationChannelName(),
-                liteDownloadBatchStatus.getDownloadBatchTitle(),
-                liteDownloadBatchStatus.percentageDownloaded(),
-                (int) liteDownloadBatchStatus.bytesTotalSize(),
-                (int) liteDownloadBatchStatus.bytesDownloaded()
+                liteDownloadBatchStatus
         );
 
         if (liteDownloadBatchStatus.status() == DELETION) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -128,7 +128,7 @@ class LiteDownloadManagerDownloader {
     }
 
     private void updateNotification(DownloadBatchStatus liteDownloadBatchStatus, DownloadService downloadService) {
-        NotificationInformation notificationInformation = notificationCreator.createNotification(
+        NotificationInformation notificationInformation = notificationCreator.createNotificationWithProgress(
                 notificationChannelCreator.getNotificationChannelName(),
                 liteDownloadBatchStatus.getDownloadBatchTitle(),
                 liteDownloadBatchStatus.percentageDownloaded(),

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationNotification.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationNotification.java
@@ -1,0 +1,50 @@
+package com.novoda.downloadmanager;
+
+import android.app.Notification;
+import android.content.Context;
+import android.support.annotation.DrawableRes;
+import android.support.v4.app.NotificationCompat;
+
+class MigrationNotification implements NotificationCreator<MigrationStatus> {
+
+    private final Context context;
+    private final int iconDrawable;
+
+    MigrationNotification(Context context, @DrawableRes int iconDrawable) {
+        this.context = context.getApplicationContext();
+        this.iconDrawable = iconDrawable;
+    }
+
+    @Override
+    public NotificationInformation createNotification(String notificationChannelName, MigrationStatus migrationStatus) {
+        String title = migrationStatus.message();
+
+        Notification notification = new NotificationCompat.Builder(context, notificationChannelName)
+                .setSmallIcon(iconDrawable)
+                .setContentTitle(migrationStatus.message())
+                .build();
+
+        return new MigrationNotificationInformation(title.hashCode(), notification);
+    }
+
+    private static class MigrationNotificationInformation implements NotificationInformation {
+
+        private final int id;
+        private final Notification notification;
+
+        MigrationNotificationInformation(int id, Notification notification) {
+            this.id = id;
+            this.notification = notification;
+        }
+
+        @Override
+        public int getId() {
+            return id;
+        }
+
+        @Override
+        public Notification getNotification() {
+            return notification;
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationNotificationChannelCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationNotificationChannelCreator.java
@@ -5,11 +5,11 @@ import android.app.NotificationManager;
 import android.content.res.Resources;
 import android.os.Build;
 
-class DownloadNotificationChannelCreator implements NotificationChannelCreator {
+class MigrationNotificationChannelCreator implements NotificationChannelCreator {
 
     private final Resources resources;
 
-    DownloadNotificationChannelCreator(Resources resources) {
+    MigrationNotificationChannelCreator(Resources resources) {
         this.resources = resources;
     }
 
@@ -24,11 +24,11 @@ class DownloadNotificationChannelCreator implements NotificationChannelCreator {
     }
 
     private String channelName() {
-        return resources.getString(R.string.download_notification_channel_name);
+        return resources.getString(R.string.migration_notification_channel_name);
     }
 
     private String channelDescription() {
-        return resources.getString(R.string.download_notification_channel_description);
+        return resources.getString(R.string.migration_notification_channel_description);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationStatus.java
@@ -1,0 +1,7 @@
+package com.novoda.downloadmanager;
+
+interface MigrationStatus {
+
+    String message();
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -2,9 +2,9 @@ package com.novoda.downloadmanager;
 
 public interface NotificationCreator {
 
-    NotificationInformation createNotification(String notificationChannelName,
-                                               DownloadBatchTitle downloadBatchTitle,
-                                               int percentageDownloaded,
-                                               int bytesFileSize,
-                                               int bytesDownloaded);
+    NotificationInformation createNotificationWithProgress(String notificationChannelName,
+                                                           DownloadBatchTitle downloadBatchTitle,
+                                                           int percentageDownloaded,
+                                                           int bytesFileSize,
+                                                           int bytesDownloaded);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -1,7 +1,7 @@
 package com.novoda.downloadmanager;
 
-public interface NotificationCreator<PAYLOAD> {
+public interface NotificationCreator<T> {
 
-    NotificationInformation createNotification(String notificationChannelName, PAYLOAD notificationPayload);
+    NotificationInformation createNotification(String notificationChannelName, T notificationPayload);
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -1,10 +1,7 @@
 package com.novoda.downloadmanager;
 
-public interface NotificationCreator {
+public interface NotificationCreator<PAYLOAD> {
 
-    NotificationInformation createNotificationWithProgress(String notificationChannelName,
-                                                           DownloadBatchTitle downloadBatchTitle,
-                                                           int percentageDownloaded,
-                                                           int bytesFileSize,
-                                                           int bytesDownloaded);
+    NotificationInformation createNotification(String notificationChannelName, PAYLOAD notificationPayload);
+
 }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -1,0 +1,15 @@
+package com.novoda.downloadmanager;
+
+class VersionOneToVersionTwoMigrationStatus implements MigrationStatus {
+
+    private final String message;
+
+    public VersionOneToVersionTwoMigrationStatus(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -4,7 +4,7 @@ class VersionOneToVersionTwoMigrationStatus implements MigrationStatus {
 
     private final String message;
 
-    public VersionOneToVersionTwoMigrationStatus(String message) {
+    VersionOneToVersionTwoMigrationStatus(String message) {
         this.message = message;
     }
 

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
   <string name="app_name">Lite DownloadManager</string>
-  <string name="notification_channel_name">download-manager</string>
-  <string name="notification_channel_description">Download Manager Notification Service</string>
+  <string name="download_notification_channel_name">download-manager</string>
+  <string name="download_notification_channel_description">Download Manager Notification Service</string>
+  <string name="migration_notification_channel_name">download-manager-migration</string>
+  <string name="migration_notification_channel_description">Download Manager Migration Notification Service</string>
 </resources>


### PR DESCRIPTION
### Problem
We have a `MigrationService` but it does not supply notifications to the user! 😱 

### Solution
Implement a `foreground` Service and forward a `MigrationStatus` that will be mapped to a `Notification` and displayed. Decided to open a PR now because I've made some, potentially controversial changes to the `NotificationCreator` interface 😬  I plan to tidy up how we pass information between the `Service` and the `Migrator` in a follow-up PR, possibly by exposing a `MigrationService` interface that can be used to send notifications on `Migrator` progress updates. This would be similar to how the other `Service` works in the library.   

### Screen Capture
![migration](https://user-images.githubusercontent.com/3380092/34047764-3738c5f6-e1a9-11e7-9b5c-8cf3845a4122.png)
