### PR TITLE
File getCurrentSize

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -46,15 +46,9 @@ public class CustomFilePersistence implements FilePersistence {
     }
 
     @Override
-    public long getCurrentSize() {
-        Log.v("getCurrentSize: " + currentSize);
-        return currentSize;
-    }
-
-    @Override
     public long getCurrentSize(FilePath filePath) {
         Log.v("getCurrentSize for " + filePath + ": " + currentSize);
-        return 0;
+        return currentSize;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -66,7 +66,7 @@ class DownloadFile {
         }
 
         filePath = result.filePath();
-        fileSize.setCurrentSize(filePersistence.getCurrentSize());
+        fileSize.setCurrentSize(filePersistence.getCurrentSize(filePath));
 
         persistSync();
 

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -142,13 +142,8 @@ class ExternalFilePersistence implements FilePersistence {
 
     @Override
     public long getCurrentSize(FilePath filePath) {
-        try {
-            File file = new File(filePath.path());
-            return file.length();
-        } catch (NullPointerException e) {
-            Log.e(e, "Error requesting file size for " + filePath.path());
-            return 0;
-        }
+        File file = new File(filePath.path());
+        return file.length();
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -141,21 +141,6 @@ class ExternalFilePersistence implements FilePersistence {
     }
 
     @Override
-    public long getCurrentSize() {
-        if (fileOutputStream == null) {
-            Log.e("Cannot get the current file size, you must create the file first");
-            return 0;
-        }
-
-        try {
-            return fileOutputStream.getChannel().size();
-        } catch (IOException e) {
-            Log.e(e, "Error requesting file size, make sure you create one first");
-            return 0;
-        }
-    }
-
-    @Override
     public long getCurrentSize(FilePath filePath) {
         try {
             FileOutputStream file = new FileOutputStream(filePath.path(), APPEND);

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -143,10 +143,10 @@ class ExternalFilePersistence implements FilePersistence {
     @Override
     public long getCurrentSize(FilePath filePath) {
         try {
-            FileOutputStream file = new FileOutputStream(filePath.path(), APPEND);
-            return file.getChannel().size();
-        } catch (IOException e) {
-            Log.e(e, "Error requesting file size for " + filePath);
+            File file = new File(filePath.path());
+            return file.length();
+        } catch (NullPointerException e) {
+            Log.e(e, "Error requesting file size for " + filePath.path());
             return 0;
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -14,8 +14,6 @@ public interface FilePersistence {
 
     void delete(FilePath absoluteFilePath);
 
-    long getCurrentSize();
-
     long getCurrentSize(FilePath filePath);
 
     void close();

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -106,13 +106,8 @@ class InternalFilePersistence implements FilePersistence {
 
     @Override
     public long getCurrentSize(FilePath filePath) {
-        try {
-            File file = new File(filePath.path());
-            return file.length();
-        } catch (NullPointerException e) {
-            Log.e(e, "Error requesting file size for " + filePath.path());
-            return 0;
-        }
+        File file = new File(filePath.path());
+        return file.length();
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -105,38 +105,13 @@ class InternalFilePersistence implements FilePersistence {
     }
 
     @Override
-    public long getCurrentSize() {
-        if (fileOutputStream == null) {
-            Log.e("Cannot get the current file size, you must create the file first");
-            return 0;
-        }
-
-        try {
-            return fileOutputStream.getChannel().size();
-        } catch (IOException e) {
-            Log.e(e, "Error requesting file size, make sure you create one first");
-            return 0;
-        }
-    }
-
-    @Override
     public long getCurrentSize(FilePath filePath) {
-        File file = new File(filePath.path());
-        FileOutputStream fileOutputStream = null;
         try {
-            fileOutputStream = new FileOutputStream(file);
-            return fileOutputStream.getChannel().size();
-        } catch (IOException e) {
+            File file = new File(filePath.path());
+            return file.length();
+        } catch (NullPointerException e) {
             Log.e(e, "Error requesting file size for " + filePath.path());
             return 0;
-        } finally {
-            if (fileOutputStream != null) {
-                try {
-                    fileOutputStream.close();
-                } catch (IOException e) {
-                    Log.e(e, "Error requesting file size for " + filePath.path());
-                }
-            }
         }
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -61,11 +61,6 @@ class FilePersistenceFixtures {
             }
 
             @Override
-            public long getCurrentSize() {
-                return currentSize;
-            }
-
-            @Override
             public long getCurrentSize(FilePath filePath) {
                 return currentSize;
             }


### PR DESCRIPTION
## Problem
`fileOutputStream.getChannel().size();` is outputting 0 for the file size for internal persistence. I'm unsure as to why this is the case, it seems that `FileChannel` is readonly and shares the position information from the stream. It doesn't seem to guarantee that the `size` is referring to the size of the file as any changes on the stream can influence this `FileChannel` object. 

## Solution
From what I have read it seems generally better to use `File.length` instead or use `Files.size` but that's only available from api 26 and onwards.