### PR TITLE
Generic NotificationDispatcher

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.support.annotation.WorkerThread;
-
 import com.novoda.notils.logger.simple.Log;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
@@ -9,65 +7,29 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 class DownloadBatchStatusNotificationDispatcher {
 
     private static final boolean NOTIFICATION_SEEN = true;
-    private final Object waitForDownloadService;
-    private final NotificationCreator<DownloadBatchStatus> notificationCreator;
     private final DownloadsNotificationSeenPersistence notificationSeenPersistence;
+    private final NotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
 
-    private DownloadService downloadService;
-
-    DownloadBatchStatusNotificationDispatcher(Object waitForDownloadService,
-                                              NotificationCreator<DownloadBatchStatus> notificationCreator,
-                                              DownloadsNotificationSeenPersistence notificationSeenPersistence) {
-        this.waitForDownloadService = waitForDownloadService;
-        this.notificationCreator = notificationCreator;
+    DownloadBatchStatusNotificationDispatcher(DownloadsNotificationSeenPersistence notificationSeenPersistence,
+                                              NotificationDispatcher<DownloadBatchStatus> notificationDispatcher) {
         this.notificationSeenPersistence = notificationSeenPersistence;
+        this.notificationDispatcher = notificationDispatcher;
     }
 
-    @WorkerThread
     void updateNotification(DownloadBatchStatus downloadBatchStatus) {
-        WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
-                .thenPerform(executeUpdateNotification(downloadBatchStatus));
-    }
+        if (downloadBatchStatus.notificationSeen()) {
+            Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
+            return;
+        }
 
-    private WaitForDownloadService.ThenPerform.Action<Void> executeUpdateNotification(DownloadBatchStatus downloadBatchStatus) {
-        return () -> {
-            NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
-            DownloadBatchStatus.Status status = downloadBatchStatus.status();
+        if (downloadBatchStatus.status() == DOWNLOADED) {
+            notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
+        }
 
-            if (downloadBatchStatus.notificationSeen()) {
-                Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
-                return null;
-            }
-            downloadService.dismissStackedNotification(notificationInformation);
-
-            if (status == DOWNLOADED) {
-                notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
-            }
-
-            switch (notificationInformation.notificationStackState()) {
-                case SINGLE_PERSISTENT_NOTIFICATION:
-                    downloadService.updateNotification(notificationInformation);
-                    break;
-                case STACK_NOTIFICATION_NOT_DISMISSIBLE:
-                    downloadService.stackNotificationNotDismissible(notificationInformation);
-                    break;
-                case STACK_NOTIFICATION_DISMISSIBLE:
-                    downloadService.stackNotification(notificationInformation);
-                    break;
-                default:
-                    String message = String.format(
-                            "%s: %s is not supported.",
-                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
-                            notificationInformation.notificationStackState()
-                    );
-                    throw new IllegalArgumentException(message);
-            }
-
-            return null;
-        };
+        notificationDispatcher.updateNotification(downloadBatchStatus);
     }
 
     void setDownloadService(DownloadService downloadService) {
-        this.downloadService = downloadService;
+        notificationDispatcher.setDownloadService(downloadService);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -6,7 +6,7 @@ import com.novoda.notils.logger.simple.Log;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 
-class NotificationDispatcher {
+class DownloadBatchStatusNotificationDispatcher {
 
     private static final boolean NOTIFICATION_SEEN = true;
     private final Object waitForDownloadService;
@@ -15,9 +15,9 @@ class NotificationDispatcher {
 
     private DownloadService downloadService;
 
-    NotificationDispatcher(Object waitForDownloadService,
-                           NotificationCreator<DownloadBatchStatus> notificationCreator,
-                           DownloadsNotificationSeenPersistence notificationSeenPersistence) {
+    DownloadBatchStatusNotificationDispatcher(Object waitForDownloadService,
+                                              NotificationCreator<DownloadBatchStatus> notificationCreator,
+                                              DownloadsNotificationSeenPersistence notificationSeenPersistence) {
         this.waitForDownloadService = waitForDownloadService;
         this.notificationCreator = notificationCreator;
         this.notificationSeenPersistence = notificationSeenPersistence;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -261,7 +261,7 @@ public final class DownloadManagerBuilder {
             notificationChannelProvider.registerNotificationChannel(applicationContext);
         }
 
-        NotificationDispatcher notificationDispatcher = new NotificationDispatcher(LOCK, notificationCreator, downloadsBatchPersistence);
+        DownloadBatchStatusNotificationDispatcher notificationDispatcher = new DownloadBatchStatusNotificationDispatcher(LOCK, notificationCreator, downloadsBatchPersistence);
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 LOCK,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -261,7 +261,11 @@ public final class DownloadManagerBuilder {
             notificationChannelProvider.registerNotificationChannel(applicationContext);
         }
 
-        DownloadBatchStatusNotificationDispatcher notificationDispatcher = new DownloadBatchStatusNotificationDispatcher(LOCK, notificationCreator, downloadsBatchPersistence);
+        NotificationDispatcher<DownloadBatchStatus> notificationDispatcher = new NotificationDispatcher<>(LOCK, notificationCreator);
+        DownloadBatchStatusNotificationDispatcher batchStatusNotificationDispatcher = new DownloadBatchStatusNotificationDispatcher(
+                downloadsBatchPersistence,
+                notificationDispatcher
+        );
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 LOCK,
@@ -270,7 +274,7 @@ public final class DownloadManagerBuilder {
                 fileOperations,
                 downloadsBatchPersistence,
                 downloadsFilePersistence,
-                notificationDispatcher,
+                batchStatusNotificationDispatcher,
                 connectionChecker,
                 callbacks,
                 callbackThrottleCreator

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -17,7 +17,7 @@ class LiteDownloadManagerDownloader {
     private final FileOperations fileOperations;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final DownloadsFilePersistence downloadsFilePersistence;
-    private final NotificationDispatcher notificationDispatcher;
+    private final DownloadBatchStatusNotificationDispatcher notificationDispatcher;
     private final List<DownloadBatchStatusCallback> callbacks;
     private final ConnectionChecker connectionChecker;
 
@@ -33,7 +33,7 @@ class LiteDownloadManagerDownloader {
                                   FileOperations fileOperations,
                                   DownloadsBatchPersistence downloadsBatchPersistence,
                                   DownloadsFilePersistence downloadsFilePersistence,
-                                  NotificationDispatcher notificationDispatcher,
+                                  DownloadBatchStatusNotificationDispatcher notificationDispatcher,
                                   ConnectionChecker connectionChecker,
                                   List<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationDispatcher.java
@@ -1,0 +1,56 @@
+package com.novoda.downloadmanager;
+
+import android.support.annotation.WorkerThread;
+
+class NotificationDispatcher<T> {
+
+    private final Object waitForDownloadService;
+    private final NotificationCreator<T> notificationCreator;
+
+    private DownloadService downloadService;
+
+    NotificationDispatcher(Object waitForDownloadService,
+                           NotificationCreator<T> notificationCreator) {
+        this.waitForDownloadService = waitForDownloadService;
+        this.notificationCreator = notificationCreator;
+    }
+
+    @WorkerThread
+    void updateNotification(T payload) {
+        WaitForDownloadService.<Void>waitFor(downloadService, waitForDownloadService)
+                .thenPerform(executeUpdateNotification(payload));
+    }
+
+    private WaitForDownloadService.ThenPerform.Action<Void> executeUpdateNotification(T downloadBatchStatus) {
+        return () -> {
+            NotificationInformation notificationInformation = notificationCreator.createNotification(downloadBatchStatus);
+
+            downloadService.dismissStackedNotification(notificationInformation);
+
+            switch (notificationInformation.notificationStackState()) {
+                case SINGLE_PERSISTENT_NOTIFICATION:
+                    downloadService.updateNotification(notificationInformation);
+                    break;
+                case STACK_NOTIFICATION_NOT_DISMISSIBLE:
+                    downloadService.stackNotificationNotDismissible(notificationInformation);
+                    break;
+                case STACK_NOTIFICATION_DISMISSIBLE:
+                    downloadService.stackNotification(notificationInformation);
+                    break;
+                default:
+                    String message = String.format(
+                            "%s: %s is not supported.",
+                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
+                            notificationInformation.notificationStackState()
+                    );
+                    throw new IllegalArgumentException(message);
+            }
+
+            return null;
+        };
+    }
+
+    void setDownloadService(DownloadService downloadService) {
+        this.downloadService = downloadService;
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
@@ -2,124 +2,61 @@ package com.novoda.downloadmanager;
 
 import com.novoda.notils.logger.simple.Log;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Test;
 
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
-import static com.novoda.downloadmanager.NotificationInformationFixtures.notificationInformation;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DownloadBatchStatusNotificationDispatcherTest {
 
-    private static final DownloadBatchStatus QUEUED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
-    private static final DownloadBatchStatus DOWNLOADING_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build();
-    private static final DownloadBatchStatus PAUSED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.PAUSED).build();
-    private static final DownloadBatchStatus ERROR_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.ERROR).build();
-    private static final DownloadBatchStatus DELETED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DELETED).build();
-    private static final DownloadBatchStatus DOWNLOADED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADED).build();
-
-    private static final NotificationInformation STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_DISMISSIBLE).build();
-    private static final NotificationInformation STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_NOT_DISMISSIBLE).build();
-    private static final NotificationInformation SINGLE_PERSISTENT_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(SINGLE_PERSISTENT_NOTIFICATION).build();
-
-    private final Object lock = spy(new Object());
-    private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
+    private final NotificationDispatcher<DownloadBatchStatus> notificationDispatcher = mock(NotificationDispatcher.class);
     private final DownloadsNotificationSeenPersistence persistence = mock(DownloadsNotificationSeenPersistence.class);
-    private final DownloadService downloadService = mock(DownloadService.class);
 
-    private DownloadBatchStatusNotificationDispatcher notificationDispatcher;
+    private DownloadBatchStatusNotificationDispatcher downloadBatchStatusNotificationDispatcher;
 
     @Before
     public void setUp() {
         Log.setShowLogs(false);
-        given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
-
-        notificationDispatcher = new DownloadBatchStatusNotificationDispatcher(lock, notificationCreator, persistence);
-        notificationDispatcher.setDownloadService(downloadService);
-    }
-
-    @Test
-    public void showsSinglePersistentNotification() {
-        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
-
-        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
-
-        verify(downloadService).updateNotification(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
-    }
-
-    @Test
-    public void stacksNonDismissibleNotification() {
-        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION);
-
-        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
-
-        verify(downloadService).stackNotificationNotDismissible(STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION);
-    }
-
-    @Test
-    public void stacksDismissibleNotification() {
-        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION);
-
-        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
-
-        verify(downloadService).stackNotification(STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION);
-    }
-
-    @Test
-    public void dismissesStackedNotification_whenUpdatingNotification() {
-        List<DownloadBatchStatus> allDownloadBatchStatuses = Arrays.asList(QUEUED_BATCH_STATUS, DOWNLOADING_BATCH_STATUS, PAUSED_BATCH_STATUS, ERROR_BATCH_STATUS, DELETED_BATCH_STATUS, DOWNLOADED_BATCH_STATUS);
-
-        for (DownloadBatchStatus downloadBatchStatus : allDownloadBatchStatuses) {
-            notificationDispatcher.updateNotification(downloadBatchStatus);
-            verify(downloadService).dismissStackedNotification(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
-            reset(downloadService);
-        }
-    }
-
-    @Test
-    public void doesNotUpdateNotificationSeen_whenDownloadBatchStatusIsAnythingButDownloaded() {
-        List<DownloadBatchStatus> allStatusesMinusDownloaded = Arrays.asList(QUEUED_BATCH_STATUS, DOWNLOADING_BATCH_STATUS, PAUSED_BATCH_STATUS, ERROR_BATCH_STATUS, DELETED_BATCH_STATUS);
-
-        for (DownloadBatchStatus downloadBatchStatus : allStatusesMinusDownloaded) {
-            notificationDispatcher.updateNotification(downloadBatchStatus);
-        }
-
-        verifyZeroInteractions(persistence);
+        downloadBatchStatusNotificationDispatcher = new DownloadBatchStatusNotificationDispatcher(persistence, notificationDispatcher);
     }
 
     @Test
     public void updatesNotificationSeen_whenStatusIsDownloaded() {
-        notificationDispatcher.updateNotification(DOWNLOADED_BATCH_STATUS);
+        InternalDownloadBatchStatus downloadedBatchStatus = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADED).build();
 
-        verify(persistence).updateNotificationSeenAsync(DOWNLOADED_BATCH_STATUS.getDownloadBatchId(), true);
+        downloadBatchStatusNotificationDispatcher.updateNotification(downloadedBatchStatus);
+
+        verify(persistence).updateNotificationSeenAsync(downloadedBatchStatus.getDownloadBatchId(), true);
     }
 
     @Test
-    public void doesNotUpdateNotifications_whenNotificationHasBeenSeen() {
+    public void doesNothing_whenNotificationHasBeenSeen() {
         InternalDownloadBatchStatus notificationSeenStatus = anInternalDownloadsBatchStatus().withNotificationSeen(true).build();
 
-        notificationDispatcher.updateNotification(notificationSeenStatus);
+        downloadBatchStatusNotificationDispatcher.updateNotification(notificationSeenStatus);
 
-        verifyZeroInteractions(downloadService);
+        verifyZeroInteractions(notificationDispatcher, persistence);
     }
 
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenUpdatingNotification() {
-        notificationDispatcher.setDownloadService(downloadService);
+    @Test
+    public void updatesNotification_whenNotificationHasNotBeenSeen() {
+        InternalDownloadBatchStatus notificationNotSeenStatus = anInternalDownloadsBatchStatus().withNotificationSeen(false).build();
 
-        notificationDispatcher.updateNotification(DOWNLOADING_BATCH_STATUS);
+        downloadBatchStatusNotificationDispatcher.updateNotification(notificationNotSeenStatus);
+
+        verify(notificationDispatcher).updateNotification(notificationNotSeenStatus);
+    }
+
+    @Test
+    public void setsDownloadServiceOnNotificationDispatcher() {
+        DownloadService downloadService = mock(DownloadService.class);
+
+        downloadBatchStatusNotificationDispatcher.setDownloadService(downloadService);
+
+        verify(notificationDispatcher).setDownloadService(downloadService);
     }
 
 }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-public class NotificationDispatcherTest {
+public class DownloadBatchStatusNotificationDispatcherTest {
 
     private static final DownloadBatchStatus QUEUED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
     private static final DownloadBatchStatus DOWNLOADING_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build();
@@ -39,14 +39,14 @@ public class NotificationDispatcherTest {
     private final DownloadsNotificationSeenPersistence persistence = mock(DownloadsNotificationSeenPersistence.class);
     private final DownloadService downloadService = mock(DownloadService.class);
 
-    private NotificationDispatcher notificationDispatcher;
+    private DownloadBatchStatusNotificationDispatcher notificationDispatcher;
 
     @Before
     public void setUp() {
         Log.setShowLogs(false);
         given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
 
-        notificationDispatcher = new NotificationDispatcher(lock, notificationCreator, persistence);
+        notificationDispatcher = new DownloadBatchStatusNotificationDispatcher(lock, notificationCreator, persistence);
         notificationDispatcher.setDownloadService(downloadService);
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/NotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NotificationDispatcherTest.java
@@ -1,0 +1,96 @@
+package com.novoda.downloadmanager;
+
+import com.novoda.notils.logger.simple.Log;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
+import static com.novoda.downloadmanager.NotificationInformationFixtures.notificationInformation;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class NotificationDispatcherTest {
+
+    private static final DownloadBatchStatus QUEUED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
+    private static final DownloadBatchStatus DOWNLOADING_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build();
+    private static final DownloadBatchStatus PAUSED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.PAUSED).build();
+    private static final DownloadBatchStatus ERROR_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.ERROR).build();
+    private static final DownloadBatchStatus DELETED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DELETED).build();
+    private static final DownloadBatchStatus DOWNLOADED_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADED).build();
+
+    private static final NotificationInformation STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_DISMISSIBLE).build();
+    private static final NotificationInformation STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_NOT_DISMISSIBLE).build();
+    private static final NotificationInformation SINGLE_PERSISTENT_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(SINGLE_PERSISTENT_NOTIFICATION).build();
+
+    private final Object lock = spy(new Object());
+    private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
+    private final DownloadService downloadService = mock(DownloadService.class);
+
+    private NotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
+
+    @Before
+    public void setUp() {
+        Log.setShowLogs(false);
+        given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
+
+        notificationDispatcher = new NotificationDispatcher<>(lock, notificationCreator);
+        notificationDispatcher.setDownloadService(downloadService);
+    }
+
+    @Test
+    public void showsSinglePersistentNotification() {
+        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
+
+        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
+
+        verify(downloadService).updateNotification(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
+    }
+
+    @Test
+    public void stacksNonDismissibleNotification() {
+        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION);
+
+        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
+
+        verify(downloadService).stackNotificationNotDismissible(STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION);
+    }
+
+    @Test
+    public void stacksDismissibleNotification() {
+        given(notificationCreator.createNotification(QUEUED_BATCH_STATUS)).willReturn(STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION);
+
+        notificationDispatcher.updateNotification(QUEUED_BATCH_STATUS);
+
+        verify(downloadService).stackNotification(STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION);
+    }
+
+    @Test
+    public void dismissesStackedNotification_whenUpdatingNotification() {
+        List<DownloadBatchStatus> allDownloadBatchStatuses = Arrays.asList(QUEUED_BATCH_STATUS, DOWNLOADING_BATCH_STATUS, PAUSED_BATCH_STATUS, ERROR_BATCH_STATUS, DELETED_BATCH_STATUS, DOWNLOADED_BATCH_STATUS);
+
+        for (DownloadBatchStatus downloadBatchStatus : allDownloadBatchStatuses) {
+            notificationDispatcher.updateNotification(downloadBatchStatus);
+            verify(downloadService).dismissStackedNotification(SINGLE_PERSISTENT_NOTIFICATION_INFORMATION);
+            reset(downloadService);
+        }
+    }
+
+    @Test(timeout = 500)
+    public void waitsForServiceToExist_whenUpdatingNotification() {
+        notificationDispatcher.setDownloadService(downloadService);
+
+        notificationDispatcher.updateNotification(DOWNLOADING_BATCH_STATUS);
+    }
+
+}


### PR DESCRIPTION
Trying to keep these PRs small because I can 😄 should make reviews quicker and easier, hopefully 💃 

## Problem 
The Migration and standard download functionality have more or less the same logic for receiving a `payload` and dispatching `notifications` but they are represented by two different classes 😬 

## Solution
Create a generic `NotificationDispatcher<T>` that can be used by both the Migration service and the standard Download service. 

Created a clone of the `NotificationDispatcher` currently in the epic branch and made it generic. Added this generic `NotificationDispatcher` to the `DownloadBatchStatusNotificationDispatcher`. `DownloadBatchStatusNotificationDispatcher` now deals with the code specific for `DownloadBatchStatus`, so:
- Do nothing when a notification has already been seen (DOWNLOADED)
- Mark as seen when the status is `DOWNLOADED`
- Dispatch to the generic `NotificationDispatcher<T>` for all other occurrences. 

## Tests Added
Split the tests that were originally in the `NotificationDispatcher` into two. One, the persistence and notification seen check tests have been moved to the `DownloadBatchStatusNotificationDispatcherTest` class. Two, the remaining checks on `NotificationStackState` now exist in the `NotificationDispatcherTest` class.

## Follow up
- Create a generic interface for the Services, Download and Migration, that represents just the displaying of `Notifications`.
- Use the generic `NotificationDispatcher<T>` in the `LiteMigrationService` where we do the same checks for `NotificationStackState` and display notifications.
- Add additional state that represents `do not display anything` 😄 