### PR TITLE
V2 error status

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -56,7 +56,7 @@ class DownloadBatch {
         totalBatchSizeBytes = getTotalSize(downloadFiles);
 
         if (totalBatchSizeBytes <= ZERO_BYTES) {
-            DownloadError downloadError = new DownloadError(DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE);
+            Optional<DownloadError> downloadError = Optional.of(new DownloadError(DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE));
             downloadBatchStatus.markAsError(downloadError, downloadsBatchPersistence);
             notifyCallback(downloadBatchStatus);
             return;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -46,7 +46,7 @@ class DownloadBatch {
 
     void download() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
-        if (status == PAUSED || status == DELETION || status == DOWNLOADED) {
+        if (status == PAUSED || status == DELETION) {
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.Nullable;
-
 import java.security.InvalidParameterException;
 
 public interface DownloadBatchStatus {
@@ -44,9 +42,5 @@ public interface DownloadBatchStatus {
 
     long downloadedDateTimeInMillis();
 
-    /**
-     * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
-     */
-    @Nullable
     DownloadError.Error getDownloadErrorType();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.Nullable;
+
 import java.security.InvalidParameterException;
 
 public interface DownloadBatchStatus {
@@ -42,5 +44,9 @@ public interface DownloadBatchStatus {
 
     long downloadedDateTimeInMillis();
 
+    /**
+     * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
+     */
+    @Nullable
     DownloadError.Error getDownloadErrorType();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -47,7 +47,7 @@ class DownloadFile {
     }
 
     void download(final Callback callback) {
-        moveStatusToDownloadingIfQueuedOrError();
+        downloadFileStatus.markAsDownloading();
 
         callback.onUpdate(downloadFileStatus);
 
@@ -144,12 +144,6 @@ class DownloadFile {
     private void updateAndFeedbackWithStatus(Error error, Callback callback) {
         downloadFileStatus.markAsError(error);
         callback.onUpdate(downloadFileStatus);
-    }
-
-    private void moveStatusToDownloadingIfQueuedOrError() {
-        if (downloadFileStatus.isMarkedAsQueued() || downloadFileStatus.isMarkedAsError()) {
-            downloadFileStatus.markAsDownloading();
-        }
     }
 
     void pause() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -49,6 +49,8 @@ class DownloadFile {
     void download(final Callback callback) {
         moveStatusToDownloadingIfQueuedOrError();
 
+        callback.onUpdate(downloadFileStatus);
+
         fileSize = requestTotalFileSizeIfNecessary(fileSize);
 
         if (fileSize.isTotalSizeUnknown()) {
@@ -65,8 +67,6 @@ class DownloadFile {
 
         filePath = result.filePath();
         fileSize.setCurrentSize(filePersistence.getCurrentSize());
-
-        callback.onUpdate(downloadFileStatus);
 
         persistSync();
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -47,9 +47,7 @@ class DownloadFile {
     }
 
     void download(final Callback callback) {
-        callback.onUpdate(downloadFileStatus);
-
-        moveStatusToDownloadingIfQueued();
+        moveStatusToDownloadingIfQueuedOrError();
 
         fileSize = requestTotalFileSizeIfNecessary(fileSize);
 
@@ -67,6 +65,8 @@ class DownloadFile {
 
         filePath = result.filePath();
         fileSize.setCurrentSize(filePersistence.getCurrentSize());
+
+        callback.onUpdate(downloadFileStatus);
 
         persistSync();
 
@@ -146,8 +146,8 @@ class DownloadFile {
         callback.onUpdate(downloadFileStatus);
     }
 
-    private void moveStatusToDownloadingIfQueued() {
-        if (downloadFileStatus.isMarkedAsQueued()) {
+    private void moveStatusToDownloadingIfQueuedOrError() {
+        if (downloadFileStatus.isMarkedAsQueued() || downloadFileStatus.isMarkedAsError()) {
             downloadFileStatus.markAsDownloading();
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -12,7 +12,7 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markForDeletion();
 
-    void markAsError(DownloadError downloadError, DownloadsBatchStatusPersistence persistence);
+    void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence);
 
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
@@ -25,6 +25,6 @@ interface InternalDownloadFileStatus extends DownloadFileStatus {
     void markAsError(DownloadError.Error error);
 
     @Nullable
-    DownloadError error();
+    Optional<DownloadError> error();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.Nullable;
-
 interface InternalDownloadFileStatus extends DownloadFileStatus {
 
     void update(FileSize fileSize, FilePath localFilePath);
@@ -24,7 +22,6 @@ interface InternalDownloadFileStatus extends DownloadFileStatus {
 
     void markAsError(DownloadError.Error error);
 
-    @Nullable
     Optional<DownloadError> error();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.Nullable;
+
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private static final long ZERO_BYTES = 0;
@@ -113,8 +115,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         persistence.updateStatusAsync(downloadBatchId, status);
     }
 
+    @Nullable
     @Override
     public DownloadError.Error getDownloadErrorType() {
-        return downloadError.or(new DownloadError(DownloadError.Error.UNKNOWN)).error();
+        if (downloadError.isPresent()) {
+            return downloadError.get().error();
+        } else {
+            return null;
+        }
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.Nullable;
-
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private static final long ZERO_BYTES = 0;
@@ -16,8 +14,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     private int percentageDownloaded;
     private Status status;
 
-    @Nullable
-    private DownloadError downloadError;
+    private Optional<DownloadError> downloadError = Optional.absent();
 
     LiteDownloadBatchStatus(DownloadBatchId downloadBatchId, DownloadBatchTitle downloadBatchTitle, long downloadedDateTimeInMillis, Status status) {
         this.downloadBatchTitle = downloadBatchTitle;
@@ -100,7 +97,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     }
 
     @Override
-    public void markAsError(DownloadError downloadError, DownloadsBatchStatusPersistence persistence) {
+    public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
         updateStatus(status, persistence);
@@ -116,13 +113,8 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         persistence.updateStatusAsync(downloadBatchId, status);
     }
 
-    @Nullable
     @Override
     public DownloadError.Error getDownloadErrorType() {
-        if (downloadError != null) {
-            return downloadError.error();
-        } else {
-            return null;
-        }
+        return downloadError.or(new DownloadError(DownloadError.Error.UNKNOWN)).error();
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.Nullable;
-
 class LiteDownloadFileStatus implements InternalDownloadFileStatus {
 
     private final DownloadBatchId downloadBatchId;
@@ -10,7 +8,7 @@ class LiteDownloadFileStatus implements InternalDownloadFileStatus {
     private FileSize fileSize;
     private FilePath localFilePath;
     private Status status;
-    private DownloadError downloadError;
+    private Optional<DownloadError> downloadError = Optional.absent();
 
     LiteDownloadFileStatus(DownloadBatchId downloadBatchId, DownloadFileId downloadFileId, Status status, FileSize fileSize, FilePath localFilePath) {
         this.downloadBatchId = downloadBatchId;
@@ -102,12 +100,11 @@ class LiteDownloadFileStatus implements InternalDownloadFileStatus {
     @Override
     public void markAsError(DownloadError.Error error) {
         status = Status.ERROR;
-        downloadError = new DownloadError(error);
+        downloadError = Optional.of(new DownloadError(error));
     }
 
     @Override
-    @Nullable
-    public DownloadError error() {
+    public Optional<DownloadError> error() {
         return downloadError;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
@@ -86,7 +86,7 @@ class LiteDownloadFileStatus implements InternalDownloadFileStatus {
 
     @Override
     public boolean isMarkedAsError() {
-        return status == Status.ERROR && downloadError != null;
+        return status == Status.ERROR;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
@@ -1,10 +1,10 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
-import android.util.Log;
 
 import com.evernote.android.job.JobManager;
 import com.evernote.android.job.JobRequest;
+import com.novoda.notils.logger.simple.Log;
 
 import java.util.concurrent.TimeUnit;
 
@@ -34,7 +34,7 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
                 builder.setRequiredNetworkType(JobRequest.NetworkType.METERED);
                 break;
             default:
-                Log.w(getClass().getSimpleName(), "Unknown ConnectionType: " + connectionType);
+                Log.w("Unknown ConnectionType: " + connectionType);
                 break;
         }
 
@@ -42,5 +42,6 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
         JobManager jobManager = JobManager.instance();
 
         jobManager.schedule(jobRequest);
+        Log.v("Scheduling Network Recovery.");
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.Nullable;
-
 class InternalDownloadBatchStatusFixtures {
 
     private DownloadBatchTitle downloadBatchTitle = DownloadBatchTitleFixtures.aDownloadBatchTitle().build();
@@ -95,7 +93,6 @@ class InternalDownloadBatchStatusFixtures {
                 return downloadedDateTimeInMillis;
             }
 
-            @Nullable
             @Override
             public DownloadError.Error getDownloadErrorType() {
                 return downloadErrorType;
@@ -130,9 +127,9 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
-            public void markAsError(DownloadError downloadError, DownloadsBatchStatusPersistence persistence) {
+            public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
                 status = Status.ERROR;
-                downloadErrorType = downloadError.error();
+                downloadErrorType = downloadError.get().error();
                 persistence.updateStatusAsync(downloadBatchId, status);
             }
 


### PR DESCRIPTION
## Problem
Given a network error occurs when a reschedule job occurs the `download` file status fails to update. 

A batch is marked as `QUEUED` when retrying but the `File` is still marked as error. It will download the file because there aren't checks to block this in the `DownloadFile` but no updates are forwarded to the `UI` because it is blocked. 

## Solution
When the `File.Status == ERROR` mark the `File` as `DOWNLOADING` this will force the `file` to continue downloading and pass updates back to the UI and notification system.

`isMarkedAsError` was checking for an `Error` object which may not exist when coming from persistence layer, so the checks fail for `isMarkedAsError`. Instead we now have `Optional<Error>` and where this is exposed to a client we return either `Error.get` or `null`.