### PR TITLE
V2 file naming migrations

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -67,6 +67,10 @@ class DownloadBatch {
             long currentBytesDownloaded = getBytesDownloadedFrom(fileBytesDownloadedMap);
             downloadBatchStatus.update(currentBytesDownloaded, totalBatchSizeBytes);
 
+            if (currentBytesDownloaded == totalBatchSizeBytes && totalBatchSizeBytes != ZERO_BYTES) {
+                downloadBatchStatus.markAsDownloaded(downloadsBatchPersistence);
+            }
+
             if (downloadFileStatus.isMarkedAsError()) {
                 downloadBatchStatus.markAsError(downloadFileStatus.error(), downloadsBatchPersistence);
             }
@@ -83,10 +87,6 @@ class DownloadBatch {
 
         if (networkError()) {
             DownloadsNetworkRecoveryCreator.getInstance().scheduleRecovery();
-        }
-
-        if (status == DOWNLOADED) {
-            downloadBatchStatus.markAsDownloaded(downloadsBatchPersistence);
         }
 
         callbackThrottle.stopUpdates();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -8,6 +8,8 @@ import java.util.concurrent.Executor;
 
 class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
 
+    private static final long ZERO_BYTES = 0;
+
     private final Executor executor;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final DownloadsPersistence downloadsPersistence;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -8,8 +8,6 @@ import java.util.concurrent.Executor;
 
 class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
 
-    private static final long ZERO_BYTES = 0;
-
     private final Executor executor;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final DownloadsPersistence downloadsPersistence;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -41,10 +41,6 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         this.bytesDownloaded = currentBytesDownloaded;
         this.totalBatchSizeBytes = totalBatchSizeBytes;
         this.percentageDownloaded = getPercentageFrom(bytesDownloaded, totalBatchSizeBytes);
-
-        if (this.bytesDownloaded == this.totalBatchSizeBytes && this.totalBatchSizeBytes != ZERO_BYTES) {
-            this.status = Status.DOWNLOADED;
-        }
     }
 
     private int getPercentageFrom(long bytesDownloaded, long totalFileSizeBytes) {

--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -74,14 +74,15 @@ class Migration {
     }
 
     static class FileMetadata {
+
         private final String originalFileLocation;
         private final FileSize fileSize;
-        private final String uri;
+        private final String originalNetworkAddress;
 
-        FileMetadata(String originalFileLocation, FileSize fileSize, String uri) {
+        FileMetadata(String originalFileLocation, FileSize fileSize, String originalNetworkAddress) {
             this.originalFileLocation = originalFileLocation;
             this.fileSize = fileSize;
-            this.uri = uri;
+            this.originalNetworkAddress = originalNetworkAddress;
         }
 
         String originalFileLocation() {
@@ -92,8 +93,8 @@ class Migration {
             return fileSize;
         }
 
-        String uri() {
-            return uri;
+        String originalNetworkAddress() {
+            return originalNetworkAddress;
         }
 
         @Override
@@ -113,14 +114,14 @@ class Migration {
             if (fileSize != null ? !fileSize.equals(that.fileSize) : that.fileSize != null) {
                 return false;
             }
-            return uri != null ? uri.equals(that.uri) : that.uri == null;
+            return originalNetworkAddress != null ? originalNetworkAddress.equals(that.originalNetworkAddress) : that.originalNetworkAddress == null;
         }
 
         @Override
         public int hashCode() {
             int result = originalFileLocation != null ? originalFileLocation.hashCode() : 0;
             result = 31 * result + (fileSize != null ? fileSize.hashCode() : 0);
-            result = 31 * result + (uri != null ? uri.hashCode() : 0);
+            result = 31 * result + (originalNetworkAddress != null ? originalNetworkAddress.hashCode() : 0);
             return result;
         }
 
@@ -128,7 +129,7 @@ class Migration {
         public String toString() {
             return "FileMetadata{" + "originalFileLocation='" + originalFileLocation + '\''
                     + ", fileSize=" + fileSize
-                    + ", uri='" + uri + '\''
+                    + ", originalNetworkAddress='" + originalNetworkAddress + '\''
                     + '}';
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -15,8 +15,8 @@ class MigrationExtractor {
     private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
 
     private static final String DOWNLOADS_QUERY = "SELECT uri, _data, total_bytes FROM Downloads WHERE batch_id = ?";
-    private static final int URI_COLUMN = 0;
-    private static final int FILE_NAME_COLUMN = 1;
+    private static final int NETWORK_ADDRESS_COLUMN = 0;
+    private static final int FILE_LOCATION_COLUMN = 1;
     private static final int FILE_SIZE_COLUMN = 2;
 
     private final SqlDatabaseWrapper database;
@@ -40,13 +40,13 @@ class MigrationExtractor {
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
 
             while (downloadsCursor.moveToNext()) {
-                String uri = downloadsCursor.getString(URI_COLUMN);
-                String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
-                newBatchBuilder.addFile(uri);
+                String originalNetworkAddress = downloadsCursor.getString(NETWORK_ADDRESS_COLUMN);
+                String originalFileLocation = downloadsCursor.getString(FILE_LOCATION_COLUMN);
+                newBatchBuilder.addFile(originalNetworkAddress);
 
                 long rawFileSize = downloadsCursor.getLong(FILE_SIZE_COLUMN);
                 FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
-                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileName, fileSize, uri);
+                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileLocation, fileSize, originalNetworkAddress);
                 fileMetadataList.add(fileMetadata);
             }
             downloadsCursor.close();

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import android.database.Cursor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 class MigrationExtractor {
@@ -28,38 +29,54 @@ class MigrationExtractor {
     List<Migration> extractMigrations() {
         Cursor batchesCursor = database.rawQuery(BATCHES_QUERY);
 
-        List<Migration> migrations = new ArrayList<>();
-        while (batchesCursor.moveToNext()) {
-
-            String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
-            String batchTitle = batchesCursor.getString(TITLE_COLUMN);
-            long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
-
-            Batch.Builder newBatchBuilder = new Batch.Builder(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
-            List<Migration.FileMetadata> fileMetadataList = extractFileMetadataFrom(batchId, newBatchBuilder);
-
-            Batch batch = newBatchBuilder.build();
-            migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis));
+        if (batchesCursor == null) {
+            return Collections.emptyList();
         }
-        batchesCursor.close();
-        return migrations;
+
+        try {
+            List<Migration> migrations = new ArrayList<>();
+
+            while (batchesCursor.moveToNext()) {
+                String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
+                String batchTitle = batchesCursor.getString(TITLE_COLUMN);
+                long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
+
+                Batch.Builder newBatchBuilder = new Batch.Builder(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
+                List<Migration.FileMetadata> fileMetadataList = extractFileMetadataFrom(batchId, newBatchBuilder);
+
+                Batch batch = newBatchBuilder.build();
+                migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis));
+            }
+
+            return migrations;
+        } finally {
+            batchesCursor.close();
+        }
     }
 
     private List<Migration.FileMetadata> extractFileMetadataFrom(String batchId, Batch.Builder newBatchBuilder) {
         Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
-        List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
 
-        while (downloadsCursor.moveToNext()) {
-            String originalNetworkAddress = downloadsCursor.getString(NETWORK_ADDRESS_COLUMN);
-            String originalFileLocation = downloadsCursor.getString(FILE_LOCATION_COLUMN);
-            newBatchBuilder.addFile(originalNetworkAddress);
-
-            long rawFileSize = downloadsCursor.getLong(FILE_SIZE_COLUMN);
-            FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
-            Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileLocation, fileSize, originalNetworkAddress);
-            fileMetadataList.add(fileMetadata);
+        if (downloadsCursor == null) {
+            return Collections.emptyList();
         }
-        downloadsCursor.close();
-        return fileMetadataList;
+
+        try {
+            List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
+
+            while (downloadsCursor.moveToNext()) {
+                String originalNetworkAddress = downloadsCursor.getString(NETWORK_ADDRESS_COLUMN);
+                String originalFileLocation = downloadsCursor.getString(FILE_LOCATION_COLUMN);
+                newBatchBuilder.addFile(originalNetworkAddress);
+
+                long rawFileSize = downloadsCursor.getLong(FILE_SIZE_COLUMN);
+                FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
+                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileLocation, fileSize, originalNetworkAddress);
+                fileMetadataList.add(fileMetadata);
+            }
+            return fileMetadataList;
+        } finally {
+            downloadsCursor.close();
+        }
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -147,7 +147,8 @@ class MigrationJob implements Runnable {
     private void migrateCompleteDownloads(InternalMigrationStatus migrationStatus,
                                           SqlDatabaseWrapper database,
                                           MigrationExtractor migrationExtractor,
-                                          DownloadsPersistence downloadsPersistence, String basePath) {
+                                          DownloadsPersistence downloadsPersistence,
+                                          String basePath) {
         List<Migration> migrations = migrationExtractor.extractMigrations();
         Log.d(TAG, "migrations are all EXTRACTED, time is " + System.nanoTime());
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -5,8 +5,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,8 +55,9 @@ class MigrationJob implements Runnable {
 
         Log.d(TAG, "about to extract migrations, time is " + System.nanoTime());
 
-        migratePartialDownloads(database, partialDownloadMigrationExtractor, downloadsPersistence);
-        migrateCompleteDownloads(migrationStatus, database, migrationExtractor, downloadsPersistence, internalFilePersistence);
+        String basePath = internalFilePersistence.basePath().path();
+        migratePartialDownloads(database, partialDownloadMigrationExtractor, downloadsPersistence, basePath);
+        migrateCompleteDownloads(migrationStatus, database, migrationExtractor, downloadsPersistence, basePath);
     }
 
     private void onUpdate(MigrationStatus migrationStatus) {
@@ -69,13 +68,14 @@ class MigrationJob implements Runnable {
 
     private void migratePartialDownloads(SqlDatabaseWrapper database,
                                          PartialDownloadMigrationExtractor partialDownloadMigrationExtractor,
-                                         DownloadsPersistence downloadsPersistence) {
+                                         DownloadsPersistence downloadsPersistence,
+                                         String basePath) {
         List<Migration> partialMigrations = partialDownloadMigrationExtractor.extractMigrations();
         for (Migration partialMigration : partialMigrations) {
             downloadsPersistence.startTransaction();
             database.startTransaction();
 
-            migrateV1DataToV2Database(downloadsPersistence, partialMigration);
+            migrateV1DataToV2Database(downloadsPersistence, partialMigration, basePath);
             deleteFrom(database, partialMigration);
 
             downloadsPersistence.transactionSuccess();
@@ -86,7 +86,7 @@ class MigrationJob implements Runnable {
         Log.d(TAG, "partial migrations are all EXTRACTED, time is " + System.nanoTime());
     }
 
-    private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration) {
+    private void migrateV1DataToV2Database(DownloadsPersistence downloadsPersistence, Migration migration, String basePath) {
         Batch batch = migration.batch();
 
         DownloadBatchId downloadBatchId = batch.getDownloadBatchId();
@@ -105,8 +105,12 @@ class MigrationJob implements Runnable {
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
             String url = fileMetadata.originalNetworkAddress();
 
+            FilePath filePath = new LiteFilePath(fileMetadata.originalFileLocation());
+            if (filePath.path() == null || filePath.path().isEmpty()) {
+                filePath = FilePathCreator.create(basePath, FileNameExtractor.extractFrom(url).name());
+            }
             FileName fileName = LiteFileName.from(batch, url);
-            FilePath filePath = FilePathCreator.create("", fileName.name());
+
             String rawDownloadFileId = batch.getTitle() + System.nanoTime();
             DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(rawDownloadFileId);
             DownloadsFilePersisted persistedFile = new LiteDownloadsFilePersisted(
@@ -144,8 +148,7 @@ class MigrationJob implements Runnable {
     private void migrateCompleteDownloads(InternalMigrationStatus migrationStatus,
                                           SqlDatabaseWrapper database,
                                           MigrationExtractor migrationExtractor,
-                                          DownloadsPersistence downloadsPersistence,
-                                          InternalFilePersistence internalFilePersistence) {
+                                          DownloadsPersistence downloadsPersistence, String basePath) {
         List<Migration> migrations = migrationExtractor.extractMigrations();
         Log.d(TAG, "migrations are all EXTRACTED, time is " + System.nanoTime());
 
@@ -161,8 +164,7 @@ class MigrationJob implements Runnable {
             downloadsPersistence.startTransaction();
             database.startTransaction();
 
-            migrateV1FilesToV2Location(internalFilePersistence, migration);
-            migrateV1DataToV2Database(downloadsPersistence, migration);
+            migrateV1DataToV2Database(downloadsPersistence, migration, basePath);
             deleteFrom(database, migration);
 
             downloadsPersistence.transactionSuccess();
@@ -181,41 +183,6 @@ class MigrationJob implements Runnable {
         database.deleteDatabase();
         migrationStatus.markAsComplete();
         onUpdate(migrationStatus);
-    }
-
-    private void migrateV1FilesToV2Location(InternalFilePersistence internalFilePersistence, Migration migration) {
-        for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-            FilePath filePath = FilePathCreator.create(internalFilePersistence.basePath().path(), fileMetadata.originalNetworkAddress());
-            internalFilePersistence.create(filePath, fileMetadata.fileSize());
-            FileInputStream inputStream = null;
-            try {
-                // open the v1 file
-                inputStream = new FileInputStream(new File(fileMetadata.originalFileLocation()));
-                byte[] bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
-
-                // read the v1 file
-                int readLast = 0;
-                while (readLast != -1) {
-                    readLast = inputStream.read(bytes);
-                    if (readLast != 0 && readLast != -1) {
-                        // write the v1 file to the v2 location
-                        internalFilePersistence.write(bytes, 0, readLast);
-                        bytes = new byte[RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK];
-                    }
-                }
-            } catch (IOException e) {
-                Log.e(getClass().getSimpleName(), e.getMessage());
-            } finally {
-                try {
-                    internalFilePersistence.close();
-                    if (inputStream != null) {
-                        inputStream.close();
-                    }
-                } catch (IOException e) {
-                    Log.e(getClass().getSimpleName(), e.getMessage());
-                }
-            }
-        }
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -14,7 +14,6 @@ class MigrationJob implements Runnable {
 
     private static final String TAG = "V1 to V2 migrator";
 
-    private static final int RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK = 4096;
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -103,7 +103,7 @@ class MigrationJob implements Runnable {
         downloadsPersistence.persistBatch(persistedBatch);
 
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-            String url = fileMetadata.uri();
+            String url = fileMetadata.originalNetworkAddress();
 
             FileName fileName = LiteFileName.from(batch, url);
             FilePath filePath = FilePathCreator.create("", fileName.name());
@@ -185,7 +185,7 @@ class MigrationJob implements Runnable {
 
     private void migrateV1FilesToV2Location(InternalFilePersistence internalFilePersistence, Migration migration) {
         for (Migration.FileMetadata fileMetadata : migration.getFileMetadata()) {
-            FilePath filePath = FilePathCreator.create(internalFilePersistence.basePath().path(), fileMetadata.uri());
+            FilePath filePath = FilePathCreator.create(internalFilePersistence.basePath().path(), fileMetadata.originalNetworkAddress());
             internalFilePersistence.create(filePath, fileMetadata.fileSize());
             FileInputStream inputStream = null;
             try {

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -95,7 +95,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
                     DownloadBatchIdCreator.createFrom(roomFile.batchId),
                     DownloadFileIdCreator.createFrom(roomFile.id),
                     LiteFileName.from(roomFile.name),
-                    FilePathCreator.create("", roomFile.path),
+                    new LiteFilePath(roomFile.path),
                     roomFile.totalSize,
                     roomFile.url,
                     FilePersistenceType.from(roomFile.persistenceType)


### PR DESCRIPTION
## Problem
When performing #311 we broke the migration part of v2 😬  it attempted to put all of the downloads into the new directory with the same names, it was stripping the name from the network address instead of relying on the current download location 😱 

## Solution
Now that we are relying on a `String` and not hashes for the `FileName` and `FilePath` we can forget about migrating the files from v1 to v2, we can just update the db to point to those files instead! WOOP WOOP. We are assuming that this is ok because if you can access the files now, then you should be able to access them in v2! 

In the case of partial downloads, these are moved to the new internal scheme. We grab the `basePath` and append the `FileName` to generate the absolute path.

## Potential future work
We could allow clients to specify where they want their old files to go by supplying a relative path or absolute path for them.
