### PR TITLE
Make download error public so that it can be checked by the client

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -1,8 +1,8 @@
 package com.novoda.downloadmanager;
 
-class DownloadError {
+public class DownloadError {
 
-    enum Error {
+    public enum Error {
         FILE_TOTAL_SIZE_REQUEST_FAILED,
         FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE,
         FILE_CANNOT_BE_WRITTEN,


### PR DESCRIPTION
When a download batch status is triggered by our update callbacks, it could be possible that the batch has an error.

We need this error to be public so that a client can check it out.