### PR TITLE
Notification removed on app start

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -37,11 +37,11 @@ class NotificationDispatcher {
             NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
             DownloadBatchStatus.Status status = downloadBatchStatus.status();
 
-            downloadService.dismissStackedNotification(notificationInformation);
             if (downloadBatchStatus.notificationSeen()) {
                 Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
                 return null;
             }
+            downloadService.dismissStackedNotification(notificationInformation);
 
             if (status == DOWNLOADED) {
                 notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);


### PR DESCRIPTION
## Problem
When an asset has been downloaded and a notification is displayed, if the user restarts the app without dismissing the notification then the notification is automatically dismissed 😬 

## Solution
Only remove notifications that a user has already seen and dismissed, otherwise do nothing. Whenever we displayed a notification we remove the previous notification, which is ok except when it is `DOWNLOADED` this could happen when restarting the app and it will just remove it even if the user hasn't dismissed. We don't have to worry about the other stack states because these never trigger the notification dispatching again.

## Screen Capture
Before | After
--- | ---
![before_downloaded](https://user-images.githubusercontent.com/3380092/36094068-bfcca194-0fe4-11e8-96ce-f01a3f3080c3.gif) | ![after_downloaded](https://user-images.githubusercontent.com/3380092/36094069-bfe4bcc0-0fe4-11e8-9032-3e64aa4d6f88.gif)
