### PR TITLE
Client specifies notification stackable or not

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -210,6 +210,11 @@ public class MainActivity extends AppCompatActivity {
 
     private static class MigrationNotificationCustomizer implements NotificationCustomizer<MigrationStatus> {
         @Override
+        public boolean isStackableNotification(MigrationStatus payload) {
+            return false;
+        }
+
+        @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, MigrationStatus payload) {
             return builder
                     .setProgress(payload.totalNumberOfBatchesToMigrate(), payload.numberOfMigratedBatches(), false)

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -211,7 +211,8 @@ public class MainActivity extends AppCompatActivity {
     private static class MigrationNotificationCustomizer implements NotificationCustomizer<MigrationStatus> {
         @Override
         public boolean isStackableNotification(MigrationStatus payload) {
-            return false;
+            MigrationStatus.Status status = payload.status();
+            return status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT;
         }
 
         @Override

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -210,9 +210,14 @@ public class MainActivity extends AppCompatActivity {
 
     private static class MigrationNotificationCustomizer implements NotificationCustomizer<MigrationStatus> {
         @Override
-        public boolean isStackableNotification(MigrationStatus payload) {
+        public NotificationStackState notificationStackState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
-            return status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT;
+
+            if (status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT) {
+                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+            } else {
+                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+            }
         }
 
         @Override

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -42,8 +42,8 @@ dependencies {
     implementation 'android.arch.persistence.room:runtime:1.0.0'
     implementation 'com.evernote:android-job:1.2.0-alpha3'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.13.0'
-    testImplementation 'com.google.truth:truth:0.36'
+    testImplementation 'org.mockito:mockito-core:2.15.0'
+    testImplementation 'com.google.truth:truth:0.39'
 }
 
 publish {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -27,6 +27,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+
 public final class DownloadManagerBuilder {
 
     private static final Object LOCK = new Object();
@@ -314,11 +319,15 @@ public final class DownloadManagerBuilder {
         }
 
         @Override
-        public boolean isStackableNotification(DownloadBatchStatus payload) {
+        public NotificationStackState notificationStackState(DownloadBatchStatus payload) {
             DownloadBatchStatus.Status status = payload.status();
-            return status == DownloadBatchStatus.Status.DELETED
-                    || status == DownloadBatchStatus.Status.DOWNLOADED
-                    || status == DownloadBatchStatus.Status.ERROR;
+            if (status == DOWNLOADED || status == DELETED || status == ERROR) {
+                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+            } else if (status == PAUSED) {
+                return NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
+            } else {
+                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+            }
         }
 
         @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -314,6 +314,14 @@ public final class DownloadManagerBuilder {
         }
 
         @Override
+        public boolean isStackableNotification(DownloadBatchStatus payload) {
+            DownloadBatchStatus.Status status = payload.status();
+            return status == DownloadBatchStatus.Status.DELETED
+                    || status == DownloadBatchStatus.Status.DOWNLOADED
+                    || status == DownloadBatchStatus.Status.ERROR;
+        }
+
+        @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, DownloadBatchStatus payload) {
             DownloadBatchTitle downloadBatchTitle = payload.getDownloadBatchTitle();
             String title = downloadBatchTitle.asString();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -82,7 +82,8 @@ public final class DownloadMigratorBuilder {
 
         @Override
         public boolean isStackableNotification(MigrationStatus payload) {
-            return false;
+            MigrationStatus.Status status = payload.status();
+            return status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT;
         }
 
         @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -81,6 +81,11 @@ public final class DownloadMigratorBuilder {
         }
 
         @Override
+        public boolean isStackableNotification(MigrationStatus payload) {
+            return false;
+        }
+
+        @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, MigrationStatus payload) {
             String title = payload.status().toRawValue();
             String content = resources.getString(R.string.migration_notification_content_progress, payload.percentageMigrated());

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -81,9 +81,14 @@ public final class DownloadMigratorBuilder {
         }
 
         @Override
-        public boolean isStackableNotification(MigrationStatus payload) {
+        public NotificationStackState notificationStackState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
-            return status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT;
+
+            if (status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT) {
+                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+            } else {
+                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+            }
         }
 
         @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -14,8 +14,6 @@ import android.util.Log;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.novoda.downloadmanager.MigrationStatus.Status;
-
 public class LiteDownloadMigrationService extends Service implements DownloadMigrationService {
 
     private static final String TAG = "MigrationService";
@@ -78,7 +76,7 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
         public void onUpdate(MigrationStatus migrationStatus) {
             NotificationInformation notification = notificationCreator.createNotification(migrationStatus);
 
-            if (migrationStatus.status() == Status.COMPLETE || migrationStatus.status() == Status.DB_NOT_PRESENT) {
+            if (notification.isStackable()) {
                 stackNotification(notification);
             } else {
                 updateNotification(notification);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -14,6 +14,8 @@ import android.util.Log;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+
 public class LiteDownloadMigrationService extends Service implements DownloadMigrationService {
 
     private static final String TAG = "MigrationService";
@@ -76,7 +78,7 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
         public void onUpdate(MigrationStatus migrationStatus) {
             NotificationInformation notification = notificationCreator.createNotification(migrationStatus);
 
-            if (notification.isStackable()) {
+            if (notification.notificationStackState() == STACK_NOTIFICATION_DISMISSIBLE) {
                 stackNotification(notification);
             } else {
                 updateNotification(notification);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -14,8 +14,6 @@ import android.util.Log;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
-
 public class LiteDownloadMigrationService extends Service implements DownloadMigrationService {
 
     private static final String TAG = "MigrationService";
@@ -78,10 +76,21 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
         public void onUpdate(MigrationStatus migrationStatus) {
             NotificationInformation notification = notificationCreator.createNotification(migrationStatus);
 
-            if (notification.notificationStackState() == STACK_NOTIFICATION_DISMISSIBLE) {
-                stackNotification(notification);
-            } else {
-                updateNotification(notification);
+            switch (notification.notificationStackState()) {
+                case SINGLE_PERSISTENT_NOTIFICATION:
+                    updateNotification(notification);
+                    break;
+                case STACK_NOTIFICATION_DISMISSIBLE:
+                    stackNotification(notification);
+                    break;
+                case STACK_NOTIFICATION_NOT_DISMISSIBLE:
+                default:
+                    String message = String.format(
+                            "%s: %s is not supported.",
+                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
+                            notification.notificationStackState()
+                    );
+                    throw new IllegalArgumentException(message);
             }
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -36,6 +36,11 @@ class NotificationCreator<T> {
                 NotificationCompat.Builder builder = new NotificationCompat.Builder(applicationContext, notificationChannelProvider.channelId());
                 return notificationCustomizer.customNotificationFrom(builder, notificationPayload);
             }
+
+            @Override
+            public boolean isStackable() {
+                return notificationCustomizer.isStackableNotification(notificationPayload);
+            }
         };
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -38,8 +38,8 @@ class NotificationCreator<T> {
             }
 
             @Override
-            public boolean isStackable() {
-                return notificationCustomizer.isStackableNotification(notificationPayload);
+            public NotificationCustomizer.NotificationStackState notificationStackState() {
+                return notificationCustomizer.notificationStackState(notificationPayload);
             }
         };
     }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
@@ -4,5 +4,8 @@ import android.app.Notification;
 import android.support.v4.app.NotificationCompat;
 
 public interface NotificationCustomizer<T> {
+
+    boolean isStackableNotification(T payload);
+
     Notification customNotificationFrom(NotificationCompat.Builder builder, T payload);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
@@ -5,7 +5,13 @@ import android.support.v4.app.NotificationCompat;
 
 public interface NotificationCustomizer<T> {
 
-    boolean isStackableNotification(T payload);
+    NotificationStackState notificationStackState(T payload);
 
     Notification customNotificationFrom(NotificationCompat.Builder builder, T payload);
+
+    enum NotificationStackState {
+        SINGLE_PERSISTENT_NOTIFICATION,
+        STACK_NOTIFICATION_NOT_DISMISSIBLE,
+        STACK_NOTIFICATION_DISMISSIBLE
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -5,8 +5,6 @@ import android.support.annotation.WorkerThread;
 import com.novoda.notils.logger.simple.Log;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
 
 class NotificationDispatcher {
 
@@ -46,12 +44,23 @@ class NotificationDispatcher {
                 notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
             }
 
-            if (notificationInformation.notificationStackState() == STACK_NOTIFICATION_DISMISSIBLE) {
-                downloadService.stackNotification(notificationInformation);
-            } else if (notificationInformation.notificationStackState() == STACK_NOTIFICATION_NOT_DISMISSIBLE) {
-                downloadService.stackNotificationNotDismissible(notificationInformation);
-            } else {
-                downloadService.updateNotification(notificationInformation);
+            switch (notificationInformation.notificationStackState()) {
+                case SINGLE_PERSISTENT_NOTIFICATION:
+                    downloadService.updateNotification(notificationInformation);
+                    break;
+                case STACK_NOTIFICATION_NOT_DISMISSIBLE:
+                    downloadService.stackNotificationNotDismissible(notificationInformation);
+                    break;
+                case STACK_NOTIFICATION_DISMISSIBLE:
+                    downloadService.stackNotification(notificationInformation);
+                    break;
+                default:
+                    String message = String.format(
+                            "%s: %s is not supported.",
+                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
+                            notificationInformation.notificationStackState()
+                    );
+                    throw new IllegalArgumentException(message);
             }
 
             return null;

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -4,10 +4,9 @@ import android.support.annotation.WorkerThread;
 
 import com.novoda.notils.logger.simple.Log;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
 
 class NotificationDispatcher {
 
@@ -45,11 +44,12 @@ class NotificationDispatcher {
 
             if (status == DOWNLOADED) {
                 notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
+            }
+
+            if (notificationInformation.notificationStackState() == STACK_NOTIFICATION_DISMISSIBLE) {
                 downloadService.stackNotification(notificationInformation);
-            } else if (status == PAUSED) {
+            } else if (notificationInformation.notificationStackState() == STACK_NOTIFICATION_NOT_DISMISSIBLE) {
                 downloadService.stackNotificationNotDismissible(notificationInformation);
-            } else if (status == DELETED || status == ERROR) {
-                downloadService.stackNotification(notificationInformation);
             } else {
                 downloadService.updateNotification(notificationInformation);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
@@ -7,4 +7,6 @@ interface NotificationInformation {
     int getId();
 
     Notification getNotification();
+
+    boolean isStackable();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
@@ -8,5 +8,5 @@ interface NotificationInformation {
 
     Notification getNotification();
 
-    boolean isStackable();
+    NotificationCustomizer.NotificationStackState notificationStackState();
 }

--- a/library/src/test/java/com/novoda/downloadmanager/NotificationInformationFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NotificationInformationFixtures.java
@@ -1,0 +1,51 @@
+package com.novoda.downloadmanager;
+
+import android.app.Notification;
+
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+import static org.mockito.Mockito.mock;
+
+class NotificationInformationFixtures {
+
+    private int id = 0;
+    private Notification notification = mock(Notification.class);
+    private NotificationCustomizer.NotificationStackState notificationStackState = SINGLE_PERSISTENT_NOTIFICATION;
+
+    static NotificationInformationFixtures notificationInformation() {
+        return new NotificationInformationFixtures();
+    }
+
+    NotificationInformationFixtures withId(int id) {
+        this.id = id;
+        return this;
+    }
+
+    NotificationInformationFixtures withNotification(Notification notification) {
+        this.notification = notification;
+        return this;
+    }
+
+    NotificationInformationFixtures withNotificationStackState(NotificationCustomizer.NotificationStackState notificationStackState) {
+        this.notificationStackState = notificationStackState;
+        return this;
+    }
+
+    NotificationInformation build() {
+        return new NotificationInformation() {
+            @Override
+            public int getId() {
+                return id;
+            }
+
+            @Override
+            public Notification getNotification() {
+                return notification;
+            }
+
+            @Override
+            public NotificationCustomizer.NotificationStackState notificationStackState() {
+                return notificationStackState;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Problem 
Currently the client is not able to specify whether a notification should display as stackable or non-stackable, as well as stating whether a notification should be dismissible. 

## Solution
Introduce a `NotificationStackState` enum that defines:
`SINGLE_PERSISTENT_NOTIFICATION`
`STACK_NOTIFICATION_NOT_DISMISSIBLE`
`STACK_NOTIFICATION_DISMISSIBLE`

which when dispatching notifications will determine what method is called on the corresponding `Service`. 

## Future work
- Introduce a new interface that is used to collate the different types of notifications that the `download-manager` supports. Attach this new interface to both the `DownloadService` and the `MigrationService`.
- Ensure that the `MigrationService` deals with all `NotificationStackState`s.
- Repurpose `NotificationDispatcher` that checks the `NotificationStackState` and forwards to the appropriate `Service` method to display the notification.