### PR TITLE
Incomplete downloads

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -21,6 +21,15 @@ class Migration {
         return fileMetadata;
     }
 
+    boolean hasDownloadedBatch() {
+        for (FileMetadata fileMetadatum : fileMetadata) {
+            if (fileMetadatum.fileSize().currentSize() != fileMetadatum.fileSize().totalSize()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -56,7 +56,6 @@ class MigrationJob implements Runnable {
         onUpdate(migrationStatus);
 
         Log.d(TAG, "about to extract migrations, time is " + System.nanoTime());
-        Log.d(TAG, "partial migrations are all EXTRACTED, time is " + System.nanoTime());
 
         migratePartialDownloads(database, partialDownloadMigrationExtractor, downloadsPersistence);
         migrateCompleteDownloads(migrationStatus, database, migrationExtractor, downloadsPersistence, internalFilePersistence);
@@ -83,6 +82,7 @@ class MigrationJob implements Runnable {
             database.setTransactionSuccessful();
             database.endTransaction();
         }
+        Log.d(TAG, "partial migrations are all EXTRACTED, time is " + System.nanoTime());
     }
 
     private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -131,7 +131,11 @@ class MigrationJob implements Runnable {
         return metadata.originalFileLocation() != null && !metadata.originalFileLocation().isEmpty();
     }
 
-    private void migrateCompleteDownloads(InternalMigrationStatus migrationStatus, SqlDatabaseWrapper database, MigrationExtractor migrationExtractor, DownloadsPersistence downloadsPersistence, InternalFilePersistence internalFilePersistence) {
+    private void migrateCompleteDownloads(InternalMigrationStatus migrationStatus,
+                                          SqlDatabaseWrapper database,
+                                          MigrationExtractor migrationExtractor,
+                                          DownloadsPersistence downloadsPersistence,
+                                          InternalFilePersistence internalFilePersistence) {
         List<Migration> migrations = migrationExtractor.extractMigrations();
         Log.d(TAG, "migrations are all EXTRACTED, time is " + System.nanoTime());
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -69,13 +69,12 @@ class MigrationJob implements Runnable {
 
     private void migratePartialDownloads(SqlDatabaseWrapper database, PartialDownloadMigrationExtractor partialDownloadMigrationExtractor, DownloadsPersistence downloadsPersistence) {
         List<Migration> partialMigrations = partialDownloadMigrationExtractor.extractMigrations();
-        for (int i = 0; i < partialMigrations.size(); i++) {
+        for (Migration partialMigration : partialMigrations) {
             downloadsPersistence.startTransaction();
             database.startTransaction();
 
-            Migration migration = partialMigrations.get(i);
-            migrateV1DataToV2Database(downloadsPersistence, migration);
-            deleteFrom(database, migration);
+            migrateV1DataToV2Database(downloadsPersistence, partialMigration);
+            deleteFrom(database, partialMigration);
 
             downloadsPersistence.transactionSuccess();
             downloadsPersistence.endTransaction();

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status;
+
 class MigrationJob implements Runnable {
 
     private static final String TAG = "V1 to V2 migrator";
@@ -41,6 +43,7 @@ class MigrationJob implements Runnable {
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
+        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
         MigrationExtractor migrationExtractor = new MigrationExtractor(database);
         DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(context);
         InternalFilePersistence internalFilePersistence = new InternalFilePersistence();
@@ -53,6 +56,82 @@ class MigrationJob implements Runnable {
         onUpdate(migrationStatus);
 
         Log.d(TAG, "about to extract migrations, time is " + System.nanoTime());
+        Log.d(TAG, "partial migrations are all EXTRACTED, time is " + System.nanoTime());
+
+        migratePartialDownloads(database, partialDownloadMigrationExtractor, downloadsPersistence);
+        migrateCompleteDownloads(migrationStatus, database, migrationExtractor, downloadsPersistence, internalFilePersistence);
+    }
+
+    private void onUpdate(MigrationStatus migrationStatus) {
+        for (MigrationCallback migrationCallback : migrationCallbacks) {
+            migrationCallback.onUpdate(migrationStatus);
+        }
+    }
+
+    private void migratePartialDownloads(SqlDatabaseWrapper database, PartialDownloadMigrationExtractor partialDownloadMigrationExtractor, DownloadsPersistence downloadsPersistence) {
+        List<Migration> partialMigrations = partialDownloadMigrationExtractor.extractMigrations();
+        for (int i = 0; i < partialMigrations.size(); i++) {
+            downloadsPersistence.startTransaction();
+            database.startTransaction();
+
+            Migration migration = partialMigrations.get(i);
+            migrateV1DataToV2Database(downloadsPersistence, migration);
+            deleteFrom(database, migration);
+
+            downloadsPersistence.transactionSuccess();
+            downloadsPersistence.endTransaction();
+            database.setTransactionSuccessful();
+            database.endTransaction();
+        }
+    }
+
+    private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {
+        Batch batch = migration.batch();
+
+        DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
+
+        Status downloadBatchStatus = migration.hasDownloadedBatch() ? Status.DOWNLOADED : Status.QUEUED;
+
+        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), downloadBatchStatus);
+        downloadsPersistence.persistBatch(persistedBatch);
+
+        for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
+            String url = fileMetadata.uri();
+
+            FileName fileName = LiteFileName.from(batch, url);
+            FilePath filePath = FilePathCreator.create(fileName.name());
+            DownloadFileId downloadFileId = DownloadFileId.from(batch);
+            DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
+                    batch.getDownloadBatchId(),
+                    downloadFileId,
+                    fileName,
+                    filePath,
+                    fileMetadata.fileSize().totalSize(),
+                    url,
+                    FilePersistenceType.INTERNAL
+            );
+            downloadsPersistence.persistFile(persistedFile);
+        }
+    }
+
+    // TODO: See https://github.com/novoda/download-manager/issues/270
+    private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
+        Batch batch = migration.batch();
+        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().stringValue() + ", time is " + System.nanoTime());
+        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().stringValue());
+        for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
+            if (hasValidFileLocation(metadata)) {
+                File file = new File(metadata.originalFileLocation());
+                file.delete();
+            }
+        }
+    }
+
+    private boolean hasValidFileLocation(Migration.FileMetadata metadata) {
+        return metadata.originalFileLocation() != null && !metadata.originalFileLocation().isEmpty();
+    }
+
+    private void migrateCompleteDownloads(InternalMigrationStatus migrationStatus, SqlDatabaseWrapper database, MigrationExtractor migrationExtractor, DownloadsPersistence downloadsPersistence, InternalFilePersistence internalFilePersistence) {
         List<Migration> migrations = migrationExtractor.extractMigrations();
         Log.d(TAG, "migrations are all EXTRACTED, time is " + System.nanoTime());
 
@@ -90,12 +169,6 @@ class MigrationJob implements Runnable {
         onUpdate(migrationStatus);
     }
 
-    private void onUpdate(MigrationStatus migrationStatus) {
-        for (MigrationCallback migrationCallback : migrationCallbacks) {
-            migrationCallback.onUpdate(migrationStatus);
-        }
-    }
-
     private void migrateV1FilesToV2Location(InternalFilePersistence internalFilePersistence, Migration migration) {
         Batch batch = migration.batch();
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
@@ -131,43 +204,6 @@ class MigrationJob implements Runnable {
                     e.printStackTrace();
                 }
             }
-        }
-    }
-
-    private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {
-        Batch batch = migration.batch();
-
-        DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
-        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), DownloadBatchStatus.Status.DOWNLOADED);
-        downloadsPersistence.persistBatch(persistedBatch);
-
-        for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-            String url = fileMetadata.uri();
-
-            FileName fileName = LiteFileName.from(batch, url);
-            FilePath filePath = FilePathCreator.create(fileName.name());
-            DownloadFileId downloadFileId = DownloadFileId.from(batch);
-            DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
-                    batch.getDownloadBatchId(),
-                    downloadFileId,
-                    fileName,
-                    filePath,
-                    fileMetadata.fileSize().totalSize(),
-                    url,
-                    FilePersistenceType.INTERNAL
-            );
-            downloadsPersistence.persistFile(persistedFile);
-        }
-    }
-
-    // TODO: See https://github.com/novoda/download-manager/issues/270
-    private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
-        Batch batch = migration.batch();
-        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().stringValue() + ", time is " + System.nanoTime());
-        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().stringValue());
-        for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
-            File file = new File(metadata.originalFileLocation());
-            file.delete();
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -1,0 +1,64 @@
+package com.novoda.downloadmanager;
+
+import android.database.Cursor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class PartialDownloadMigrationExtractor {
+
+    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title FROM batches INNER JOIN DownloadsByBatch ON " +
+            "DownloadsByBatch.batch_id = batches._id WHERE DownloadsByBatch.batch_total_bytes != DownloadsByBatch.batch_current_bytes " +
+            "GROUP BY batches._id";
+    private static final String URIS_QUERY = "SELECT uri, _data, current_bytes, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final int BATCH_ID_COLUMN = 0;
+    private static final int URI_COLUMN = 0;
+    private static final int TITLE_COLUMN = 1;
+    private static final int FILE_NAME_COLUMN = 1;
+    private static final int CURRENT_FILE_SIZE_COLUMN = 2;
+    private static final int TOTAL_FILE_SIZE_COLUMN = 3;
+
+    private final SqlDatabaseWrapper database;
+
+    PartialDownloadMigrationExtractor(SqlDatabaseWrapper database) {
+        this.database = database;
+    }
+
+    List<Migration> extractMigrations() {
+        Cursor batchesCursor = database.rawQuery(BATCHES_QUERY);
+
+        List<Migration> migrations = new ArrayList<>();
+        while (batchesCursor.moveToNext()) {
+
+            String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
+            String batchTitle = batchesCursor.getString(TITLE_COLUMN);
+
+            Cursor uriCursor = database.rawQuery(URIS_QUERY, batchId);
+            Batch.Builder newBatchBuilder = new Batch.Builder(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
+            List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
+
+            while (uriCursor.moveToNext()) {
+                String uri = uriCursor.getString(URI_COLUMN);
+                String originalFileName = uriCursor.getString(FILE_NAME_COLUMN);
+
+                long currentRawFileSize = uriCursor.getLong(CURRENT_FILE_SIZE_COLUMN);
+                if (originalFileName == null || originalFileName.isEmpty()) {
+                    currentRawFileSize = 0;
+                }
+
+                newBatchBuilder.addFile(uri);
+
+                long totalRawFileSize = uriCursor.getLong(TOTAL_FILE_SIZE_COLUMN);
+                FileSize fileSize = new LiteFileSize(currentRawFileSize, totalRawFileSize);
+                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileName, fileSize, uri);
+                fileMetadataList.add(fileMetadata);
+            }
+            uriCursor.close();
+
+            Batch batch = newBatchBuilder.build();
+            migrations.add(new Migration(batch, fileMetadataList));
+        }
+        batchesCursor.close();
+        return migrations;
+    }
+}


### PR DESCRIPTION
### Problem
The new version of the `download-manager` is capable of migrating **complete** downloads from v1 to v2. We also need to be able to migrate **incomplete** downloads, those that do not have a local file path or have a local file path but where the current bytes do not match the total bytes for a batch.

### Solution
Create a `PartialDownloadMigrationExtractor` that is responsible for extracting a `List<Migration>` that represents just the partial downloads. For partials we check whether the whole batch is downloaded. If the whole batch is not downloaded then we mark it with **queueing** which will automatically trigger a re-download of the files. For the partial downloads that had a local file we delete rather than carrying on from the current byte range. 

If we decide to carry on from a given byte range this would be more effort and greater risk for the migration process. 