### PR TITLE
Fix total file size

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -199,7 +199,7 @@ public class MainActivity extends AppCompatActivity {
             String status = getStatusMessage(downloadBatchStatus);
 
             String message = "Batch " + downloadBatchStatus.getDownloadBatchTitle().asString()
-                    + "\ndownloaded: " + downloadBatchStatus.percentageDownloaded()
+                    + "\ndownloaded: " + downloadBatchStatus.percentageDownloaded() + "%"
                     + "\nbytes: " + downloadBatchStatus.bytesDownloaded()
                     + status
                     + "\n";

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFileSizeCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFileSizeCreator.java
@@ -10,7 +10,7 @@ final class InternalFileSizeCreator {
     }
 
     static InternalFileSize unknownFileSize() {
-        return UNKNOWN;
+        return UNKNOWN.copy();
     }
 
     static InternalFileSize createFromCurrentAndTotalSize(long currentSize, long totalSize) {


### PR DESCRIPTION
### Problem
When initialising a new `DownloadFile` we use the `UNKNOWN` InternalFileSize. The problem is that _all_ new DownloadFiles used the same instance of InternalFileSize, which was updated with the total size of the first downloaded file, resulting in an inconsistent total batch size.

### Solution
Use a copy if the constant instance when initialising a new `InternalFileSize`

### Bonus
Show the `%` symbol in the demo activity logs because it was not clear to me that they were referring to the download percentage, at the beginning.