### PR TITLE
Expose Date on BatchStatus

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -20,6 +20,7 @@ class DownloadBatch {
 
     private final DownloadBatchId downloadBatchId;
     private final DownloadBatchTitle downloadBatchTitle;
+    private final long downloadedDateTimeInMillis;
     private final Map<DownloadFileId, Long> fileBytesDownloadedMap;
     private final InternalDownloadBatchStatus downloadBatchStatus;
     private final List<DownloadFile> downloadFiles;
@@ -31,6 +32,7 @@ class DownloadBatch {
 
     DownloadBatch(DownloadBatchTitle downloadBatchTitle,
                   DownloadBatchId downloadBatchId,
+                  long downloadedDateTimeInMillis,
                   List<DownloadFile> downloadFiles,
                   Map<DownloadFileId, Long> fileBytesDownloadedMap,
                   InternalDownloadBatchStatus internalDownloadBatchStatus,
@@ -38,6 +40,7 @@ class DownloadBatch {
                   CallbackThrottle callbackThrottle) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.downloadFiles = downloadFiles;
         this.fileBytesDownloadedMap = fileBytesDownloadedMap;
         this.downloadBatchStatus = internalDownloadBatchStatus;
@@ -192,6 +195,12 @@ class DownloadBatch {
     }
 
     void persist() {
-        downloadsBatchPersistence.persistAsync(downloadBatchTitle, downloadBatchId, downloadBatchStatus.status(), downloadFiles);
+        downloadsBatchPersistence.persistAsync(
+                downloadBatchTitle,
+                downloadBatchId,
+                downloadBatchStatus.status(),
+                downloadFiles,
+                downloadedDateTimeInMillis
+        );
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -18,9 +18,6 @@ class DownloadBatch {
 
     private static final int ZERO_BYTES = 0;
 
-    private final DownloadBatchId downloadBatchId;
-    private final DownloadBatchTitle downloadBatchTitle;
-    private final long downloadedDateTimeInMillis;
     private final Map<DownloadFileId, Long> fileBytesDownloadedMap;
     private final InternalDownloadBatchStatus downloadBatchStatus;
     private final List<DownloadFile> downloadFiles;
@@ -30,17 +27,11 @@ class DownloadBatch {
     private long totalBatchSizeBytes;
     private DownloadBatchCallback callback;
 
-    DownloadBatch(DownloadBatchTitle downloadBatchTitle,
-                  DownloadBatchId downloadBatchId,
-                  long downloadedDateTimeInMillis,
+    DownloadBatch(InternalDownloadBatchStatus internalDownloadBatchStatus,
                   List<DownloadFile> downloadFiles,
                   Map<DownloadFileId, Long> fileBytesDownloadedMap,
-                  InternalDownloadBatchStatus internalDownloadBatchStatus,
                   DownloadsBatchPersistence downloadsBatchPersistence,
                   CallbackThrottle callbackThrottle) {
-        this.downloadBatchTitle = downloadBatchTitle;
-        this.downloadBatchId = downloadBatchId;
-        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.downloadFiles = downloadFiles;
         this.fileBytesDownloadedMap = fileBytesDownloadedMap;
         this.downloadBatchStatus = internalDownloadBatchStatus;
@@ -168,7 +159,7 @@ class DownloadBatch {
     }
 
     void delete() {
-        downloadsBatchPersistence.deleteAsync(downloadBatchId);
+        downloadsBatchPersistence.deleteAsync(downloadBatchStatus.getDownloadBatchId());
         downloadBatchStatus.markForDeletion();
         notifyCallback(downloadBatchStatus);
         for (DownloadFile downloadFile : downloadFiles) {
@@ -177,7 +168,7 @@ class DownloadBatch {
     }
 
     DownloadBatchId getId() {
-        return downloadBatchId;
+        return downloadBatchStatus.getDownloadBatchId();
     }
 
     InternalDownloadBatchStatus status() {
@@ -196,11 +187,11 @@ class DownloadBatch {
 
     void persist() {
         downloadsBatchPersistence.persistAsync(
-                downloadBatchTitle,
-                downloadBatchId,
+                downloadBatchStatus.getDownloadBatchTitle(),
+                downloadBatchStatus.getDownloadBatchId(),
                 downloadBatchStatus.status(),
                 downloadFiles,
-                downloadedDateTimeInMillis
+                downloadBatchStatus.downloadedDateTimeInMillis()
         );
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -20,6 +20,7 @@ final class DownloadBatchFactory {
         Map<DownloadFileId, String> fileUrls = batch.getFileUrls();
         List<DownloadFile> downloadFiles = new ArrayList<>(fileUrls.size());
         DownloadBatchId downloadBatchId = batch.getDownloadBatchId();
+        long downloadedDateTimeInMillis = System.currentTimeMillis();
 
         for (Map.Entry<DownloadFileId, String> urlByDownloadId : fileUrls.entrySet()) {
             InternalFileSize fileSize = InternalFileSizeCreator.unknownFileSize();
@@ -59,12 +60,14 @@ final class DownloadBatchFactory {
         InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                 downloadBatchId,
                 downloadBatchTitle,
+                downloadedDateTimeInMillis,
                 DownloadBatchStatus.Status.QUEUED
         );
 
         return new DownloadBatch(
                 downloadBatchTitle,
                 downloadBatchId,
+                downloadedDateTimeInMillis,
                 downloadFiles,
                 new HashMap<>(),
                 liteDownloadBatchStatus,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -65,12 +65,9 @@ final class DownloadBatchFactory {
         );
 
         return new DownloadBatch(
-                downloadBatchTitle,
-                downloadBatchId,
-                downloadedDateTimeInMillis,
+                liteDownloadBatchStatus,
                 downloadFiles,
                 new HashMap<>(),
-                liteDownloadBatchStatus,
                 downloadsBatchPersistence,
                 callbackThrottle
         );

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -42,6 +42,8 @@ public interface DownloadBatchStatus {
 
     Status status();
 
+    long downloadedDateTimeInMillis();
+
     /**
      * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
      */

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
@@ -7,4 +7,6 @@ public interface DownloadsBatchPersisted {
     DownloadBatchStatus.Status downloadBatchStatus();
 
     DownloadBatchTitle downloadBatchTitle();
+
+    long downloadedDateTimeInMillis();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -90,12 +90,9 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                 CallbackThrottle callbackThrottle = callbackThrottleCreator.create();
 
                 DownloadBatch downloadBatch = new DownloadBatch(
-                        downloadBatchTitle,
-                        downloadBatchId,
-                        downloadedDateTimeInMillis,
+                        liteDownloadBatchStatus,
                         downloadFiles,
                         downloadedFileSizeMap,
-                        liteDownloadBatchStatus,
                         DownloadsBatchPersistence.this,
                         callbackThrottle
                 );

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -23,15 +23,21 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
         this.callbackThrottleCreator = callbackThrottleCreator;
     }
 
-    void persistAsync(final DownloadBatchTitle downloadBatchTitle,
-                      final DownloadBatchId downloadBatchId,
-                      final DownloadBatchStatus.Status status,
-                      final List<DownloadFile> downloadFiles) {
+    void persistAsync(DownloadBatchTitle downloadBatchTitle,
+                      DownloadBatchId downloadBatchId,
+                      DownloadBatchStatus.Status status,
+                      List<DownloadFile> downloadFiles,
+                      long downloadedDateTimeInMillis) {
         executor.execute(() -> {
             downloadsPersistence.startTransaction();
 
             try {
-                LiteDownloadsBatchPersisted batchPersisted = new LiteDownloadsBatchPersisted(downloadBatchTitle, downloadBatchId, status);
+                LiteDownloadsBatchPersisted batchPersisted = new LiteDownloadsBatchPersisted(
+                        downloadBatchTitle,
+                        downloadBatchId,
+                        status,
+                        downloadedDateTimeInMillis
+                );
                 downloadsPersistence.persistBatch(batchPersisted);
 
                 for (DownloadFile downloadFile : downloadFiles) {
@@ -54,9 +60,11 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                 DownloadBatchStatus.Status status = batchPersisted.downloadBatchStatus();
                 DownloadBatchId downloadBatchId = batchPersisted.downloadBatchId();
                 DownloadBatchTitle downloadBatchTitle = batchPersisted.downloadBatchTitle();
+                long downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
                 InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                         downloadBatchId,
                         downloadBatchTitle,
+                        downloadedDateTimeInMillis,
                         status
                 );
 
@@ -84,6 +92,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                 DownloadBatch downloadBatch = new DownloadBatch(
                         downloadBatchTitle,
                         downloadBatchId,
+                        downloadedDateTimeInMillis,
                         downloadFiles,
                         downloadedFileSizeMap,
                         liteDownloadBatchStatus,

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -9,6 +9,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private final DownloadBatchTitle downloadBatchTitle;
     private final DownloadBatchId downloadBatchId;
+    private final long downloadedDateTimeInMillis;
 
     private long bytesDownloaded;
     private long totalBatchSizeBytes;
@@ -18,9 +19,10 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Nullable
     private DownloadError downloadError;
 
-    LiteDownloadBatchStatus(DownloadBatchId downloadBatchId, DownloadBatchTitle downloadBatchTitle, Status status) {
+    LiteDownloadBatchStatus(DownloadBatchId downloadBatchId, DownloadBatchTitle downloadBatchTitle, long downloadedDateTimeInMillis, Status status) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.status = status;
     }
 
@@ -71,6 +73,11 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public Status status() {
         return status;
+    }
+
+    @Override
+    public long downloadedDateTimeInMillis() {
+        return downloadedDateTimeInMillis;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
@@ -5,11 +5,16 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     private final DownloadBatchTitle downloadBatchTitle;
     private final DownloadBatchId downloadBatchId;
     private final DownloadBatchStatus.Status status;
+    private final long downloadedDateTimeInMillis;
 
-    LiteDownloadsBatchPersisted(DownloadBatchTitle downloadBatchTitle, DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
+    LiteDownloadsBatchPersisted(DownloadBatchTitle downloadBatchTitle,
+                                DownloadBatchId downloadBatchId,
+                                DownloadBatchStatus.Status status,
+                                long downloadedDateTimeInMillis) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
         this.status = status;
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
     }
 
     @Override
@@ -25,5 +30,10 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     @Override
     public DownloadBatchTitle downloadBatchTitle() {
         return downloadBatchTitle;
+    }
+
+    @Override
+    public long downloadedDateTimeInMillis() {
+        return downloadedDateTimeInMillis;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -7,10 +7,12 @@ class Migration {
 
     private final Batch batch;
     private final List<FileMetadata> fileMetadata;
+    private final long downloadedDateTimeInMillis;
 
-    Migration(Batch batch, List<FileMetadata> fileMetadata) {
+    Migration(Batch batch, List<FileMetadata> fileMetadata, long downloadedDateTimeInMillis) {
         this.batch = batch;
         this.fileMetadata = Collections.unmodifiableList(fileMetadata);
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
     }
 
     Batch batch() {
@@ -41,16 +43,20 @@ class Migration {
 
         Migration migration = (Migration) o;
 
-        if (batch != null ? !batch.equals(migration.batch) : migration.batch != null) {
+        if (downloadedDateTimeInMillis != migration.downloadedDateTimeInMillis) {
             return false;
         }
-        return fileMetadata != null ? fileMetadata.equals(migration.fileMetadata) : migration.fileMetadata == null;
+        if (!batch.equals(migration.batch)) {
+            return false;
+        }
+        return fileMetadata.equals(migration.fileMetadata);
     }
 
     @Override
     public int hashCode() {
-        int result = batch != null ? batch.hashCode() : 0;
-        result = 31 * result + (fileMetadata != null ? fileMetadata.hashCode() : 0);
+        int result = batch.hashCode();
+        result = 31 * result + fileMetadata.hashCode();
+        result = 31 * result + (int) (downloadedDateTimeInMillis ^ (downloadedDateTimeInMillis >>> 32));
         return result;
     }
 
@@ -59,6 +65,7 @@ class Migration {
         return "Migration{"
                 + "batch=" + batch
                 + ", fileMetadata=" + fileMetadata
+                + ", downloadedDateTimeInMillis=" + downloadedDateTimeInMillis
                 + '}';
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -23,6 +23,10 @@ class Migration {
         return fileMetadata;
     }
 
+    public long downloadedDateTimeInMillis() {
+        return downloadedDateTimeInMillis;
+    }
+
     boolean hasDownloadedBatch() {
         for (FileMetadata fileMetadatum : fileMetadata) {
             if (fileMetadatum.fileSize().currentSize() != fileMetadatum.fileSize().totalSize()) {

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -7,12 +7,15 @@ import java.util.List;
 
 class MigrationExtractor {
 
-    private static final String BATCHES_QUERY = "SELECT DISTINCT batches._id, batches.batch_title FROM batches INNER JOIN DownloadsByBatch ON "
-            + "DownloadsByBatch.batch_id = batches._id WHERE DownloadsByBatch.batch_total_bytes = DownloadsByBatch.batch_current_bytes";
-    private static final String URIS_QUERY = "SELECT uri, _data, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title, batches.last_modified_timestamp FROM "
+            + "batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
+            + "WHERE DownloadsByBatch.batch_total_bytes = DownloadsByBatch.batch_current_bytes GROUP BY batches._id";
     private static final int BATCH_ID_COLUMN = 0;
-    private static final int URI_COLUMN = 0;
     private static final int TITLE_COLUMN = 1;
+    private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
+
+    private static final String DOWNLOADS_QUERY = "SELECT uri, _data, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final int URI_COLUMN = 0;
     private static final int FILE_NAME_COLUMN = 1;
     private static final int FILE_SIZE_COLUMN = 2;
 
@@ -30,25 +33,26 @@ class MigrationExtractor {
 
             String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
             String batchTitle = batchesCursor.getString(TITLE_COLUMN);
+            long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
 
-            Cursor uriCursor = database.rawQuery(URIS_QUERY, batchId);
+            Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
             Batch.Builder newBatchBuilder = new Batch.Builder(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
 
-            while (uriCursor.moveToNext()) {
-                String uri = uriCursor.getString(URI_COLUMN);
-                String originalFileName = uriCursor.getString(FILE_NAME_COLUMN);
+            while (downloadsCursor.moveToNext()) {
+                String uri = downloadsCursor.getString(URI_COLUMN);
+                String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
                 newBatchBuilder.addFile(uri);
 
-                long rawFileSize = uriCursor.getLong(FILE_SIZE_COLUMN);
+                long rawFileSize = downloadsCursor.getLong(FILE_SIZE_COLUMN);
                 FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
                 Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileName, fileSize, uri);
                 fileMetadataList.add(fileMetadata);
             }
-            uriCursor.close();
+            downloadsCursor.close();
 
             Batch batch = newBatchBuilder.build();
-            migrations.add(new Migration(batch, fileMetadataList));
+            migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis));
         }
         batchesCursor.close();
         return migrations;

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -89,11 +89,17 @@ class MigrationJob implements Runnable {
     private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {
         Batch batch = migration.batch();
 
+        DownloadBatchId downloadBatchId = batch.getDownloadBatchId();
         DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.getTitle());
-
         Status downloadBatchStatus = migration.hasDownloadedBatch() ? Status.DOWNLOADED : Status.QUEUED;
+        long downloadedDateTimeInMillis = migration.downloadedDateTimeInMillis();
 
-        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(downloadBatchTitle, batch.getDownloadBatchId(), downloadBatchStatus);
+        DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(
+                downloadBatchTitle,
+                downloadBatchId,
+                downloadBatchStatus,
+                downloadedDateTimeInMillis
+        );
         downloadsPersistence.persistBatch(persistedBatch);
 
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
@@ -104,7 +110,7 @@ class MigrationJob implements Runnable {
             String rawDownloadFileId = batch.getTitle() + System.nanoTime();
             DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(rawDownloadFileId);
             DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
-                    batch.getDownloadBatchId(),
+                    downloadBatchId,
                     downloadFileId,
                     fileName,
                     filePath,

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -7,13 +7,15 @@ import java.util.List;
 
 class PartialDownloadMigrationExtractor {
 
-    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title FROM batches INNER JOIN DownloadsByBatch ON "
-            + "DownloadsByBatch.batch_id = batches._id WHERE DownloadsByBatch.batch_total_bytes != DownloadsByBatch.batch_current_bytes "
-            + "GROUP BY batches._id";
-    private static final String URIS_QUERY = "SELECT uri, _data, current_bytes, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title, batches.last_modified_timestamp "
+            + "FROM batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
+            + "WHERE DownloadsByBatch.batch_total_bytes != DownloadsByBatch.batch_current_bytes GROUP BY batches._id";
     private static final int BATCH_ID_COLUMN = 0;
-    private static final int URI_COLUMN = 0;
     private static final int TITLE_COLUMN = 1;
+    private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
+
+    private static final String DOWNLOADS_QUERY = "SELECT uri, _data, current_bytes, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final int URI_COLUMN = 0;
     private static final int FILE_NAME_COLUMN = 1;
     private static final int CURRENT_FILE_SIZE_COLUMN = 2;
     private static final int TOTAL_FILE_SIZE_COLUMN = 3;
@@ -32,31 +34,32 @@ class PartialDownloadMigrationExtractor {
 
             String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
             String batchTitle = batchesCursor.getString(TITLE_COLUMN);
+            long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
 
-            Cursor uriCursor = database.rawQuery(URIS_QUERY, batchId);
+            Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
             Batch.Builder newBatchBuilder = new Batch.Builder(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
 
-            while (uriCursor.moveToNext()) {
-                String uri = uriCursor.getString(URI_COLUMN);
-                String originalFileName = uriCursor.getString(FILE_NAME_COLUMN);
+            while (downloadsCursor.moveToNext()) {
+                String uri = downloadsCursor.getString(URI_COLUMN);
+                String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
 
-                long currentRawFileSize = uriCursor.getLong(CURRENT_FILE_SIZE_COLUMN);
+                long currentRawFileSize = downloadsCursor.getLong(CURRENT_FILE_SIZE_COLUMN);
                 if (originalFileName == null || originalFileName.isEmpty()) {
                     currentRawFileSize = 0;
                 }
 
                 newBatchBuilder.addFile(uri);
 
-                long totalRawFileSize = uriCursor.getLong(TOTAL_FILE_SIZE_COLUMN);
+                long totalRawFileSize = downloadsCursor.getLong(TOTAL_FILE_SIZE_COLUMN);
                 FileSize fileSize = new LiteFileSize(currentRawFileSize, totalRawFileSize);
                 Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileName, fileSize, uri);
                 fileMetadataList.add(fileMetadata);
             }
-            uriCursor.close();
+            downloadsCursor.close();
 
             Batch batch = newBatchBuilder.build();
-            migrations.add(new Migration(batch, fileMetadataList));
+            migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis));
         }
         batchesCursor.close();
         return migrations;

--- a/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
@@ -20,4 +20,7 @@ class RoomBatch {
 
     @ColumnInfo(name = "batch_status")
     public String status;
+
+    @ColumnInfo(name = "batch_downloaded_date_time_in_millis")
+    public long downloadedDateTimeInMillis;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -39,6 +39,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.id = batchPersisted.downloadBatchId().stringValue();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
         roomBatch.title = batchPersisted.downloadBatchTitle().asString();
+        roomBatch.downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
 
         database.roomBatchDao().insert(roomBatch);
     }
@@ -52,7 +53,8 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
             DownloadsBatchPersisted batchPersisted = new LiteDownloadsBatchPersisted(
                     DownloadBatchTitleCreator.createFrom(roomBatch.title),
                     DownloadBatchIdCreator.createFrom(roomBatch.id),
-                    DownloadBatchStatus.Status.from(roomBatch.status)
+                    DownloadBatchStatus.Status.from(roomBatch.status),
+                    roomBatch.downloadedDateTimeInMillis
             );
             batchPersistedList.add(batchPersisted);
         }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
@@ -5,7 +5,8 @@ import static com.novoda.downloadmanager.DownloadBatchIdFixtures.aDownloadBatchI
 final class DownloadsBatchPersistedFixtures {
     private DownloadBatchId downloadBatchId = aDownloadBatchId().build();
     private DownloadBatchStatus.Status downloadBatchStatus = DownloadBatchStatus.Status.DOWNLOADED;
-    private DownloadBatchTitle downloadBatchTitle;
+    private DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle("title");
+    private long downloadedDateTimeInMillis = 123456789L;
 
     static DownloadsBatchPersistedFixtures aDownloadsBatchPersisted() {
         return new DownloadsBatchPersistedFixtures();
@@ -35,6 +36,11 @@ final class DownloadsBatchPersistedFixtures {
         return this;
     }
 
+    DownloadsBatchPersistedFixtures withDownloadedDateTimeInMillis(long downloadedDateTimeInMillis) {
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
+        return this;
+    }
+
     DownloadsBatchPersisted build() {
         return new DownloadsBatchPersisted() {
             @Override
@@ -50,6 +56,11 @@ final class DownloadsBatchPersistedFixtures {
             @Override
             public DownloadBatchTitle downloadBatchTitle() {
                 return downloadBatchTitle;
+            }
+
+            @Override
+            public long downloadedDateTimeInMillis() {
+                return downloadedDateTimeInMillis;
             }
         };
     }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -11,6 +11,7 @@ class InternalDownloadBatchStatusFixtures {
     private DownloadBatchId downloadBatchId = DownloadBatchIdFixtures.aDownloadBatchId().build();
     private DownloadBatchStatus.Status status = DownloadBatchStatus.Status.QUEUED;
     private DownloadError.Error downloadErrorType = null;
+    private long downloadedDateTimeInMillis = 123456789L;
 
     static InternalDownloadBatchStatusFixtures anInternalDownloadsBatchStatus() {
         return new InternalDownloadBatchStatusFixtures();
@@ -43,6 +44,11 @@ class InternalDownloadBatchStatusFixtures {
 
     InternalDownloadBatchStatusFixtures withStatus(DownloadBatchStatus.Status status) {
         this.status = status;
+        return this;
+    }
+
+    InternalDownloadBatchStatusFixtures withDownloadedDateTimeInMillis(long downloadedDateTimeInMillis) {
+        this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         return this;
     }
 
@@ -82,6 +88,11 @@ class InternalDownloadBatchStatusFixtures {
             @Override
             public Status status() {
                 return status;
+            }
+
+            @Override
+            public long downloadedDateTimeInMillis() {
+                return downloadedDateTimeInMillis;
             }
 
             @Nullable

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -18,14 +18,16 @@ import static org.mockito.Mockito.mock;
 
 public class MigrationExtractorTest {
 
-    private static final String BATCHES_QUERY = "SELECT DISTINCT batches._id, batches.batch_title FROM batches INNER JOIN DownloadsByBatch ON " +
-            "DownloadsByBatch.batch_id = batches._id WHERE DownloadsByBatch.batch_total_bytes = DownloadsByBatch.batch_current_bytes";
+    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title, batches.last_modified_timestamp FROM "
+            + "batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
+            + "WHERE DownloadsByBatch.batch_total_bytes = DownloadsByBatch.batch_current_bytes GROUP BY batches._id";
 
     private static final String DOWNLOADS_QUERY = "SELECT uri, _data, total_bytes FROM Downloads WHERE batch_id = ?";
 
     private static final StubCursor BATCHES_CURSOR = new StubCursor.Builder()
             .with("_id", "1", "2")
             .with("batch_title", "title_1", "title_2")
+            .with("last_modified_timestamp", "12345", "67890")
             .build();
 
     private static final Cursor BATCH_ONE_DOWNLOADS_CURSOR = new StubCursor.Builder()
@@ -85,8 +87,8 @@ public class MigrationExtractorTest {
         secondFileMetadata.add(new Migration.FileMetadata("data_4", new LiteFileSize(750, 750), fourthUri));
 
         return Arrays.asList(
-                new Migration(firstBatch, firstFileMetadata),
-                new Migration(secondBatch, secondFileMetadata)
+                new Migration(firstBatch, firstFileMetadata, 12345),
+                new Migration(secondBatch, secondFileMetadata, 67890)
         );
     }
 }


### PR DESCRIPTION
### Problem
In v1 we were supporting the clients to know the `download-date`, we don't anymore 😱 

### Solution
Migrate `last_modified_timestamp` from v1 to v2 and expose in v2 for the clients. As per #294 this has been moved to the `batch` rather than each individual `download`.


  