### PR TITLE
Make downloadBatchId and FileId consistent

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
@@ -57,11 +57,11 @@ public class CustomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
-        Log.v("Delete batch id: " + downloadBatchId.stringValue());
+        Log.v("Delete batch id: " + downloadBatchId.rawId());
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-        Log.v("update batch id: " + downloadBatchId.stringValue() + " with status: " + status);
+        Log.v("update batch id: " + downloadBatchId.rawId() + " with status: " + status);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -76,8 +76,8 @@ public final class Batch {
         }
 
         public Builder addFile(String fileUrl) {
-            String id = downloadBatchId.rawId() + fileUrl;
-            DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(id);
+            String rawId = downloadBatchId.rawId() + fileUrl;
+            DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(rawId);
             fileUrls.put(downloadFileId, fileUrl);
             return this;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -76,7 +76,7 @@ public final class Batch {
         }
 
         public Builder addFile(String fileUrl) {
-            String id = downloadBatchId.stringValue() + fileUrl;
+            String id = downloadBatchId.rawId() + fileUrl;
             DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(id);
             fileUrls.put(downloadFileId, fileUrl);
             return this;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchId.java
@@ -2,5 +2,5 @@ package com.novoda.downloadmanager;
 
 public interface DownloadBatchId {
 
-    String stringValue();
+    String rawId();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchIdCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchIdCreator.java
@@ -6,7 +6,7 @@ public final class DownloadBatchIdCreator {
         // non-instantiable class
     }
 
-    public static DownloadBatchId createFrom(String id) {
-        return new LiteDownloadBatchId(id);
+    public static DownloadBatchId createFrom(String rawId) {
+        return new LiteDownloadBatchId(rawId);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileId.java
@@ -2,5 +2,5 @@ package com.novoda.downloadmanager;
 
 public interface DownloadFileId {
 
-    String toRawId();
+    String rawId();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileIdCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileIdCreator.java
@@ -7,6 +7,6 @@ public final class DownloadFileIdCreator {
     }
 
     public static DownloadFileId createFrom(String id) {
-        return new LiteDownloadFileId(id.hashCode());
+        return new LiteDownloadFileId(id);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileIdCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileIdCreator.java
@@ -6,7 +6,7 @@ public final class DownloadFileIdCreator {
         // non-instantiable class
     }
 
-    public static DownloadFileId createFrom(String id) {
-        return new LiteDownloadFileId(id);
+    public static DownloadFileId createFrom(String rawId) {
+        return new LiteDownloadFileId(rawId);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchId.java
@@ -18,19 +18,18 @@ class LiteDownloadBatchId implements DownloadBatchId {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof LiteDownloadBatchId)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         LiteDownloadBatchId that = (LiteDownloadBatchId) o;
 
-        return id.equals(that.id);
-
+        return id != null ? id.equals(that.id) : that.id == null;
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchId.java
@@ -9,7 +9,7 @@ class LiteDownloadBatchId implements DownloadBatchId {
     }
 
     @Override
-    public String stringValue() {
+    public String rawId() {
         return id;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileId.java
@@ -2,10 +2,15 @@ package com.novoda.downloadmanager;
 
 final class LiteDownloadFileId implements DownloadFileId {
 
-    private final int id;
+    private final String id;
 
-    LiteDownloadFileId(int id) {
+    LiteDownloadFileId(String id) {
         this.id = id;
+    }
+
+    @Override
+    public String rawId() {
+        return String.valueOf(id);
     }
 
     @Override
@@ -13,30 +18,24 @@ final class LiteDownloadFileId implements DownloadFileId {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof LiteDownloadFileId)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
         LiteDownloadFileId that = (LiteDownloadFileId) o;
 
-        return id == that.id;
-
-    }
-
-    @Override
-    public String toRawId() {
-        return String.valueOf(id);
+        return id != null ? id.equals(that.id) : that.id == null;
     }
 
     @Override
     public int hashCode() {
-        return id;
+        return id != null ? id.hashCode() : 0;
     }
 
     @Override
     public String toString() {
         return "LiteDownloadFileId{"
-                + "id=" + id
+                + "id='" + id + '\''
                 + '}';
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileId.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileId.java
@@ -10,7 +10,7 @@ final class LiteDownloadFileId implements DownloadFileId {
 
     @Override
     public String rawId() {
-        return String.valueOf(id);
+        return id;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -125,8 +125,8 @@ class MigrationJob implements Runnable {
     // TODO: See https://github.com/novoda/download-manager/issues/270
     private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
         Batch batch = migration.batch();
-        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().stringValue() + ", time is " + System.nanoTime());
-        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().stringValue());
+        Log.d(TAG, "about to delete the batch: " + batch.getDownloadBatchId().rawId() + ", time is " + System.nanoTime());
+        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.getDownloadBatchId().rawId());
         for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
             if (hasValidFileLocation(metadata)) {
                 File file = new File(metadata.originalFileLocation());

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -36,7 +36,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     @Override
     public void persistBatch(final DownloadsBatchPersisted batchPersisted) {
         RoomBatch roomBatch = new RoomBatch();
-        roomBatch.id = batchPersisted.downloadBatchId().stringValue();
+        roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
         roomBatch.title = batchPersisted.downloadBatchTitle().asString();
         roomBatch.downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
@@ -66,11 +66,11 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     public void persistFile(DownloadsFilePersisted filePersisted) {
         RoomFile roomFile = new RoomFile();
         roomFile.totalSize = filePersisted.totalFileSize();
-        roomFile.batchId = filePersisted.downloadBatchId().stringValue();
+        roomFile.batchId = filePersisted.downloadBatchId().rawId();
         roomFile.url = filePersisted.url();
         roomFile.name = filePersisted.fileName().name();
         roomFile.path = filePersisted.filePath().path();
-        roomFile.id = filePersisted.downloadFileId().toRawId();
+        roomFile.id = filePersisted.downloadFileId().rawId();
         roomFile.persistenceType = filePersisted.filePersistenceType().toRawValue();
 
         database.roomFileDao().insert(roomFile);
@@ -84,7 +84,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public List<DownloadsFilePersisted> loadFiles(DownloadBatchId downloadBatchId) {
-        List<RoomFile> roomFiles = database.roomFileDao().loadAllFilesFor(downloadBatchId.stringValue());
+        List<RoomFile> roomFiles = database.roomFileDao().loadAllFilesFor(downloadBatchId.rawId());
         return getDownloadsFilePersisted(roomFiles);
     }
 
@@ -108,13 +108,13 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
-        RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.stringValue());
+        RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         database.roomBatchDao().delete(roomBatch);
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-        RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.stringValue());
+        RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
     }

--- a/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
@@ -57,7 +57,7 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
     @Override
     public List<DownloadsFilePersisted> loadFiles(final DownloadBatchId batchId) {
         for (Map.Entry<DownloadsBatchPersisted, List<DownloadsFilePersisted>> batchWithFiles : filesByBatches.entrySet()) {
-            if (batchId.stringValue().equals(batchWithFiles.getKey().downloadBatchId().stringValue())) {
+            if (batchId.rawId().equals(batchWithFiles.getKey().downloadBatchId().rawId())) {
                 return batchWithFiles.getValue();
             }
         }


### PR DESCRIPTION
## Problem
I forget why but we thought that introducing a hash version of the id during the creation might be better 🤔  in retrospect it wasn't because what ends up happening is, you use this creator in multiple places but each time it creates a completely different object because you are hashing an already hashed object 😂 

## Solution
Just use a plan value, `String` was used for the `BatchId` and I like to be able to read the db when I look at it. 