### PR TITLE
Duplicate files across batches

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -24,12 +24,12 @@ import com.novoda.downloadmanager.DownloadFileIdCreator;
 import com.novoda.downloadmanager.DownloadMigrator;
 import com.novoda.downloadmanager.DownloadMigratorBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
-import com.novoda.downloadmanager.LocalFilesDirectory;
-import com.novoda.downloadmanager.LocalFilesDirectoryFactory;
 import com.novoda.downloadmanager.MigrationCallback;
 import com.novoda.downloadmanager.MigrationStatus;
 import com.novoda.downloadmanager.NotificationCustomizer;
 import com.novoda.notils.logger.simple.Log;
+
+import java.io.File;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
 
@@ -151,11 +151,19 @@ public class MainActivity extends AppCompatActivity {
     };
 
     private final View.OnClickListener logFileDirectoryOnClick = v -> {
-        LocalFilesDirectory localFilesDirectory = LocalFilesDirectoryFactory.create(getApplicationContext());
-        for (String fileName : localFilesDirectory.contents()) {
-            Log.d("LogFileDirectory", fileName);
-        }
+        File[] files = getFilesDir().listFiles();
+        logAllFiles(files);
     };
+
+    private void logAllFiles(File[] files) {
+        for (File file : files) {
+            if (file.isDirectory()) {
+                logAllFiles(file.listFiles());
+            } else {
+                Log.d("LogFileDirectory", file.getAbsolutePath());
+            }
+        }
+    }
 
     private final View.OnClickListener logDownloadFileStatusOnClick = v -> liteDownloadManagerCommands.getDownloadStatusWithMatching(
             FILE_ID_1,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -1,5 +1,6 @@
 package com.novoda.downloadmanager;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,7 +84,7 @@ final class DownloadBatchFactory {
     }
 
     private static String prependBatchIdTo(String filePath, DownloadBatchId downloadBatchId) {
-        return filePath;
+        return sanitizeBatchIdPath(downloadBatchId.rawId()) + File.separatorChar + filePath;
     }
 
     private static String sanitizeBatchIdPath(String batchIdPath) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -1,5 +1,6 @@
 package com.novoda.downloadmanager;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,7 +34,7 @@ final class DownloadBatchFactory {
             FilePersistence filePersistence = filePersistenceCreator.create();
 
             String basePath = filePersistence.basePath().path();
-            FilePath filePath = FilePathCreator.create(basePath, relativePathFrom(batchFile));
+            FilePath filePath = FilePathCreator.create(basePath, prependBatchIdTo(relativePathFrom(batchFile), downloadBatchId));
             FileName fileName = FileNameExtractor.extractFrom(filePath.path());
 
             DownloadFileId downloadFileId = downloadFileIdFrom(batch, batchFile);
@@ -80,6 +81,10 @@ final class DownloadBatchFactory {
                 callbackThrottle,
                 connectionChecker
         );
+    }
+
+    private static String prependBatchIdTo(String filePath, DownloadBatchId downloadBatchId) {
+        return downloadBatchId.rawId() + File.separatorChar + filePath;
     }
 
     private static String relativePathFrom(BatchFile batchFile) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -1,6 +1,5 @@
 package com.novoda.downloadmanager;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -84,7 +83,7 @@ final class DownloadBatchFactory {
     }
 
     private static String prependBatchIdTo(String filePath, DownloadBatchId downloadBatchId) {
-        return sanitizeBatchIdPath(downloadBatchId.rawId()) + File.separatorChar + filePath;
+        return filePath;
     }
 
     private static String sanitizeBatchIdPath(String batchIdPath) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -84,7 +84,11 @@ final class DownloadBatchFactory {
     }
 
     private static String prependBatchIdTo(String filePath, DownloadBatchId downloadBatchId) {
-        return downloadBatchId.rawId() + File.separatorChar + filePath;
+        return sanitizeBatchIdPath(downloadBatchId.rawId()) + File.separatorChar + filePath;
+    }
+
+    private static String sanitizeBatchIdPath(String batchIdPath) {
+        return batchIdPath.replaceAll("[:\\\\/*?|<>]", "_");
     }
 
     private static String relativePathFrom(BatchFile batchFile) {

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -77,6 +77,7 @@ class MigrationJob implements Runnable {
 
             migrateV1DataToV2Database(downloadsPersistence, partialMigration, basePath);
             deleteFrom(database, partialMigration);
+            deleteFiles(partialMigration);
 
             downloadsPersistence.transactionSuccess();
             downloadsPersistence.endTransaction();
@@ -128,10 +129,7 @@ class MigrationJob implements Runnable {
     }
 
     // TODO: See https://github.com/novoda/download-manager/issues/270
-    private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
-        Batch batch = migration.batch();
-        Log.d(TAG, "about to delete the batch: " + batch.downloadBatchId().rawId() + ", time is " + System.nanoTime());
-        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.downloadBatchId().rawId());
+    private void deleteFiles(Migration migration) {
         for (Migration.FileMetadata metadata : migration.getFileMetadata()) {
             if (hasValidFileLocation(metadata)) {
                 File file = new File(metadata.originalFileLocation());
@@ -185,6 +183,12 @@ class MigrationJob implements Runnable {
         database.deleteDatabase();
         migrationStatus.markAsComplete();
         onUpdate(migrationStatus);
+    }
+
+    private void deleteFrom(SqlDatabaseWrapper database, Migration migration) {
+        Batch batch = migration.batch();
+        Log.d(TAG, "about to delete the batch: " + batch.downloadBatchId().rawId() + ", time is " + System.nanoTime());
+        database.delete(TABLE_BATCHES, WHERE_CLAUSE_ID, batch.downloadBatchId().rawId());
     }
 
 }


### PR DESCRIPTION
Create a folder for every batch, containing all the relative files.
The folder uses the batch id as name, sanitised so that it doesn't contain not-allowed chars.
Updated the Main Activity log method to display all the files also in subfolders, so that now we have this log:

```
LogFileDirectory /data/user/0/com.novoda.downloadmanager.demo.simple/files/batch_id_1/foo/bar/5mb.zip 
LogFileDirectory /data/user/0/com.novoda.downloadmanager.demo.simple/files/batch_id_1/10MB.zip 
LogFileDirectory /data/user/0/com.novoda.downloadmanager.demo.simple/files/batch_id_2/10MB.zip 
LogFileDirectory /data/user/0/com.novoda.downloadmanager.demo.simple/files/batch_id_2/20MB.zip 
```