### PR TITLE
323/revert-back-added-permission

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -4,7 +4,10 @@
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <!--More information here: https://developer.android.com/reference/android/support/v4/content/ContextCompat.html#getExternalFilesDirs(android.content.Context, java.lang.String) -->
+  <uses-permission
+      android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+      android:maxSdkVersion="18" />
 
   <application android:supportsRtl="true">
 


### PR DESCRIPTION
Reverted back the permission settings. More info can be found in #323 and <a href="https://developer.android.com/reference/android/support/v4/content/ContextCompat.html#getExternalFilesDirs(android.content.Context, java.lang.String)">here</a>

I'm sure that this will not have any effect. In fact I tested it by making it downlod to external storage and the download is just successful.

#### Screen recording: 

![external](https://user-images.githubusercontent.com/763339/35685607-7d60caba-076a-11e8-923b-91f3924862b0.gif)

#### File status output

<details>
FileStatus:  LiteDownloadFileStatus{downloadBatchId=LiteDownloadBatchId{id='batch_id_1'}, downloadFileId=LiteDownloadFileId{id='file_id_1'}, fileSize=LiteFileSize{currentSize=5242880, totalSize=5242880}, localFilePath=LiteFilePath{path='/storage/emulated/0/Android/data/com.novoda.downloadmanager.demo.simple/files/foo/bar/5mb.zip'}, status=DOWNLOADED, downloadError=Optional<Absent>} 
</details>

Fixes #323