### PR TITLE
V2 delete by absolute path

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -41,8 +41,8 @@ public class CustomFilePersistence implements FilePersistence {
     }
 
     @Override
-    public void delete() {
-        Log.v("delete");
+    public void delete(FilePath absoluteFilePath) {
+        Log.v("delete: " + absoluteFilePath);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -100,7 +100,7 @@ class DownloadFile {
             public void onDownloadFinished() {
                 filePersistence.close();
                 if (downloadFileStatus.isMarkedForDeletion()) {
-                    filePersistence.delete();
+                    filePersistence.delete(filePath);
                 }
             }
         });
@@ -166,7 +166,7 @@ class DownloadFile {
             downloadFileStatus.markForDeletion();
             fileDownloader.stopDownloading();
         } else {
-            filePersistence.delete();
+            filePersistence.delete(filePath);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
@@ -96,7 +96,7 @@ class DownloadsFilePersistence {
             case DELETION:
                 return InternalDownloadFileStatus.Status.DELETION;
             case DOWNLOADED:
-                return InternalDownloadFileStatus.Status.DOWNLOADING;
+                return InternalDownloadFileStatus.Status.DOWNLOADED;
             default:
                 throw new InvalidParameterException("Batch status " + batchStatus + " is unsupported");
         }

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -22,8 +22,6 @@ class ExternalFilePersistence implements FilePersistence {
 
     @Nullable
     private FileOutputStream fileOutputStream;
-    @Nullable
-    private File file;
 
     @Override
     public void initialiseWith(Context context) {
@@ -61,7 +59,7 @@ class ExternalFilePersistence implements FilePersistence {
         }
 
         try {
-            file = new File(absoluteFilePath.path());
+            File file = new File(absoluteFilePath.path());
             boolean parentDirectoriesExist = ensureParentDirectoriesExistFor(file);
 
             if (!parentDirectoriesExist) {
@@ -129,15 +127,16 @@ class ExternalFilePersistence implements FilePersistence {
     }
 
     @Override
-    public void delete() {
-        if (file == null) {
-            Log.w("Cannot delete, you must create the file first");
+    public void delete(FilePath absoluteFilePath) {
+        if (absoluteFilePath == null || absoluteFilePath.isUnknown()) {
+            Log.w("Cannot delete, you must create the file first.");
             return;
         }
 
-        boolean deleted = file.delete();
+        File fileToDelete = new File(absoluteFilePath.path());
+        boolean deleted = fileToDelete.delete();
 
-        String message = String.format("File or Directory: %s deleted: %s", file.getPath(), deleted);
+        String message = String.format("File or Directory: %s deleted: %s", absoluteFilePath.path(), deleted);
         Log.d(getClass().getSimpleName(), message);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -12,7 +12,7 @@ public interface FilePersistence {
 
     boolean write(byte[] buffer, int offset, int numberOfBytesToWrite);
 
-    void delete();
+    void delete(FilePath absoluteFilePath);
 
     long getCurrentSize();
 

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -56,7 +56,7 @@ class FilePersistenceFixtures {
             }
 
             @Override
-            public void delete() {
+            public void delete(FilePath absoluteFilePath) {
                 // do nothing.
             }
 


### PR DESCRIPTION
## Problem
We noticed that the download percentage being displayed in the UI was jumping when it hit the second file 🤔  turns out that when we updated to use `absolute paths` we forgot to update the delete method 😬  it was still attempting to use a `FileName` on the `Context` of the library!

After we did this, downloads still weren't being deleted when the app was restarted 🤔  the library was saying that the `File.status` was `DOWNLOADING` even though the `Batch` was `DOWNLOADED` 😬  turns out there was a bad mapping between `Batch` and `File` statuses where `DOWNLOADED` batch was mapped to a `DOWNLOADING` file 😂 

## Solution
Delete files using an absolute path! Correctly map `DOWNLOADED` batch to `DOWNLOADED` file.