### PR TITLE
Duplicate notifications on restart

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
@@ -1,11 +1,11 @@
 package com.novoda.downloadmanager.demo;
 
-import com.novoda.notils.logger.simple.Log;
 import com.novoda.downloadmanager.DownloadBatchId;
 import com.novoda.downloadmanager.DownloadBatchStatus;
 import com.novoda.downloadmanager.DownloadsBatchPersisted;
 import com.novoda.downloadmanager.DownloadsFilePersisted;
 import com.novoda.downloadmanager.DownloadsPersistence;
+import com.novoda.notils.logger.simple.Log;
 
 import java.util.Collections;
 import java.util.List;
@@ -63,5 +63,10 @@ public class CustomDownloadsPersistence implements DownloadsPersistence {
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         Log.v("update batch id: " + downloadBatchId.rawId() + " with status: " + status);
+    }
+
+    @Override
+    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+        Log.v("update batch id: " + downloadBatchId.rawId() + " with notificationSeen: " + notificationSeen);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -204,7 +204,7 @@ class DownloadBatch {
                 downloadBatchStatus.status(),
                 downloadFiles,
                 downloadBatchStatus.downloadedDateTimeInMillis(),
-                false
+                downloadBatchStatus.notificationSeen()
         );
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -203,7 +203,8 @@ class DownloadBatch {
                 downloadBatchStatus.getDownloadBatchId(),
                 downloadBatchStatus.status(),
                 downloadFiles,
-                downloadBatchStatus.downloadedDateTimeInMillis()
+                downloadBatchStatus.downloadedDateTimeInMillis(),
+                false
         );
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 final class DownloadBatchFactory {
 
+    private static final boolean NOTIFICATION_NOT_SEEN = false;
+
     private DownloadBatchFactory() {
         // non instantiable factory class
     }
@@ -66,7 +68,8 @@ final class DownloadBatchFactory {
                 downloadBatchId,
                 downloadBatchTitle,
                 downloadedDateTimeInMillis,
-                DownloadBatchStatus.Status.QUEUED
+                DownloadBatchStatus.Status.QUEUED,
+                NOTIFICATION_NOT_SEEN
         );
 
         return new DownloadBatch(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -49,4 +49,6 @@ public interface DownloadBatchStatus {
      */
     @Nullable
     DownloadError.Error getDownloadErrorType();
+
+    boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -234,7 +234,7 @@ public final class DownloadManagerBuilder {
             notificationManager.createNotificationChannel(notificationChannel);
         }
 
-        NotificationDispatcher notificationDispatcher = new NotificationDispatcher(LOCK, notificationCreator);
+        NotificationDispatcher notificationDispatcher = new NotificationDispatcher(LOCK, notificationCreator, downloadsBatchPersistence);
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 LOCK,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -8,5 +8,5 @@ interface DownloadService {
 
     void stackNotification(NotificationInformation notificationInformation);
 
-    void dismissNotification(NotificationInformation notificationInformation);
+    void dismissStackedNotification(NotificationInformation notificationInformation);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -8,5 +8,7 @@ interface DownloadService {
 
     void stackNotification(NotificationInformation notificationInformation);
 
+    void stackNotificationNotDismissable(NotificationInformation notificationInformation);
+
     void dismissStackedNotification(NotificationInformation notificationInformation);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadService.java
@@ -8,7 +8,7 @@ interface DownloadService {
 
     void stackNotification(NotificationInformation notificationInformation);
 
-    void stackNotificationNotDismissable(NotificationInformation notificationInformation);
+    void stackNotificationNotDismissible(NotificationInformation notificationInformation);
 
     void dismissStackedNotification(NotificationInformation notificationInformation);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
@@ -9,4 +9,6 @@ public interface DownloadsBatchPersisted {
     DownloadBatchTitle downloadBatchTitle();
 
     long downloadedDateTimeInMillis();
+
+    boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -66,11 +66,13 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                 DownloadBatchId downloadBatchId = batchPersisted.downloadBatchId();
                 DownloadBatchTitle downloadBatchTitle = batchPersisted.downloadBatchTitle();
                 long downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
+                boolean notificationSeen = batchPersisted.notificationSeen();
                 InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                         downloadBatchId,
                         downloadBatchTitle,
                         downloadedDateTimeInMillis,
-                        status
+                        status,
+                        notificationSeen
                 );
 
                 List<DownloadFile> downloadFiles = downloadsFilePersistence.loadSync(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
 
-class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
+class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, DownloadsNotificationSeenPersistence {
 
     private final Executor executor;
     private final DownloadsFilePersistence downloadsFilePersistence;
@@ -130,6 +130,19 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
             downloadsPersistence.startTransaction();
             try {
                 downloadsPersistence.update(downloadBatchId, status);
+                downloadsPersistence.transactionSuccess();
+            } finally {
+                downloadsPersistence.endTransaction();
+            }
+        });
+    }
+
+    @Override
+    public void updateNotificationSeenAsync(final DownloadBatchId downloadBatchId, final boolean notificationSeen) {
+        executor.execute(() -> {
+            downloadsPersistence.startTransaction();
+            try {
+                downloadsPersistence.update(downloadBatchId, notificationSeen);
                 downloadsPersistence.transactionSuccess();
             } finally {
                 downloadsPersistence.endTransaction();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -30,7 +30,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                       DownloadBatchId downloadBatchId,
                       DownloadBatchStatus.Status status,
                       List<DownloadFile> downloadFiles,
-                      long downloadedDateTimeInMillis) {
+                      long downloadedDateTimeInMillis,
+                      boolean notificationSeen) {
         executor.execute(() -> {
             downloadsPersistence.startTransaction();
 
@@ -39,7 +40,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence {
                         downloadBatchTitle,
                         downloadBatchId,
                         status,
-                        downloadedDateTimeInMillis
+                        downloadedDateTimeInMillis,
+                        notificationSeen
                 );
                 downloadsPersistence.persistBatch(batchPersisted);
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsNotificationSeenPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsNotificationSeenPersistence.java
@@ -1,0 +1,6 @@
+package com.novoda.downloadmanager;
+
+interface DownloadsNotificationSeenPersistence {
+
+    void updateNotificationSeenAsync(DownloadBatchId downloadBatchId, boolean notificationSeen);
+}

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsPersistence.java
@@ -24,4 +24,6 @@ public interface DownloadsPersistence {
 
     void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 
+    void update(DownloadBatchId downloadBatchId, boolean notificationSeen);
+
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -19,6 +19,4 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
     void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence);
 
     void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence);
-
-    boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -15,4 +15,6 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
     void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence);
 
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
+
+    boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -16,7 +16,4 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
 
-    void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence);
-
-    void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -16,5 +16,9 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
 
+    void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence);
+
+    void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence);
+
     boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -15,14 +15,20 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     private long totalBatchSizeBytes;
     private int percentageDownloaded;
     private Status status;
+    private boolean notificationSeen;
 
     private Optional<DownloadError> downloadError = Optional.absent();
 
-    LiteDownloadBatchStatus(DownloadBatchId downloadBatchId, DownloadBatchTitle downloadBatchTitle, long downloadedDateTimeInMillis, Status status) {
+    LiteDownloadBatchStatus(DownloadBatchId downloadBatchId,
+                            DownloadBatchTitle downloadBatchTitle,
+                            long downloadedDateTimeInMillis,
+                            Status status,
+                            boolean notificationSeen) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.status = status;
+        this.notificationSeen = notificationSeen;
     }
 
     @Override
@@ -123,5 +129,10 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         } else {
             return null;
         }
+    }
+
+    @Override
+    public boolean notificationSeen() {
+        return notificationSeen;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -102,6 +102,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public void markForDeletion() {
         status = Status.DELETION;
+        notificationSeen = false;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -117,6 +117,16 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         updateStatus(status, persistence);
     }
 
+    @Override
+    public void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence) {
+        persistence.updateNotificationSeenAsync(downloadBatchId, true);
+    }
+
+    @Override
+    public void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence) {
+        persistence.updateNotificationSeenAsync(downloadBatchId, false);
+    }
+
     private void updateStatus(Status status, DownloadsBatchStatusPersistence persistence) {
         persistence.updateStatusAsync(downloadBatchId, status);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -117,16 +117,6 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         updateStatus(status, persistence);
     }
 
-    @Override
-    public void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence) {
-        persistence.updateNotificationSeenAsync(downloadBatchId, true);
-    }
-
-    @Override
-    public void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence) {
-        persistence.updateNotificationSeenAsync(downloadBatchId, false);
-    }
-
     private void updateStatus(Status status, DownloadsBatchStatusPersistence persistence) {
         persistence.updateStatusAsync(downloadBatchId, status);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -70,6 +70,14 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
+    public void stackNotificationNotDismissable(NotificationInformation notificationInformation) {
+        stopForeground(true);
+        Notification notification = notificationInformation.getNotification();
+        notification.flags |= Notification.FLAG_ONGOING_EVENT;
+        notificationManagerCompat.notify(NOTIFICATION_TAG, notificationInformation.getId(), notification);
+    }
+
+    @Override
     public void dismissStackedNotification(NotificationInformation notificationInformation) {
         notificationManagerCompat.cancel(NOTIFICATION_TAG, notificationInformation.getId());
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -65,10 +65,6 @@ public class LiteDownloadService extends Service implements DownloadService {
     @Override
     public void stackNotification(NotificationInformation notificationInformation) {
         stopForeground(true);
-        showFinalDownloadedNotification(notificationInformation);
-    }
-
-    private void showFinalDownloadedNotification(NotificationInformation notificationInformation) {
         Notification notification = notificationInformation.getNotification();
         notificationManagerCompat.notify(NOTIFICATION_TAG, notificationInformation.getId(), notification);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -70,7 +70,7 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void stackNotificationNotDismissable(NotificationInformation notificationInformation) {
+    public void stackNotificationNotDismissible(NotificationInformation notificationInformation) {
         stopForeground(true);
         Notification notification = notificationInformation.getNotification();
         notification.flags |= Notification.FLAG_ONGOING_EVENT;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -74,8 +74,7 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void dismissNotification(NotificationInformation notificationInformation) {
-        stopForeground(true);
+    public void dismissStackedNotification(NotificationInformation notificationInformation) {
         notificationManagerCompat.cancel(NOTIFICATION_TAG, notificationInformation.getId());
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
@@ -6,15 +6,18 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     private final DownloadBatchId downloadBatchId;
     private final DownloadBatchStatus.Status status;
     private final long downloadedDateTimeInMillis;
+    private final boolean notificationSeen;
 
     LiteDownloadsBatchPersisted(DownloadBatchTitle downloadBatchTitle,
                                 DownloadBatchId downloadBatchId,
                                 DownloadBatchStatus.Status status,
-                                long downloadedDateTimeInMillis) {
+                                long downloadedDateTimeInMillis,
+                                boolean notificationSeen) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
         this.status = status;
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
+        this.notificationSeen = notificationSeen;
     }
 
     @Override
@@ -35,5 +38,10 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     @Override
     public long downloadedDateTimeInMillis() {
         return downloadedDateTimeInMillis;
+    }
+
+    @Override
+    public boolean notificationSeen() {
+        return notificationSeen;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -16,6 +16,7 @@ class MigrationJob implements Runnable {
 
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
+    private static final boolean NOTIFICATION_NOT_SEEN = false;
 
     private final Context context;
     private final File databasePath;
@@ -98,7 +99,7 @@ class MigrationJob implements Runnable {
                 downloadBatchId,
                 downloadBatchStatus,
                 downloadedDateTimeInMillis,
-                false
+                NOTIFICATION_NOT_SEEN
         );
         downloadsPersistence.persistBatch(persistedBatch);
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -97,7 +97,8 @@ class MigrationJob implements Runnable {
                 downloadBatchTitle,
                 downloadBatchId,
                 downloadBatchStatus,
-                downloadedDateTimeInMillis
+                downloadedDateTimeInMillis,
+                false
         );
         downloadsPersistence.persistBatch(persistedBatch);
 

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -7,6 +7,7 @@ import com.novoda.notils.logger.simple.Log;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETION;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
 class NotificationDispatcher {
 
@@ -45,6 +46,8 @@ class NotificationDispatcher {
             if (status == DOWNLOADED) {
                 notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
                 downloadService.stackNotification(notificationInformation);
+            } else if (status == PAUSED) {
+                downloadService.stackNotificationNotDismissable(notificationInformation);
             } else if (status == DELETION || status == ERROR) {
                 downloadService.stackNotification(notificationInformation);
             } else {

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -47,7 +47,7 @@ class NotificationDispatcher {
                 notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
                 downloadService.stackNotification(notificationInformation);
             } else if (status == PAUSED) {
-                downloadService.stackNotificationNotDismissable(notificationInformation);
+                downloadService.stackNotificationNotDismissible(notificationInformation);
             } else if (status == DELETION || status == ERROR) {
                 downloadService.stackNotification(notificationInformation);
             } else {

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -36,6 +36,7 @@ class NotificationDispatcher {
             NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
             DownloadBatchStatus.Status status = downloadBatchStatus.status();
 
+            downloadService.dismissStackedNotification(notificationInformation);
             if (downloadBatchStatus.notificationSeen()) {
                 Log.v("DownloadBatchStatus: ", downloadBatchStatus.getDownloadBatchId(), " notification has already been seen.");
                 return null;

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -10,12 +10,16 @@ class NotificationDispatcher {
 
     private final Object waitForDownloadService;
     private final NotificationCreator<DownloadBatchStatus> notificationCreator;
+    private final DownloadsNotificationSeenPersistence notificationSeenPersistence;
 
     private DownloadService downloadService;
 
-    NotificationDispatcher(Object waitForDownloadService, NotificationCreator<DownloadBatchStatus> notificationCreator) {
+    NotificationDispatcher(Object waitForDownloadService,
+                           NotificationCreator<DownloadBatchStatus> notificationCreator,
+                           DownloadsNotificationSeenPersistence notificationSeenPersistence) {
         this.waitForDownloadService = waitForDownloadService;
         this.notificationCreator = notificationCreator;
+        this.notificationSeenPersistence = notificationSeenPersistence;
     }
 
     @WorkerThread

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -39,7 +39,7 @@ class NotificationDispatcher {
 
             downloadService.dismissStackedNotification(notificationInformation);
             if (downloadBatchStatus.notificationSeen()) {
-                Log.v("DownloadBatchStatus: ", downloadBatchStatus.getDownloadBatchId(), " notification has already been seen.");
+                Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
                 return null;
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
@@ -23,4 +23,7 @@ class RoomBatch {
 
     @ColumnInfo(name = "batch_downloaded_date_time_in_millis")
     public long downloadedDateTimeInMillis;
+
+    @ColumnInfo(name = "notification_seen")
+    public boolean notificationSeen;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -120,4 +120,11 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
     }
+
+    @Override
+    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+        RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        roomBatch.notificationSeen = notificationSeen;
+        database.roomBatchDao().update(roomBatch);
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -40,6 +40,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
         roomBatch.title = batchPersisted.downloadBatchTitle().asString();
         roomBatch.downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
+        roomBatch.notificationSeen = batchPersisted.notificationSeen();
 
         database.roomBatchDao().insert(roomBatch);
     }
@@ -54,7 +55,8 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
                     DownloadBatchTitleCreator.createFrom(roomBatch.title),
                     DownloadBatchIdCreator.createFrom(roomBatch.id),
                     DownloadBatchStatus.Status.from(roomBatch.status),
-                    roomBatch.downloadedDateTimeInMillis
+                    roomBatch.downloadedDateTimeInMillis,
+                    roomBatch.notificationSeen
             );
             batchPersistedList.add(batchPersisted);
         }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
@@ -7,6 +7,7 @@ final class DownloadsBatchPersistedFixtures {
     private DownloadBatchStatus.Status downloadBatchStatus = DownloadBatchStatus.Status.DOWNLOADED;
     private DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle("title");
     private long downloadedDateTimeInMillis = 123456789L;
+    private boolean notificationSeen = false;
 
     static DownloadsBatchPersistedFixtures aDownloadsBatchPersisted() {
         return new DownloadsBatchPersistedFixtures();
@@ -41,6 +42,11 @@ final class DownloadsBatchPersistedFixtures {
         return this;
     }
 
+    DownloadsBatchPersistedFixtures withNotificationSeen(boolean notificationSeen) {
+        this.notificationSeen = notificationSeen;
+        return this;
+    }
+
     DownloadsBatchPersisted build() {
         return new DownloadsBatchPersisted() {
             @Override
@@ -61,6 +67,11 @@ final class DownloadsBatchPersistedFixtures {
             @Override
             public long downloadedDateTimeInMillis() {
                 return downloadedDateTimeInMillis;
+            }
+
+            @Override
+            public boolean notificationSeen() {
+                return notificationSeen;
             }
         };
     }

--- a/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
@@ -16,22 +16,22 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void startTransaction() {
-
+        // no-op.
     }
 
     @Override
     public void endTransaction() {
-
+        // no-op.
     }
 
     @Override
     public void transactionSuccess() {
-
+        // no-op.
     }
 
     @Override
     public void persistBatch(DownloadsBatchPersisted batchPersisted) {
-
+        // no-op.
     }
 
     @Override
@@ -42,7 +42,7 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistFile(DownloadsFilePersisted filePersisted) {
-
+        // no-op.
     }
 
     @Override
@@ -66,16 +66,16 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
-
+        // no-op.
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-
+        // no-op.
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
-
+        // no-op.
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
@@ -73,4 +73,9 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
 
     }
+
+    @Override
+    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+
+    }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -10,6 +10,7 @@ class InternalDownloadBatchStatusFixtures {
     private DownloadBatchStatus.Status status = DownloadBatchStatus.Status.QUEUED;
     private DownloadError.Error downloadErrorType = null;
     private long downloadedDateTimeInMillis = 123456789L;
+    private boolean notificationSeen = false;
 
     static InternalDownloadBatchStatusFixtures anInternalDownloadsBatchStatus() {
         return new InternalDownloadBatchStatusFixtures();
@@ -52,6 +53,11 @@ class InternalDownloadBatchStatusFixtures {
 
     InternalDownloadBatchStatusFixtures withDownloadErrorType(DownloadError.Error downloadErrorType) {
         this.downloadErrorType = downloadErrorType;
+        return this;
+    }
+
+    InternalDownloadBatchStatusFixtures withNotificationSeen(boolean notificationSeen) {
+        this.notificationSeen = notificationSeen;
         return this;
     }
 
@@ -137,6 +143,11 @@ class InternalDownloadBatchStatusFixtures {
             public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
                 status = Status.DOWNLOADED;
                 persistence.updateStatusAsync(downloadBatchId, status);
+            }
+
+            @Override
+            public boolean notificationSeen() {
+                return notificationSeen;
             }
         };
     }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -146,6 +146,18 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
+            public void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence) {
+                notificationSeen = true;
+                persistence.updateNotificationSeenAsync(downloadBatchId, notificationSeen());
+            }
+
+            @Override
+            public void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence) {
+                notificationSeen = false;
+                persistence.updateNotificationSeenAsync(downloadBatchId, notificationSeen());
+            }
+
+            @Override
             public boolean notificationSeen() {
                 return notificationSeen;
             }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -146,18 +146,6 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
-            public void markNotificationAsSeen(DownloadsNotificationSeenPersistence persistence) {
-                notificationSeen = true;
-                persistence.updateNotificationSeenAsync(downloadBatchId, notificationSeen());
-            }
-
-            @Override
-            public void markNotificationAsNotSeen(DownloadsNotificationSeenPersistence persistence) {
-                notificationSeen = false;
-                persistence.updateNotificationSeenAsync(downloadBatchId, notificationSeen());
-            }
-
-            @Override
             public boolean notificationSeen() {
                 return notificationSeen;
             }

--- a/library/src/test/java/com/novoda/downloadmanager/NotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NotificationDispatcherTest.java
@@ -1,0 +1,129 @@
+package com.novoda.downloadmanager;
+
+import com.novoda.notils.logger.simple.Log;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class NotificationDispatcherTest {
+
+    private static final DownloadBatchStatus QUEUED_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
+    private static final DownloadBatchStatus DOWNLOADING_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build();
+    private static final DownloadBatchStatus PAUSED_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.PAUSED).build();
+    private static final DownloadBatchStatus ERROR_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.ERROR).build();
+    private static final DownloadBatchStatus DELETION_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DELETION).build();
+    private static final DownloadBatchStatus DOWNLOADED_BATCH_STATUS = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADED).build();
+
+    private final NotificationInformation notificationInformation = mock(NotificationInformation.class);
+    private final Object lock = spy(new Object());
+    private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
+    private final DownloadsNotificationSeenPersistence persistence = mock(DownloadsNotificationSeenPersistence.class);
+    private final DownloadService downloadService = mock(DownloadService.class);
+
+    private NotificationDispatcher notificationDispatcher;
+
+    @Before
+    public void setUp() {
+        Log.setShowLogs(false);
+        notificationDispatcher = new NotificationDispatcher(lock, notificationCreator, persistence);
+        notificationDispatcher.setDownloadService(downloadService);
+
+        given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(notificationInformation);
+    }
+
+    @Test
+    public void stacksNotification_whenStatusIsDownloaded() {
+        notificationDispatcher.updateNotification(DOWNLOADED_BATCH_STATUS);
+
+        verify(downloadService).stackNotification(notificationInformation);
+    }
+
+    @Test
+    public void stacksNonDismissibleNotification_whenStatusIsPaused() {
+        notificationDispatcher.updateNotification(PAUSED_BATCH_STATUS);
+
+        verify(downloadService).stackNotificationNotDismissible(notificationInformation);
+    }
+
+    @Test
+    public void stacksNotification_whenStatusIsDeletion() {
+        notificationDispatcher.updateNotification(DELETION_BATCH_STATUS);
+
+        verify(downloadService).stackNotification(notificationInformation);
+    }
+
+    @Test
+    public void stacksNotification_whenStatusIsError() {
+        notificationDispatcher.updateNotification(ERROR_BATCH_STATUS);
+
+        verify(downloadService).stackNotification(notificationInformation);
+    }
+
+    @Test
+    public void updatesNotification_whenStatusIsDownloading() {
+        notificationDispatcher.updateNotification(DOWNLOADING_BATCH_STATUS);
+
+        verify(downloadService).updateNotification(notificationInformation);
+    }
+
+    @Test
+    public void dismissesStackedNotification_whenUpdatingNotification() {
+        List<DownloadBatchStatus> allDownloadBatchStatuses = Arrays.asList(QUEUED_BATCH_STATUS, DOWNLOADING_BATCH_STATUS, PAUSED_BATCH_STATUS, ERROR_BATCH_STATUS, DELETION_BATCH_STATUS, DOWNLOADED_BATCH_STATUS);
+
+        for (DownloadBatchStatus downloadBatchStatus : allDownloadBatchStatuses) {
+            notificationDispatcher.updateNotification(downloadBatchStatus);
+            verify(downloadService).dismissStackedNotification(notificationInformation);
+            reset(downloadService);
+        }
+    }
+
+    @Test
+    public void doesNotUpdateNotificationSeen_whenDownloadBatchStatusIsAnythingButDownloaded() {
+        List<DownloadBatchStatus> allStatusesMinusDownloaded = Arrays.asList(QUEUED_BATCH_STATUS, DOWNLOADING_BATCH_STATUS, PAUSED_BATCH_STATUS, ERROR_BATCH_STATUS, DELETION_BATCH_STATUS);
+
+        for (DownloadBatchStatus downloadBatchStatus : allStatusesMinusDownloaded) {
+            notificationDispatcher.updateNotification(downloadBatchStatus);
+        }
+
+        verifyZeroInteractions(persistence);
+    }
+
+    @Test
+    public void updatesNotificationSeen_whenStatusIsDownloaded() {
+        notificationDispatcher.updateNotification(DOWNLOADED_BATCH_STATUS);
+
+        verify(persistence).updateNotificationSeenAsync(DOWNLOADED_BATCH_STATUS.getDownloadBatchId(), true);
+    }
+
+    @Test
+    public void doesNotUpdateNotifications_whenNotificationHasBeenSeen() {
+        InternalDownloadBatchStatus notificationSeenStatus = InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus().withNotificationSeen(true).build();
+
+        notificationDispatcher.updateNotification(notificationSeenStatus);
+
+        InOrder inOrder = Mockito.inOrder(downloadService);
+        inOrder.verify(downloadService).dismissStackedNotification(any(NotificationInformation.class));
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test(timeout = 500)
+    public void waitsForServiceToExist_whenUpdatingNotification() {
+        notificationDispatcher.setDownloadService(downloadService);
+
+        notificationDispatcher.updateNotification(DOWNLOADING_BATCH_STATUS);
+    }
+
+}


### PR DESCRIPTION
## Problem
1. When restarting the app after having shown a stacked notification, ERROR, DOWNLOADED, then the app will reshow these notifications even when originally they were swiped away by the user.

2. When pausing a download in the `download-manager` sample the notification switches to the other non-paused download. So the user has no idea what happened to the other paused download, we aren't showing a notification for it 😬 

## Solution
1. Add a persisted flag to the `DownloadBatchStatus` for `notificationSeen` that will be triggered when a notification for `DOWNLOADED` is shown. When the app restarts the first event from the `DownloadBatchStatus` will show the `notificationSeen` as true and swallow the notification. For the `ERROR` status the `download-manager` will force a re-queue so a new batch of notifications are required.

2. Add a `stackNotificationNotDismissible` which is used for the `PAUSED` state to show a persistent notification. This can be changed to an ordinary stacked notification if desired. 

## Screen Capture

#### Downloaded 
Before | After
--- | ---
![before_downloaded](https://user-images.githubusercontent.com/3380092/35677177-7db6806e-0746-11e8-9c97-63ef92db82c7.gif) | ![after_downloaded](https://user-images.githubusercontent.com/3380092/35677398-4b5b66b0-0747-11e8-902e-5ba7642384ff.gif)


#### Paused 
Before | After
--- | ---
![before_paused](https://user-images.githubusercontent.com/3380092/35677209-aa1811ae-0746-11e8-8cba-c753b7067fac.gif) | ![after_paused](https://user-images.githubusercontent.com/3380092/35677208-a9f89dce-0746-11e8-896b-f3084376e8d6.gif)

