### PR TITLE
Expose getters for batch

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -15,15 +15,15 @@ public final class Batch {
         this.fileUrls = fileUrls;
     }
 
-    DownloadBatchId getDownloadBatchId() {
+    public DownloadBatchId downloadBatchId() {
         return downloadBatchId;
     }
 
-    String getTitle() {
+    public String title() {
         return title;
     }
 
-    List<String> getFileUrls() {
+    public List<String> fileUrls() {
         return new ArrayList<>(fileUrls);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -15,15 +15,15 @@ public final class Batch {
         this.fileUrls = fileUrls;
     }
 
-    DownloadBatchId downloadBatchId() {
+    public DownloadBatchId downloadBatchId() {
         return downloadBatchId;
     }
 
-    String title() {
+    public String title() {
         return title;
     }
 
-    Map<DownloadFileId, String> fileUrlsByDownloadFileId() {
+    public Map<DownloadFileId, String> fileUrlsByDownloadFileId() {
         return new HashMap<>(fileUrls);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -16,16 +16,16 @@ final class DownloadBatchFactory {
                                      DownloadsFilePersistence downloadsFilePersistence,
                                      CallbackThrottle callbackThrottle) {
         DownloadBatchTitle downloadBatchTitle = DownloadBatchTitleCreator.createFrom(batch);
-        List<String> fileUrls = batch.getFileUrls();
+        List<String> fileUrls = batch.fileUrls();
         List<DownloadFile> downloadFiles = new ArrayList<>(fileUrls.size());
-        DownloadBatchId downloadBatchId = batch.getDownloadBatchId();
+        DownloadBatchId downloadBatchId = batch.downloadBatchId();
 
         for (String fileUrl : fileUrls) {
             InternalFileSize fileSize = InternalFileSizeCreator.unknownFileSize();
             DownloadFileId downloadFileId = DownloadFileId.from(batch);
             FilePath filePath = FilePathCreator.unknownFilePath();
             InternalDownloadFileStatus downloadFileStatus = new LiteDownloadFileStatus(
-                    batch.getDownloadBatchId(),
+                    batch.downloadBatchId(),
                     downloadFileId,
                     InternalDownloadFileStatus.Status.QUEUED,
                     fileSize,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchTitleCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchTitleCreator.java
@@ -7,7 +7,7 @@ final class DownloadBatchTitleCreator {
     }
 
     static DownloadBatchTitle createFrom(Batch batch) {
-        return new LiteDownloadBatchTitle(batch.getTitle());
+        return new LiteDownloadBatchTitle(batch.title());
     }
 
     static DownloadBatchTitle createFrom(String title) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileId.java
@@ -5,7 +5,7 @@ final class DownloadFileId {
     private final int id;
 
     static DownloadFileId from(Batch batch) {
-        String id = batch.getTitle() + System.nanoTime();
+        String id = batch.title() + System.nanoTime();
         return new DownloadFileId(id.hashCode());
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -48,7 +48,7 @@ class LiteDownloadManagerDownloader {
     }
 
     public void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
-        DownloadBatch runningDownloadBatch = downloadBatchMap.get(batch.getDownloadBatchId());
+        DownloadBatch runningDownloadBatch = downloadBatchMap.get(batch.downloadBatchId());
         if (runningDownloadBatch != null) {
             return;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -89,11 +89,11 @@ class MigrationJob implements Runnable {
     private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {
         Batch batch = migration.batch();
 
-        DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
+        DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.title());
 
         Status downloadBatchStatus = migration.hasDownloadedBatch() ? Status.DOWNLOADED : Status.QUEUED;
 
-        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), downloadBatchStatus);
+        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.downloadBatchId(), downloadBatchStatus);
         downloadsPersistence.persistBatch(persistedBatch);
 
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
@@ -103,7 +103,7 @@ class MigrationJob implements Runnable {
             FilePath filePath = FilePathCreator.create(fileName.name());
             DownloadFileId downloadFileId = DownloadFileId.from(batch);
             DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
-                    batch.getDownloadBatchId(),
+                    batch.downloadBatchId(),
                     downloadFileId,
                     fileName,
                     filePath,
@@ -118,8 +118,8 @@ class MigrationJob implements Runnable {
     // TODO: See https://github.com/novoda/download-manager/issues/270
     private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
         Batch batch = migration.batch();
-        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().stringValue() + ", time is " + System.nanoTime());
-        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().stringValue());
+        Log.d(TAG, "about to delete the batch: " + batch.downloadBatchId().stringValue() + ", time is " + System.nanoTime());
+        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.downloadBatchId().stringValue());
         for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
             if (hasValidFileLocation(metadata)) {
                 File file = new File(metadata.originalFileLocation());


### PR DESCRIPTION
### Problem
Sometimes a client needs to retrieve information on a `Batch`. Currently we do not expose the internals of the `Batch` class even though the class is public 🤔 

### Solution
Add getters for the `Batch` class.