### PR TITLE
Remove completed notification on delete

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -230,6 +230,8 @@ public final class DownloadManagerBuilder {
             notificationManager.createNotificationChannel(notificationChannel);
         }
 
+        NotificationDispatcher notificationDispatcher = new NotificationDispatcher(LOCK, notificationCreator);
+
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 LOCK,
                 EXECUTOR,
@@ -237,7 +239,7 @@ public final class DownloadManagerBuilder {
                 fileOperations,
                 downloadsBatchPersistence,
                 downloadsFilePersistence,
-                notificationCreator,
+                notificationDispatcher,
                 callbacks,
                 callbackThrottleCreator
         );

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -285,20 +285,36 @@ public final class DownloadManagerBuilder {
 
         @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
+            if (payload.status() == DownloadBatchStatus.Status.DELETION) {
+                return createDeletedNotification(builder, payload);
+            } else {
+                DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
+                int percentageDownloaded = payload.percentageDownloaded();
+                int bytesFileSize = (int) payload.bytesTotalSize();
+                int bytesDownloaded = (int) payload.bytesDownloaded();
+                String title = downloadBatchTitle.asString();
+                String content = percentageDownloaded + "% downloaded";
+
+                return builder
+                        .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
+                        .setSmallIcon(notificationIcon)
+                        .setContentTitle(title)
+                        .setContentText(content)
+                        .build();
+
+            }
+        }
+
+        private Notification createDeletedNotification(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
             DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
-            int percentageDownloaded = payload.percentageDownloaded();
-            int bytesFileSize = (int) payload.bytesTotalSize();
-            int bytesDownloaded = (int) payload.bytesDownloaded();
             String title = downloadBatchTitle.asString();
-            String content = percentageDownloaded + "% downloaded";
+            String content = "Deleted";
 
             return builder
-                    .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
                     .setSmallIcon(notificationIcon)
                     .setContentTitle(title)
                     .setContentText(content)
                     .build();
-
         }
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -285,36 +285,36 @@ public final class DownloadManagerBuilder {
 
         @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
+            DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
+            String title = downloadBatchTitle.asString();
+            builder.setSmallIcon(notificationIcon)
+                    .setContentTitle(title);
+
             if (payload.status() == DownloadBatchStatus.Status.DELETION) {
-                return createDeletedNotification(builder, payload);
+                return createDeletedNotification(builder);
             } else {
-                DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
-                int percentageDownloaded = payload.percentageDownloaded();
-                int bytesFileSize = (int) payload.bytesTotalSize();
-                int bytesDownloaded = (int) payload.bytesDownloaded();
-                String title = downloadBatchTitle.asString();
-                String content = percentageDownloaded + "% downloaded";
-
-                return builder
-                        .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
-                        .setSmallIcon(notificationIcon)
-                        .setContentTitle(title)
-                        .setContentText(content)
-                        .build();
-
+                return createProgressNotification(builder, payload);
             }
         }
 
-        private Notification createDeletedNotification(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
-            DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
-            String title = downloadBatchTitle.asString();
+        private Notification createDeletedNotification(NotificationCompat.Builder builder) {
             String content = "Deleted";
-
             return builder
-                    .setSmallIcon(notificationIcon)
-                    .setContentTitle(title)
                     .setContentText(content)
                     .build();
         }
+
+        private Notification createProgressNotification(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
+            int percentageDownloaded = payload.percentageDownloaded();
+            int bytesFileSize = (int) payload.bytesTotalSize();
+            int bytesDownloaded = (int) payload.bytesDownloaded();
+            String content = percentageDownloaded + "% downloaded";
+
+            return builder
+                    .setProgress(bytesFileSize, bytesDownloaded, NOT_INDETERMINATE)
+                    .setContentText(content)
+                    .build();
+        }
+
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -8,5 +8,5 @@ interface DownloadService {
 
     void stackNotification(NotificationInformation notificationInformation);
 
-    void dismissNotification();
+    void dismissNotification(NotificationInformation notificationInformation);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -74,8 +74,9 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void dismissNotification() {
+    public void dismissNotification(NotificationInformation notificationInformation) {
         stopForeground(true);
+        notificationManagerCompat.cancel(NOTIFICATION_TAG, notificationInformation.getId());
     }
 
     private void acquireCpuWakeLock() {

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -22,12 +22,13 @@ class NotificationDispatcher {
 
     private WaitForDownloadService.ThenPerform.Action<Void> executeUpdateNotification(DownloadBatchStatus downloadBatchStatus) {
         return () -> {
+            NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
+
             if (downloadBatchStatus.status() == DELETION) {
-                downloadService.dismissNotification();
+                downloadService.dismissNotification(notificationInformation);
                 return null;
             }
 
-            NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
             if (downloadBatchStatus.status() == DOWNLOADED) {
                 downloadService.stackNotification(notificationInformation);
                 return null;

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -24,17 +24,12 @@ class NotificationDispatcher {
         return () -> {
             NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
 
-            if (downloadBatchStatus.status() == DELETION) {
-                downloadService.dismissNotification(notificationInformation);
-                return null;
-            }
-
-            if (downloadBatchStatus.status() == DOWNLOADED) {
+            if (downloadBatchStatus.status() == DOWNLOADED || downloadBatchStatus.status() == DELETION) {
                 downloadService.stackNotification(notificationInformation);
-                return null;
+            } else {
+                downloadService.updateNotification(notificationInformation);
             }
 
-            downloadService.updateNotification(notificationInformation);
             return null;
         };
     }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -1,0 +1,44 @@
+package com.novoda.downloadmanager;
+
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETION;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+
+class NotificationDispatcher {
+
+    private final Object waitForDownloadService;
+    private final NotificationCreator<DownloadBatchStatus> notificationCreator;
+
+    private DownloadService downloadService;
+
+    NotificationDispatcher(Object waitForDownloadService, NotificationCreator<DownloadBatchStatus> notificationCreator) {
+        this.waitForDownloadService = waitForDownloadService;
+        this.notificationCreator = notificationCreator;
+    }
+
+    void updateNotification(DownloadBatchStatus downloadBatchStatus) {
+        WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
+                .thenPerform(executeUpdateNotification(downloadBatchStatus));
+    }
+
+    private WaitForDownloadService.ThenPerform.Action<Void> executeUpdateNotification(DownloadBatchStatus downloadBatchStatus) {
+        return () -> {
+            if (downloadBatchStatus.status() == DELETION) {
+                downloadService.dismissNotification();
+                return null;
+            }
+
+            NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
+            if (downloadBatchStatus.status() == DOWNLOADED) {
+                downloadService.stackNotification(notificationInformation);
+                return null;
+            }
+
+            downloadService.updateNotification(notificationInformation);
+            return null;
+        };
+    }
+
+    void setDownloadService(DownloadService downloadService) {
+        this.downloadService = downloadService;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.WorkerThread;
+
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETION;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 
@@ -15,6 +17,7 @@ class NotificationDispatcher {
         this.notificationCreator = notificationCreator;
     }
 
+    @WorkerThread
     void updateNotification(DownloadBatchStatus downloadBatchStatus) {
         WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(executeUpdateNotification(downloadBatchStatus));


### PR DESCRIPTION
### Problem
When trying to fix #300 I found that when downloads complete in the sample app and a user taps delete the notifications are still persisted, even though they don't exist anymore 😬 

### Solution
Make sure that we remove a notification that corresponds to a download that is deleted. 

I have created a `NotificationDispatcher` to encapsulate the logic related to sending notifications in one class rather than continue to include it in the already bloated `Downloader` class. 

Send a `NotificationInformation` when performing a dismiss on notifications so we can have the notification manager remove a specific notification. This would be the notifications not bound to the service anymore.

### Screen Capture

Before | After
--- | ---
![delete_notifications_before](https://user-images.githubusercontent.com/3380092/34943496-d7ab2bfc-f9f3-11e7-95db-66caf88ee137.gif) | ![delete_notification_after](https://user-images.githubusercontent.com/3380092/34943495-d792d9e4-f9f3-11e7-9d0b-46c4a36f70ca.gif)
