### PR TITLE
Delete status update v2

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomCallbackThrottle.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomCallbackThrottle.java
@@ -2,16 +2,16 @@ package com.novoda.downloadmanager.demo;
 
 import com.novoda.notils.logger.simple.Log;
 import com.novoda.downloadmanager.CallbackThrottle;
-import com.novoda.downloadmanager.DownloadBatchCallback;
+import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 import com.novoda.downloadmanager.DownloadBatchStatus;
 
 // Must be public
 public class CustomCallbackThrottle implements CallbackThrottle {
 
-    private DownloadBatchCallback callback;
+    private DownloadBatchStatusCallback callback;
 
     @Override
-    public void setCallback(DownloadBatchCallback callback) {
+    public void setCallback(DownloadBatchStatusCallback callback) {
         Log.v("setCallback");
         this.callback = callback;
     }

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -12,7 +12,7 @@ import android.widget.TextView;
 
 import com.novoda.downloadmanager.AllBatchStatusesCallback;
 import com.novoda.downloadmanager.Batch;
-import com.novoda.downloadmanager.DownloadBatchCallback;
+import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 import com.novoda.downloadmanager.DownloadBatchId;
 import com.novoda.downloadmanager.DownloadBatchIdCreator;
 import com.novoda.downloadmanager.DownloadBatchStatus;
@@ -105,7 +105,7 @@ public class MainActivity extends AppCompatActivity {
         DemoApplication demoApplication = (DemoApplication) getApplicationContext();
         liteDownloadManagerCommands = demoApplication.getLiteDownloadManagerCommands();
         liteDownloadManagerCommands.addDownloadBatchCallback(callback);
-        liteDownloadManagerCommands.getAllDownloadBatchStatuses(batchStatusesCallback);
+//        liteDownloadManagerCommands.getAllDownloadBatchStatuses(batchStatusesCallback);
 
         bindBatchViews();
     }
@@ -152,7 +152,7 @@ public class MainActivity extends AppCompatActivity {
             downloadFileStatus -> Log.d("FileStatus: ", downloadFileStatus)
     );
 
-    private final DownloadBatchCallback callback = downloadBatchStatus -> {
+    private final DownloadBatchStatusCallback callback = downloadBatchStatus -> {
         String status = getStatusMessage(downloadBatchStatus);
 
         String message = "Batch " + downloadBatchStatus.getDownloadBatchTitle().asString()

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -12,10 +12,10 @@ import android.widget.TextView;
 
 import com.novoda.downloadmanager.AllBatchStatusesCallback;
 import com.novoda.downloadmanager.Batch;
-import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 import com.novoda.downloadmanager.DownloadBatchId;
 import com.novoda.downloadmanager.DownloadBatchIdCreator;
 import com.novoda.downloadmanager.DownloadBatchStatus;
+import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 import com.novoda.downloadmanager.DownloadFileId;
 import com.novoda.downloadmanager.DownloadFileIdCreator;
 import com.novoda.downloadmanager.DownloadMigrator;
@@ -105,7 +105,7 @@ public class MainActivity extends AppCompatActivity {
         DemoApplication demoApplication = (DemoApplication) getApplicationContext();
         liteDownloadManagerCommands = demoApplication.getLiteDownloadManagerCommands();
         liteDownloadManagerCommands.addDownloadBatchCallback(callback);
-//        liteDownloadManagerCommands.getAllDownloadBatchStatuses(batchStatusesCallback);
+        liteDownloadManagerCommands.getAllDownloadBatchStatuses(batchStatusesCallback);
 
         bindBatchViews();
     }

--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottle.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottle.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager;
 
 public interface CallbackThrottle {
 
-    void setCallback(DownloadBatchCallback callback);
+    void setCallback(DownloadBatchStatusCallback callback);
 
     void update(DownloadBatchStatus downloadBatchStatus);
 

--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
@@ -2,12 +2,12 @@ package com.novoda.downloadmanager;
 
 class CallbackThrottleByProgressIncrease implements CallbackThrottle {
 
-    private DownloadBatchCallback callback;
+    private DownloadBatchStatusCallback callback;
     private DownloadBatchStatus downloadBatchStatus;
     private int currentProgress;
 
     @Override
-    public void setCallback(DownloadBatchCallback callback) {
+    public void setCallback(DownloadBatchStatusCallback callback) {
         this.callback = callback;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByTime.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByTime.java
@@ -5,14 +5,14 @@ class CallbackThrottleByTime implements CallbackThrottle {
     private final ActionScheduler actionScheduler;
 
     private DownloadBatchStatus downloadBatchStatus;
-    private DownloadBatchCallback callback;
+    private DownloadBatchStatusCallback callback;
 
     CallbackThrottleByTime(ActionScheduler actionScheduler) {
         this.actionScheduler = actionScheduler;
     }
 
     @Override
-    public void setCallback(final DownloadBatchCallback callback) {
+    public void setCallback(final DownloadBatchStatusCallback callback) {
         this.callback = callback;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -25,7 +25,7 @@ class DownloadBatch {
     private final CallbackThrottle callbackThrottle;
 
     private long totalBatchSizeBytes;
-    private DownloadBatchCallback callback;
+    private DownloadBatchStatusCallback callback;
 
     DownloadBatch(InternalDownloadBatchStatus internalDownloadBatchStatus,
                   List<DownloadFile> downloadFiles,
@@ -39,7 +39,7 @@ class DownloadBatch {
         this.callbackThrottle = callbackThrottle;
     }
 
-    void setCallback(DownloadBatchCallback callback) {
+    void setCallback(DownloadBatchStatusCallback callback) {
         this.callback = callback;
         callbackThrottle.setCallback(callback);
     }
@@ -50,6 +50,10 @@ class DownloadBatch {
         }
 
         if (downloadBatchStatus.status() == DELETION) {
+            return;
+        }
+
+        if (downloadBatchStatus.status() == DOWNLOADED) {
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -45,15 +45,16 @@ class DownloadBatch {
     }
 
     void download() {
-        if (downloadBatchStatus.status() == PAUSED) {
+        DownloadBatchStatus.Status status = downloadBatchStatus.status();
+        if (status == PAUSED) {
             return;
         }
 
-        if (downloadBatchStatus.status() == DELETION) {
+        if (status == DELETION) {
             return;
         }
 
-        if (downloadBatchStatus.status() == DOWNLOADED) {
+        if (status == DOWNLOADED) {
             return;
         }
 
@@ -92,7 +93,7 @@ class DownloadBatch {
             DownloadsNetworkRecoveryCreator.getInstance().scheduleRecovery();
         }
 
-        if (downloadBatchStatus.status() == DOWNLOADED) {
+        if (status == DOWNLOADED) {
             downloadBatchStatus.markAsDownloaded(downloadsBatchPersistence);
         }
 
@@ -140,7 +141,8 @@ class DownloadBatch {
     }
 
     void pause() {
-        if (downloadBatchStatus.status() == PAUSED || downloadBatchStatus.status() == DOWNLOADED) {
+        DownloadBatchStatus.Status status = downloadBatchStatus.status();
+        if (status == PAUSED || status == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -152,7 +154,8 @@ class DownloadBatch {
     }
 
     void resume() {
-        if (downloadBatchStatus.status() == QUEUED || downloadBatchStatus.status() == DOWNLOADING || downloadBatchStatus.status() == DOWNLOADED) {
+        DownloadBatchStatus.Status status = downloadBatchStatus.status();
+        if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -140,7 +140,7 @@ class DownloadBatch {
     }
 
     void pause() {
-        if (downloadBatchStatus.status() == PAUSED) {
+        if (downloadBatchStatus.status() == PAUSED || downloadBatchStatus.status() == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -152,7 +152,7 @@ class DownloadBatch {
     }
 
     void resume() {
-        if (downloadBatchStatus.status() == QUEUED || downloadBatchStatus.status() == DOWNLOADING) {
+        if (downloadBatchStatus.status() == QUEUED || downloadBatchStatus.status() == DOWNLOADING || downloadBatchStatus.status() == DOWNLOADED) {
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusCallback.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-public interface DownloadBatchCallback {
+public interface DownloadBatchStatusCallback {
 
     void onUpdate(DownloadBatchStatus downloadBatchStatus);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -15,7 +15,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     private final ExecutorService executor;
     private final Handler callbackHandler;
     private final Map<DownloadBatchId, DownloadBatch> downloadBatchMap;
-    private final List<DownloadBatchCallback> callbacks;
+    private final List<DownloadBatchStatusCallback> callbacks;
     private final FileOperations fileOperations;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final LiteDownloadManagerDownloader downloader;
@@ -28,7 +28,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
                     ExecutorService executor,
                     Handler callbackHandler,
                     Map<DownloadBatchId, DownloadBatch> downloadBatchMap,
-                    List<DownloadBatchCallback> callbacks,
+                    List<DownloadBatchStatusCallback> callbacks,
                     FileOperations fileOperations,
                     DownloadsBatchPersistence downloadsBatchPersistence,
                     LiteDownloadManagerDownloader downloader) {
@@ -114,12 +114,12 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     @Override
-    public void addDownloadBatchCallback(DownloadBatchCallback downloadBatchCallback) {
+    public void addDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback) {
         callbacks.add(downloadBatchCallback);
     }
 
     @Override
-    public void removeDownloadBatchCallback(DownloadBatchCallback downloadBatchCallback) {
+    public void removeDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback) {
         if (callbacks.contains(downloadBatchCallback)) {
             callbacks.remove(downloadBatchCallback);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -206,7 +206,7 @@ public final class DownloadManagerBuilder {
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloader);
-        ArrayList<DownloadBatchCallback> callbacks = new ArrayList<>();
+        ArrayList<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(
                 callbackThrottleCreatorType,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager;
 
 interface DownloadService {
 
-    void download(DownloadBatch downloadBatch, DownloadBatchCallback callback);
+    void download(DownloadBatch downloadBatch, DownloadBatchStatusCallback callback);
 
     void updateNotification(NotificationInformation notificationInformation);
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
@@ -15,9 +15,9 @@ public interface LiteDownloadManagerCommands {
 
     void delete(DownloadBatchId downloadBatchId);
 
-    void addDownloadBatchCallback(DownloadBatchCallback downloadBatchCallback);
+    void addDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback);
 
-    void removeDownloadBatchCallback(DownloadBatchCallback downloadBatchCallback);
+    void removeDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback);
 
     void submitAllStoredDownloads(AllStoredDownloadsSubmittedCallback callback);
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -18,7 +18,7 @@ class LiteDownloadManagerDownloader {
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final NotificationDispatcher notificationDispatcher;
-    private final List<DownloadBatchCallback> callbacks;
+    private final List<DownloadBatchStatusCallback> callbacks;
     private final CallbackThrottleCreator callbackThrottleCreator;
 
     private DownloadService downloadService;
@@ -32,7 +32,7 @@ class LiteDownloadManagerDownloader {
                                   DownloadsBatchPersistence downloadsBatchPersistence,
                                   DownloadsFilePersistence downloadsFilePersistence,
                                   NotificationDispatcher notificationDispatcher,
-                                  List<DownloadBatchCallback> callbacks,
+                                  List<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {
         this.waitForDownloadService = waitForDownloadService;
         this.executor = executor;
@@ -86,9 +86,9 @@ class LiteDownloadManagerDownloader {
         }
     }
 
-    private DownloadBatchCallback downloadBatchCallback() {
+    private DownloadBatchStatusCallback downloadBatchCallback() {
         return downloadBatchStatus -> callbackHandler.post(() -> {
-            for (DownloadBatchCallback callback : callbacks) {
+            for (DownloadBatchStatusCallback callback : callbacks) {
                 callback.onUpdate(downloadBatchStatus);
             }
             notificationDispatcher.updateNotification(downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -74,16 +74,14 @@ class LiteDownloadManagerDownloader {
     private WaitForDownloadService.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
         return () -> {
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
-            if (downloadBatchStatus.status() != DOWNLOADED) {
-                updateStatusToQueuedIfNeeded(downloadBatchStatus);
-                downloadService.download(downloadBatch, downloadBatchCallback());
-            }
+            updateStatusToQueuedIfNeeded(downloadBatchStatus);
+            downloadService.download(downloadBatch, downloadBatchCallback());
             return null;
         };
     }
 
     private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {
-        if (downloadBatchStatus.status() != PAUSED) {
+        if (downloadBatchStatus.status() != PAUSED && downloadBatchStatus.status() != DOWNLOADED) {
             downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -45,7 +45,7 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void download(final DownloadBatch downloadBatch, final DownloadBatchCallback callback) {
+    public void download(final DownloadBatch downloadBatch, final DownloadBatchStatusCallback callback) {
         callback.onUpdate(downloadBatch.status());
 
         downloadBatch.setCallback(callback);

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -32,6 +32,10 @@ public class NotificationCreator<T> {
         return new NotificationInformation() {
             @Override
             public int getId() {
+                if (notificationPayload instanceof DownloadBatchStatus) {
+                    return ((DownloadBatchStatus) notificationPayload).getDownloadBatchId().hashCode();
+                }
+
                 return notificationPayload.hashCode();
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
@@ -10,7 +10,7 @@ public class CallbackThrottleByProgressIncreaseTest {
 
     private static final int DOWNLOAD_PERCENTAGE = 75;
 
-    private final DownloadBatchCallback downloadBatchCallback = mock(DownloadBatchCallback.class);
+    private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
     private final DownloadBatchStatus downloadBatchStatus = mock(DownloadBatchStatus.class);
 
     private CallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease;

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByTimeTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByTimeTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.*;
 public class CallbackThrottleByTimeTest {
 
     private final ActionScheduler actionScheduler = mock(ActionScheduler.class);
-    private final DownloadBatchCallback callback = mock(DownloadBatchCallback.class);
+    private final DownloadBatchStatusCallback callback = mock(DownloadBatchStatusCallback.class);
     private final DownloadBatchStatus downloadBatchStatus = mock(DownloadBatchStatus.class);
 
     private CallbackThrottleByTime callbackThrottleByTime;

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleCreatorTest.java
@@ -62,7 +62,7 @@ public class CallbackThrottleCreatorTest {
      */
     private static class TestNotFoundCustomThrottle implements CallbackThrottle {
         @Override
-        public void setCallback(DownloadBatchCallback callback) {
+        public void setCallback(DownloadBatchStatusCallback callback) {
 
         }
 

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -48,7 +48,7 @@ public class DownloadManagerTest {
     private final Handler handler = mock(Handler.class);
     private final DownloadBatch downloadBatch = mock(DownloadBatch.class);
     private final DownloadBatch additionalDownloadBatch = mock(DownloadBatch.class);
-    private final DownloadBatchCallback downloadBatchCallback = mock(DownloadBatchCallback.class);
+    private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
     private final FileOperations fileOperations = mock(FileOperations.class);
     private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
     private final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
@@ -56,7 +56,7 @@ public class DownloadManagerTest {
     private DownloadManager downloadManager;
     private Map<DownloadBatchId, DownloadBatch> downloadBatches = new HashMap<>();
     private List<DownloadBatchStatus> downloadBatchStatuses = new ArrayList<>();
-    private List<DownloadBatchCallback> downloadBatchCallbacks = new ArrayList<>();
+    private List<DownloadBatchStatusCallback> downloadBatchCallbacks = new ArrayList<>();
     private DownloadFileStatus downloadFileStatus = null;
 
     @Before
@@ -240,7 +240,7 @@ public class DownloadManagerTest {
 
     @Test
     public void addsCallbackToInternalList() {
-        DownloadBatchCallback additionalDownloadBatchCallback = mock(DownloadBatchCallback.class);
+        DownloadBatchStatusCallback additionalDownloadBatchCallback = mock(DownloadBatchStatusCallback.class);
 
         downloadManager.addDownloadBatchCallback(additionalDownloadBatchCallback);
 

--- a/library/src/test/java/com/novoda/downloadmanager/TestNonInstantiableCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestNonInstantiableCustomThrottle.java
@@ -7,7 +7,7 @@ package com.novoda.downloadmanager;
 abstract class TestNonInstantiableCustomThrottle implements CallbackThrottle {
 
     @Override
-    public void setCallback(DownloadBatchCallback callback) {
+    public void setCallback(DownloadBatchStatusCallback callback) {
 
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/TestNonPublicCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestNonPublicCustomThrottle.java
@@ -10,7 +10,7 @@ class TestNonPublicCustomThrottle implements CallbackThrottle {
     }
 
     @Override
-    public void setCallback(DownloadBatchCallback callback) {
+    public void setCallback(DownloadBatchStatusCallback callback) {
 
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/TestValidCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestValidCustomThrottle.java
@@ -7,7 +7,7 @@ package com.novoda.downloadmanager;
 public class TestValidCustomThrottle implements CallbackThrottle {
 
     @Override
-    public void setCallback(DownloadBatchCallback callback) {
+    public void setCallback(DownloadBatchStatusCallback callback) {
 
     }
 


### PR DESCRIPTION
This is the second attempt of #301 😄 

### Problem
As per issue #300, when a batch is in the `DOWNLOADED` state and the app is cleared from memory (Removed from recents), the batch no longer has an attached `StatusCallback`. No `StatusCallback` means no updates when the `DOWNLOADED` asset is `DELETED`.

### Solution
Always attach the `StatusCallback` regardless of state. Ensure that we prevent certain events from occurring when in the `DOWNLOADED` state:

- PAUSE
- RESUME
- DOWNLOAD

All of the above triggering will change the state and then change it back immediately to `DOWNLOADED` resulting in an additional set of complete notifications being sent to the user.

Seems that `Object.hashcode` is a little broken 😬  it gave different values whenever a notification was created. For `DownloadBatchStatus` notifications we now use `DownloadBatchId.hashcode` which has resolved the double notification problem when the app is killed.


### Screen Capture

Before | After
--- | ---
![deleted_before](https://user-images.githubusercontent.com/3380092/34937397-972a1f8c-f9dc-11e7-92bd-8a4439841da2.gif) | ![deleted_after](https://user-images.githubusercontent.com/3380092/34937396-9710c7c6-f9dc-11e7-8a3a-fe372b1947c1.gif)



