### PR TITLE
Queued download when wrong connection type

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -54,7 +54,7 @@ class DownloadBatch {
         }
 
         if (!connectionChecker.isAllowedToDownload()) {
-            downloadBatchStatus.markAsError(Optional.of(new DownloadError(DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE)), downloadsBatchPersistence);
+            downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
             notifyCallback(downloadBatchStatus);
             DownloadsNetworkRecoveryCreator.getInstance().scheduleRecovery();
             return;


### PR DESCRIPTION
Queue instead of mark as error a download when the connection is not the allowed one.
The behaviour is exactly the same as before