### PR TITLE
Align Services

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -120,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final MigrationCallback migrationCallback = migrationStatus -> databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
 
-    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration();
+    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration(getDatabasePath("downloads.db"));
 
     private final CompoundButton.OnCheckedChangeListener wifiOnlyOnCheckedChange = (buttonView, isChecked) -> {
         LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -69,6 +69,7 @@ public class MainActivity extends AppCompatActivity {
                         NotificationManagerCompat.IMPORTANCE_DEFAULT
                 )
                 .withNotification(notificationCustomizer)
+                .withMigrationCallback(migrationCallback)
                 .build();
 
         textViewBatch1 = findViewById(R.id.batch_1);

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -120,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final MigrationCallback migrationCallback = migrationStatus -> databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
 
-    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration("downloads.db", migrationCallback);
+    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration();
 
     private final CompoundButton.OnCheckedChangeListener wifiOnlyOnCheckedChange = (buttonView, isChecked) -> {
         LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
@@ -2,5 +2,5 @@ package com.novoda.downloadmanager;
 
 interface DownloadMigrationService extends DownloadManagerService {
 
-    void startMigration(MigrationJob migrationJob);
+    void startMigration(MigrationJob migrationJob, MigrationCallback migrationCallback);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrationService.java
@@ -1,10 +1,6 @@
 package com.novoda.downloadmanager;
 
-interface DownloadMigrationService {
+interface DownloadMigrationService extends DownloadManagerService {
 
-    void setNotificationChannelProvider(NotificationChannelProvider notificationChannelProvider);
-
-    void setNotificationCreator(NotificationCreator<MigrationStatus> notificationCreator);
-
-    void startMigration(String databaseFilename, MigrationCallback migrationCallback);
+    void startMigration(MigrationJob migrationJob);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
@@ -1,7 +1,9 @@
 package com.novoda.downloadmanager;
 
+import java.io.File;
+
 public interface DownloadMigrator {
 
-    void startMigration();
+    void startMigration(File databaseFile);
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
@@ -2,6 +2,6 @@ package com.novoda.downloadmanager;
 
 public interface DownloadMigrator {
 
-    void startMigration(String databaseFilename, MigrationCallback migrationCallback);
+    void startMigration();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -30,7 +30,6 @@ public final class DownloadMigratorBuilder {
 
     private NotificationChannelProvider notificationChannelProvider;
     private NotificationCreator<MigrationStatus> notificationCreator;
-    private DownloadMigrationService migrationService;
     private LiteDownloadMigrator downloadMigrator;
     private MigrationCallback migrationCallback;
 
@@ -95,7 +94,7 @@ public final class DownloadMigratorBuilder {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder binder) {
-                migrationService = ((LiteDownloadMigrationService.MigrationDownloadServiceBinder) binder).getService();
+                DownloadMigrationService migrationService = ((LiteDownloadMigrationService.MigrationDownloadServiceBinder) binder).getService();
                 downloadMigrator.initialise(migrationService);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -108,7 +108,14 @@ public final class DownloadMigratorBuilder {
         Intent serviceIntent = new Intent(applicationContext, LiteDownloadMigrationService.class);
         applicationContext.bindService(serviceIntent, serviceConnection, Context.BIND_AUTO_CREATE);
 
-        downloadMigrator = new LiteDownloadMigrator(applicationContext, LOCK, EXECUTOR, handler, migrationCallback);
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(applicationContext);
+        ServiceNotificationDispatcher<MigrationStatus> notificationDispatcher = new ServiceNotificationDispatcher<>(
+                LOCK,
+                notificationCreator,
+                notificationManager
+        );
+
+        downloadMigrator = new LiteDownloadMigrator(applicationContext, LOCK, EXECUTOR, handler, migrationCallback, notificationDispatcher);
         return downloadMigrator;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -16,10 +16,13 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import java.io.File;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public final class DownloadMigratorBuilder {
 
     private static final Object LOCK = new Object();
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
 
     private final Context applicationContext;
     private final Handler handler;
@@ -103,7 +106,7 @@ public final class DownloadMigratorBuilder {
         Intent serviceIntent = new Intent(applicationContext, LiteDownloadMigrationService.class);
         applicationContext.bindService(serviceIntent, serviceConnection, Context.BIND_AUTO_CREATE);
 
-        downloadMigrator = new LiteDownloadMigrator(applicationContext, databaseFile, LOCK);
+        downloadMigrator = new LiteDownloadMigrator(applicationContext, databaseFile, LOCK, EXECUTOR, handler);
         return downloadMigrator;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -1,37 +1,45 @@
 package com.novoda.downloadmanager;
 
 import android.app.Notification;
-import android.app.NotificationManager;
 import android.app.Service;
-import android.content.Context;
 import android.content.Intent;
 import android.os.Binder;
-import android.os.Build;
 import android.os.IBinder;
+import android.os.PowerManager;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class LiteDownloadMigrationService extends Service implements DownloadMigrationService {
 
+    private static final long TEN_MINUTES_IN_MILLIS = TimeUnit.MINUTES.toMillis(10);
     private static final String TAG = "MigrationService";
-    private static volatile ExecutorService singleInstanceExecutor = Executors.newSingleThreadExecutor();
+    private static final String WAKELOCK_TAG = "MigrationWakelockTag";
 
+    private ExecutorService executor;
     private IBinder binder;
-    private NotificationManager notificationManager;
-    private NotificationChannelProvider notificationChannelProvider;
-    private NotificationCreator<MigrationStatus> notificationCreator;
+    private PowerManager.WakeLock wakeLock;
 
     @Override
     public void onCreate() {
         super.onCreate();
         Log.d(TAG, "onCreate");
+        executor = Executors.newSingleThreadExecutor();
         binder = new MigrationDownloadServiceBinder();
-        notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-
         super.onCreate();
+    }
+
+    @Override
+    public void start(int id, Notification notification) {
+        startForeground(id, notification);
+    }
+
+    @Override
+    public void stop(boolean removeNotification) {
+        stopForeground(removeNotification);
     }
 
     class MigrationDownloadServiceBinder extends Binder {
@@ -47,61 +55,29 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
     }
 
     @Override
-    public void setNotificationChannelProvider(NotificationChannelProvider notificationChannelProvider) {
-        this.notificationChannelProvider = notificationChannelProvider;
+    public void startMigration(MigrationJob migrationJob) {
+        executor.execute(() -> {
+            acquireCpuWakeLock();
+            migrationJob.run();
+            releaseCpuWakeLock();
+        });
+    }
+
+    private void acquireCpuWakeLock() {
+        PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
+        if (powerManager != null) {
+            wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG);
+            wakeLock.acquire(TEN_MINUTES_IN_MILLIS);
+        }
+    }
+
+    private void releaseCpuWakeLock() {
+        wakeLock.release();
     }
 
     @Override
-    public void setNotificationCreator(NotificationCreator<MigrationStatus> notificationCreator) {
-        this.notificationCreator = notificationCreator;
+    public void onDestroy() {
+        executor.shutdown();
+        super.onDestroy();
     }
-
-    @Override
-    public void startMigration(String databaseFilename, MigrationCallback migrationCallback) {
-        createNotificationChannel();
-        MigrationJob migrationJob = new MigrationJob(getApplicationContext(), getDatabasePath(databaseFilename));
-        migrationJob.addCallback(migrationCallback);
-        migrationJob.addCallback(notificationMigrationCallback);
-        singleInstanceExecutor.execute(migrationJob);
-    }
-
-    private void createNotificationChannel() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationChannelProvider.registerNotificationChannel(getApplicationContext());
-        }
-    }
-
-    private final MigrationCallback notificationMigrationCallback = new MigrationCallback() {
-        @Override
-        public void onUpdate(MigrationStatus migrationStatus) {
-            NotificationInformation notification = notificationCreator.createNotification(migrationStatus);
-
-            switch (notification.notificationStackState()) {
-                case SINGLE_PERSISTENT_NOTIFICATION:
-                    updateNotification(notification);
-                    break;
-                case STACK_NOTIFICATION_DISMISSIBLE:
-                    stackNotification(notification);
-                    break;
-                case STACK_NOTIFICATION_NOT_DISMISSIBLE:
-                default:
-                    String message = String.format(
-                            "%s: %s is not supported.",
-                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
-                            notification.notificationStackState()
-                    );
-                    throw new IllegalArgumentException(message);
-            }
-        }
-
-        private void updateNotification(NotificationInformation notificationInformation) {
-            startForeground(notificationInformation.getId(), notificationInformation.getNotification());
-        }
-
-        private void stackNotification(NotificationInformation notificationInformation) {
-            stopForeground(true);
-            Notification notification = notificationInformation.getNotification();
-            notificationManager.notify(notificationInformation.getId(), notification);
-        }
-    };
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrationService.java
@@ -55,7 +55,9 @@ public class LiteDownloadMigrationService extends Service implements DownloadMig
     }
 
     @Override
-    public void startMigration(MigrationJob migrationJob) {
+    public void startMigration(MigrationJob migrationJob, MigrationCallback migrationCallback) {
+        migrationJob.addCallback(migrationCallback);
+
         executor.execute(() -> {
             acquireCpuWakeLock();
             migrationJob.run();

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -4,7 +4,7 @@ staticAnalysis {
     penalty {
         maxErrors = 0
 //      Need to address GH Issue #284 before reducing.
-        maxWarnings = 4
+        maxWarnings = 5
     }
 
     checkstyle {


### PR DESCRIPTION
## Problem
Both of the `Service`s in the `download-manager` behave in different ways in terms of performing an action and reporting the status of that action. Currently the `MigrationService` creates and binds all of it's dependencies and kicks off the migration process. All status events come back to this service at which point it determines which notifications to display and which statuses to forward to the activity. 😬 

## Solution
Change the flow of the `MigrationService` so that the `MigrationBuilder` creates and binds all of the dependencies to the `LiteDownloadMigrator`. The `LiteDownloadMigrator` will trigger a `MigrationJob` when the `Service` is bound using the `Wait` mechanism. The `LiteDownloadMigrator` receives all callbacks and forwards to the `NotificationDispatcher` and the  `MainActivity` if a callback is registered. 

Important to note that the `MigrationService` essentially operates in the same way as the `DownloadService` now.

## Follow-up work
Introduce additional state that represents hiding a notification.