### PR TITLE
Allow custom DB name for migration

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -119,7 +119,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final MigrationCallback migrationCallback = migrationStatus -> databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
 
-    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration(migrationCallback);
+    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration("downloads.db", migrationCallback);
 
     private final View.OnClickListener downloadBatchesOnClick = v -> {
         Batch batch = new Batch.Builder(BATCH_ID_1, "Made in chelsea")

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
@@ -4,5 +4,5 @@ interface DownloadMigrationService {
 
     void setNotificationCreator(NotificationCreator<MigrationStatus> notificationCreator);
 
-    void startMigration(MigrationCallback migrationCallback);
+    void startMigration(String databaseFilename, MigrationCallback migrationCallback);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
@@ -2,6 +2,6 @@ package com.novoda.downloadmanager;
 
 public interface DownloadMigrator {
 
-    void startMigration(MigrationCallback migrationCallback);
+    void startMigration(String databaseFilename, MigrationCallback migrationCallback);
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -54,9 +54,9 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
     }
 
     @Override
-    public void startMigration(MigrationCallback migrationCallback) {
+    public void startMigration(String databaseFilename, MigrationCallback migrationCallback) {
         createNotificationChannel();
-        MigrationJob migrationJob = new MigrationJob(getApplicationContext(), getDatabasePath("downloads.db"));
+        MigrationJob migrationJob = new MigrationJob(getApplicationContext(), getDatabasePath(databaseFilename));
         migrationJob.addCallback(migrationCallback);
         migrationJob.addCallback(notificationMigrationCallback);
         singleInstanceExecutor.execute(migrationJob);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrator.java
@@ -22,7 +22,7 @@ class LiteDownloadMigrator implements DownloadMigrator {
     }
 
     @Override
-    public void startMigration(final MigrationCallback migrationCallback) {
+    public void startMigration(final String databaseFilename, final MigrationCallback migrationCallback) {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder binder) {
@@ -33,7 +33,7 @@ class LiteDownloadMigrator implements DownloadMigrator {
                         () -> migrationCallback.onUpdate(migrationStatus)
                 );
 
-                migrationService.startMigration(mainThreadReportingMigrationCallback);
+                migrationService.startMigration(databaseFilename, mainThreadReportingMigrationCallback);
             }
 
             @Override


### PR DESCRIPTION
### Problem
Some client apps might have custom DB names, which will not be found when migrating from v1 to vs (we were hardcoding the filename `downloads.db`)

### Solution
Extract db name as parameter in migration