### PR TITLE
Update Gradle and android plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,1 @@
-allprojects {
-    buildscript {
-        repositories {
-            jcenter()
-        }
-    }
-
-    repositories {
-        jcenter()
-        maven {
-            url 'https://maven.google.com'
-        }
-    }
-}
+buildscript {    ext.kotlin_version = '1.2.10'    repositories {        google()        jcenter()    }    dependencies {        classpath 'com.android.tools.build:gradle:3.0.1'        classpath 'com.novoda:bintray-release:0.8.0'        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"    }}allprojects {    repositories {        google()        jcenter()    }}

--- a/build.gradle
+++ b/build.gradle
@@ -1,1 +1,19 @@
-buildscript {    ext.kotlin_version = '1.2.10'    repositories {        google()        jcenter()    }    dependencies {        classpath 'com.android.tools.build:gradle:3.0.1'        classpath 'com.novoda:bintray-release:0.8.0'        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"    }}allprojects {    repositories {        google()        jcenter()    }}
+buildscript {
+    ext.kotlin_version = '1.2.10'
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.novoda:bintray-release:0.8.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}

--- a/code-quality/rules/pmd/ruleset.xml
+++ b/code-quality/rules/pmd/ruleset.xml
@@ -31,7 +31,7 @@
     <exclude name="UselessParentheses" />
   </rule>
   <rule ref="rulesets/java/unusedcode.xml">
-    <exclude name="UnusedModifier" />
+    <exclude name="UnnecessaryModifier" />
   </rule>
 
   <rule ref="rulesets/java/optimizations.xml">

--- a/code-quality/rules/pmd/ruleset.xml
+++ b/code-quality/rules/pmd/ruleset.xml
@@ -30,7 +30,7 @@
   <rule ref="rulesets/java/unnecessary.xml">
     <exclude name="UselessParentheses" />
   </rule>
-  <rule ref="rulesets/java/unusedcode.xml">
+  <rule ref="rulesets/java/unnecessary.xml">
     <exclude name="UnnecessaryModifier" />
   </rule>
 

--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -1,21 +1,13 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-    }
-}
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.novoda.downloadmanager.demo.extended"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -29,6 +21,6 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.android.support:recyclerview-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/demo-extended/build.gradle
+++ b/demo-extended/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile project(':library')
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:recyclerview-v7:27.0.2'
+    implementation project(':library')
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -1,21 +1,13 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-    }
-}
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         applicationId "com.novoda.downloadmanager.demo.simple"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0"
 
@@ -29,6 +21,6 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:appcompat-v7:25.4.0'
-    compile 'com.android.support:recyclerview-v7:25.4.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
+    compile 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile project(':library')
-    compile 'com.android.support:appcompat-v7:27.0.2'
-    compile 'com.android.support:recyclerview-v7:27.0.2'
+    implementation project(':library')
+    implementation 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,25 +1,9 @@
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
-        classpath 'com.novoda:bintray-release:0.3.4'
-    }
-}
 apply plugin: 'com.android.library'
 apply plugin: 'bintray-release'
 
-repositories {
-    jcenter()
-    maven {
-        url 'https://maven.google.com'
-    }
-}
-
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         minSdkVersion 14
@@ -46,7 +30,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-core-utils:25.4.0'
+    compile 'com.android.support:support-core-utils:27.0.2'
     compile 'com.novoda:notils:2.2.13'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
     compile 'com.evernote:android-job:1.1.7'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -30,17 +30,17 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-core-utils:27.0.2'
-    compile 'com.novoda:notils:2.2.13'
-    compile 'com.squareup.okhttp:okhttp:2.3.0'
-    compile 'com.evernote:android-job:1.1.7'
+    implementation 'com.android.support:support-core-utils:27.0.2'
+    implementation 'com.novoda:notils:2.2.13'
+    implementation 'com.squareup.okhttp:okhttp:2.3.0'
+    implementation 'com.evernote:android-job:1.1.7'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.4'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.4'
-    testCompile 'org.easytesting:fest-assert-core:2.0M10'
-    testCompile 'org.apache.commons:commons-io:1.3.2'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.4'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.4'
+    testImplementation 'org.easytesting:fest-assert-core:2.0M10'
+    testImplementation 'org.apache.commons:commons-io:1.3.2'
 }
 
 publish {


### PR DESCRIPTION
I think @joetimmins and I had this on a different ticket but wasn't sure so I thought it was worth adding on its own ticket.

 - Upgrade Gradle to `4.4`
 - Upgrade Gradle Plugin to `3.0.1`
 - Move `buildscript` blocks to top-level build script
 - Upgraded compile to `API 27` and build tools to `27.0.3`
 - Upgraded support libraries to `27.0.2` (somehow different from build tools)

PS: Merry Holidays 😂 