### PR TITLE
Downloader then perform

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -128,7 +128,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     @WorkerThread
     @Override
     public List<DownloadBatchStatus> getAllDownloadBatchStatuses() {
-        return WaitForDownloadServiceThenPerform.<List<DownloadBatchStatus>>waitFor(downloadService, waitForDownloadService)
+        return WaitForDownloadService.<List<DownloadBatchStatus>>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(this::executeGetAllDownloadBatchStatuses);
     }
 
@@ -143,7 +143,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void getAllDownloadBatchStatuses(AllBatchStatusesCallback callback) {
-        executor.submit((Runnable) () -> WaitForDownloadServiceThenPerform.<Void>waitFor(downloadService, waitForDownloadService)
+        executor.submit((Runnable) () -> WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(() -> {
                     List<DownloadBatchStatus> downloadBatchStatuses = executeGetAllDownloadBatchStatuses();
                     callbackHandler.post(() -> callback.onReceived(downloadBatchStatuses));
@@ -155,7 +155,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     @WorkerThread
     @Override
     public DownloadFileStatus getDownloadStatusWithMatching(DownloadFileId downloadFileId) {
-        return WaitForDownloadServiceThenPerform.<DownloadFileStatus>waitFor(downloadService, waitForDownloadService)
+        return WaitForDownloadService.<DownloadFileStatus>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(() -> executeGetDownloadStatusWithMatching(downloadFileId));
     }
 
@@ -173,7 +173,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void getDownloadStatusWithMatching(DownloadFileId downloadFileId, DownloadFileStatusCallback callback) {
-        executor.submit((Runnable) () -> WaitForDownloadServiceThenPerform.<Void>waitFor(downloadService, waitForDownloadService)
+        executor.submit((Runnable) () -> WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(() -> {
                     DownloadFileStatus downloadFileStatus = executeGetDownloadStatusWithMatching(downloadFileId);
                     callbackHandler.post(() -> callback.onReceived(downloadFileStatus));

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -68,11 +68,11 @@ class LiteDownloadManagerDownloader {
 
     public void download(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
-        executor.submit(() -> WaitForDownloadServiceThenPerform.<Void>waitFor(downloadService, waitForDownloadService)
+        executor.submit(() -> WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(executeDownload(downloadBatch)));
     }
 
-    private WaitForDownloadServiceThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
+    private WaitForDownloadService.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
         return () -> {
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
             if (downloadBatchStatus.status() != DOWNLOADED) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -2,15 +2,13 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETION;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
 class LiteDownloadManagerDownloader {
 
@@ -26,7 +24,8 @@ class LiteDownloadManagerDownloader {
 
     private DownloadService downloadService;
 
-    @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})// Can't group anymore these are customisable options.
+    @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
+// Can't group anymore these are customisable options.
     LiteDownloadManagerDownloader(Object waitForDownloadService,
                                   ExecutorService executor,
                                   Handler callbackHandler,
@@ -69,38 +68,19 @@ class LiteDownloadManagerDownloader {
 
     public void download(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
-        if (downloadService == null) {
-            ensureDownloadServiceExistsAndDownload(downloadBatch);
-        } else {
-            executeDownload(downloadBatch);
-        }
+        executor.submit(() -> WaitForDownloadServiceThenPerform.<Void>waitFor(downloadService, waitForDownloadService)
+                .thenPerform(executeDownload(downloadBatch)));
     }
 
-    private void ensureDownloadServiceExistsAndDownload(final DownloadBatch downloadBatch) {
-        executor.submit(() -> {
-            waitForDownloadService();
-            executeDownload(downloadBatch);
-        });
-    }
-
-    private void waitForDownloadService() {
-        try {
-            synchronized (waitForDownloadService) {
-                if (downloadService == null) {
-                    waitForDownloadService.wait();
-                }
+    private WaitForDownloadServiceThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
+        return () -> {
+            InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
+            if (downloadBatchStatus.status() != DOWNLOADED) {
+                updateStatusToQueuedIfNeeded(downloadBatchStatus);
+                downloadService.download(downloadBatch, downloadBatchCallback());
             }
-        } catch (InterruptedException e) {
-            Log.e(e, "Interrupted whilst waiting for download service.");
-        }
-    }
-
-    private void executeDownload(final DownloadBatch downloadBatch) {
-        InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
-        if (downloadBatchStatus.status() != DOWNLOADED) {
-            updateStatusToQueuedIfNeeded(downloadBatchStatus);
-            downloadService.download(downloadBatch, downloadBatchCallback());
-        }
+            return null;
+        };
     }
 
     private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {

--- a/library/src/main/java/com/novoda/downloadmanager/WaitForDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/WaitForDownloadService.java
@@ -4,26 +4,26 @@ import android.support.annotation.Nullable;
 
 import com.novoda.notils.logger.simple.Log;
 
-final class WaitForDownloadServiceThenPerform {
+final class WaitForDownloadService {
 
-    interface Action<T> {
-        T performAction();
-    }
-
-    private WaitForDownloadServiceThenPerform() {
+    private WaitForDownloadService() {
         // Uses static factory method.
     }
 
-    static <T> WaitForDownloadServiceThenPerformAction<T> waitFor(@Nullable DownloadService downloadService, Object downloadServiceLock) {
-        return new WaitForDownloadServiceThenPerformAction<>(downloadService, downloadServiceLock);
+    static <T> ThenPerform<T> waitFor(@Nullable DownloadService downloadService, Object downloadServiceLock) {
+        return new ThenPerform<>(downloadService, downloadServiceLock);
     }
 
-    static class WaitForDownloadServiceThenPerformAction<T> {
+    static class ThenPerform<T> {
+
+        interface Action<T> {
+            T performAction();
+        }
 
         private final DownloadService downloadService;
         private final Object downloadServiceLock;
 
-        WaitForDownloadServiceThenPerformAction(DownloadService downloadService, Object downloadServiceLock) {
+        ThenPerform(DownloadService downloadService, Object downloadServiceLock) {
             this.downloadService = downloadService;
             this.downloadServiceLock = downloadServiceLock;
         }


### PR DESCRIPTION
## Problem
Introduced a `WaitForDownloadServiceThenPerform` that collects the `service` waiting logic into a single class. Turns out we can use this on the `LiteDownloadManagerDownloader` too 😄 

## Solution
Use the `WaitForDownloadServiceThenPerform` on the `LiteDownloadManagerDownloader` 😄  Also rename the `WaitForDownloadServiceThenPerform` to `WaitForDownloadService` so the full command will appear:

```
        executor.submit(() -> WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
                .thenPerform(executeDownload(downloadBatch)));
```

This assumes the action is extracted to another method which will now appear as:

```
    private WaitForDownloadService.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
        return () -> {
            InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
            if (downloadBatchStatus.status() != DOWNLOADED) {
                updateStatusToQueuedIfNeeded(downloadBatchStatus);
                downloadService.download(downloadBatch, downloadBatchCallback());
            }
            return null;
        };
    }
```