### PR TITLE
Expose right number of batches in migration

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -154,7 +154,7 @@ class MigrationJob implements Runnable {
         Log.d(TAG, "about to migrate the files, time is " + System.nanoTime());
 
         for (int i = 0, size = migrations.size(); i < size; i++) {
-            migrationStatus.update(i, size - 1);
+            migrationStatus.update(i, size);
             onUpdate(migrationStatus);
 
             Migration migration = migrations.get(i);


### PR DESCRIPTION
### Problem
Given 3 downloads to be migrated, we received the `MigrationStatuses` with the following values:

`numberOfMigratedBatches` | `totalNumberOfBatchesToMigrate`
--- | ---
0 | 2
1 | 2
2 | 2

(and then the "migration completed" status)

### Solution
Expose the right number of total batches, so that we have

`numberOfMigratedBatches` | `totalNumberOfBatchesToMigrate`
--- | ---
0 | 3
1 | 3
2 | 3

(and then the "migration completed" status)