### PR TITLE
Absolute path for internal storage

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -47,7 +47,7 @@ class ExternalFilePersistence implements FilePersistence {
             return FilePersistenceResult.newInstance(Status.ERROR_INSUFFICIENT_SPACE);
         }
 
-        String absolutePath = externalFileDir.getAbsolutePath() + File.separatorChar + fileName.name();
+        String absolutePath = new File(externalFileDir, fileName.name()).getAbsolutePath();
         FilePath filePath = FilePathCreator.create(absolutePath);
         return create(filePath);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -38,7 +38,7 @@ class InternalFilePersistence implements FilePersistence {
 
         File internalFileDir = context.getFilesDir();
 
-        String absolutePath = internalFileDir.getAbsolutePath() + File.separatorChar + fileName.name();
+        String absolutePath = new File(internalFileDir, fileName.name()).getAbsolutePath();
         FilePath filePath = FilePathCreator.create(absolutePath);
         return create(filePath);
     }


### PR DESCRIPTION
### Problem
We had a discrepancy about how we were creating `FilePath`s in the different file persistences:
* in the **external** one we were storing the whole absolute path (`/storage/emulated/0/something/something/file_name.ext`)
* in the **internal** one we were storing only the file name relative to the internal storage dir (`file_name.ext`)

This was done because when accessing files using `context.openFileOutput(path)` the param string cannot contain path separator chars. The problem was that the user didn't have knowledge about if the file was stored in internal or external memory when retrieving info, and this also broke the possibility of accessing the file using `file://` URI.

### Solution
Store the entire absolute path when creating a FilePath in the internal file persistence
(`/data/user/0/app.package.name/files/file_name.ext`)