### PR TITLE
Ensure that error notifications are customised and swipeable

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'android.arch.persistence.room:runtime:1.0.0'
     implementation 'com.evernote:android-job:1.2.0-alpha3'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.12.0'
+    testImplementation 'org.mockito:mockito-core:2.13.0'
     testImplementation 'com.google.truth:truth:0.36'
 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -292,6 +292,8 @@ public final class DownloadManagerBuilder {
 
             if (payload.status() == DownloadBatchStatus.Status.DELETION) {
                 return createDeletedNotification(builder);
+            } else if (payload.status() == DownloadBatchStatus.Status.ERROR) {
+                return createErrorNotification(builder, payload);
             } else {
                 return createProgressNotification(builder, payload);
             }
@@ -299,6 +301,13 @@ public final class DownloadManagerBuilder {
 
         private Notification createDeletedNotification(NotificationCompat.Builder builder) {
             String content = "Deleted";
+            return builder
+                    .setContentText(content)
+                    .build();
+        }
+
+        private Notification createErrorNotification(NotificationCompat.Builder builder, DownloadBatchStatus downloadBatchStatus) {
+            String content = "Error: " + downloadBatchStatus.getDownloadErrorType();
             return builder
                     .setContentText(content)
                     .build();

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -4,6 +4,7 @@ import android.support.annotation.WorkerThread;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETION;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
 
 class NotificationDispatcher {
 
@@ -26,8 +27,9 @@ class NotificationDispatcher {
     private WaitForDownloadService.ThenPerform.Action<Void> executeUpdateNotification(DownloadBatchStatus downloadBatchStatus) {
         return () -> {
             NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
+            DownloadBatchStatus.Status status = downloadBatchStatus.status();
 
-            if (downloadBatchStatus.status() == DOWNLOADED || downloadBatchStatus.status() == DELETION) {
+            if (status == DOWNLOADED || status == DELETION || status == ERROR) {
                 downloadService.stackNotification(notificationInformation);
             } else {
                 downloadService.updateNotification(notificationInformation);


### PR DESCRIPTION
### Problem
When customising notifications in a client application we noticed that error notifications are not swipeable. They are not customised in the sample either, so they appear as regular notifications, without any error text 😬 

### Solution
Ensure that the `ERROR` status resolves into a swipeable notification.

### Further work
This is a quick fix for now, we plan to allow clients to specify themselves which notifications are swipeable and which are not, in a future PR. 

### Screen Capture

Before | After
--- | ---
![before_error](https://user-images.githubusercontent.com/3380092/35148831-b8e1943e-fd0b-11e7-93f0-3ebaf7ced9e7.gif) | ![after_error](https://user-images.githubusercontent.com/3380092/35148830-b8c9cebc-fd0b-11e7-9f36-65ec0addcdf0.gif)

