### PR TITLE
Delete status update

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -53,6 +53,10 @@ class DownloadBatch {
             return;
         }
 
+        if (downloadBatchStatus.status() == DOWNLOADED) {
+            return;
+        }
+
         downloadBatchStatus.markAsDownloading(downloadsBatchPersistence);
         notifyCallback(downloadBatchStatus);
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -136,7 +136,7 @@ class DownloadBatch {
     }
 
     void pause() {
-        if (downloadBatchStatus.status() == PAUSED) {
+        if (downloadBatchStatus.status() == PAUSED || downloadBatchStatus.status() == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -148,7 +148,7 @@ class DownloadBatch {
     }
 
     void resume() {
-        if (downloadBatchStatus.status() == QUEUED || downloadBatchStatus.status() == DOWNLOADING) {
+        if (downloadBatchStatus.status() == QUEUED || downloadBatchStatus.status() == DOWNLOADING || downloadBatchStatus.status() == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -53,10 +53,6 @@ class DownloadBatch {
             return;
         }
 
-        if (downloadBatchStatus.status() == DOWNLOADED) {
-            return;
-        }
-
         downloadBatchStatus.markAsDownloading(downloadsBatchPersistence);
         notifyCallback(downloadBatchStatus);
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -75,16 +75,14 @@ class LiteDownloadManagerDownloader {
     private WaitForDownloadService.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
         return () -> {
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
-            if (downloadBatchStatus.status() != DOWNLOADED) {
-                updateStatusToQueuedIfNeeded(downloadBatchStatus);
-                downloadService.download(downloadBatch, downloadBatchCallback());
-            }
+            updateStatusToQueuedIfNeeded(downloadBatchStatus);
+            downloadService.download(downloadBatch, downloadBatchCallback());
             return null;
         };
     }
 
     private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {
-        if (downloadBatchStatus.status() != PAUSED) {
+        if (downloadBatchStatus.status() != PAUSED && downloadBatchStatus.status() != DOWNLOADED) {
             downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -13,6 +13,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+
 public class LiteDownloadService extends Service implements DownloadService {
 
     private static final long TEN_MINUTES_IN_MILLIS = TimeUnit.MINUTES.toMillis(10);
@@ -46,9 +48,13 @@ public class LiteDownloadService extends Service implements DownloadService {
 
     @Override
     public void download(final DownloadBatch downloadBatch, final DownloadBatchCallback callback) {
-        callback.onUpdate(downloadBatch.status());
-
         downloadBatch.setCallback(callback);
+
+        if (downloadBatch.status().status() == DOWNLOADED) {
+            return;
+        }
+
+        callback.onUpdate(downloadBatch.status());
 
         executor.execute(() -> {
             acquireCpuWakeLock();


### PR DESCRIPTION
### Problem
As per issue #300, when a batch is in the `DOWNLOADED` state and the app is cleared from memory (Removed from recents), the batch no longer has an attached `StatusCallback`. No `StatusCallback` means no updates when the `DOWNLOADED` asset is `DELETED`.

### Solution
Always attach the `StatusCallback` regardless of state. Ensure that we prevent certain events from occurring when in the `DOWNLOADED` state:

- PAUSE
- RESUME
- DOWNLOAD

All of the above triggering will change the state and then change it back immediately to `DOWNLOADED` resulting in an additional set of complete notifications being sent to the user.

### Screen Capture

Before | After
--- | ---
![deleted_before](https://user-images.githubusercontent.com/3380092/34937397-972a1f8c-f9dc-11e7-92bd-8a4439841da2.gif) | ![deleted_after](https://user-images.githubusercontent.com/3380092/34937396-9710c7c6-f9dc-11e7-8a3a-fe372b1947c1.gif)



