### PR TITLE
Hidden state

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -211,15 +211,15 @@ public class MainActivity extends AppCompatActivity {
 
     private static class MigrationNotificationCustomizer implements NotificationCustomizer<MigrationStatus> {
         @Override
-        public NotificationStackState notificationStackState(MigrationStatus payload) {
+        public NotificationDisplayState notificationDisplayState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
 
             if (status == MigrationStatus.Status.COMPLETE) {
-                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+                return NotificationDisplayState.STACK_NOTIFICATION_DISMISSIBLE;
             } else if (status == MigrationStatus.Status.DB_NOT_PRESENT) {
-                return NotificationStackState.HIDDEN_NOTIFICATION;
+                return NotificationDisplayState.HIDDEN_NOTIFICATION;
             } else {
-                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+                return NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
             }
         }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -214,8 +214,10 @@ public class MainActivity extends AppCompatActivity {
         public NotificationStackState notificationStackState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
 
-            if (status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT) {
+            if (status == MigrationStatus.Status.COMPLETE) {
                 return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+            } else if (status == MigrationStatus.Status.DB_NOT_PRESENT) {
+                return NotificationStackState.HIDDEN_NOTIFICATION;
             } else {
                 return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -330,10 +330,8 @@ public final class DownloadManagerBuilder {
         @Override
         public NotificationStackState notificationStackState(DownloadBatchStatus payload) {
             DownloadBatchStatus.Status status = payload.status();
-            if (status == DOWNLOADED || status == DELETED || status == ERROR) {
+            if (status == DOWNLOADED || status == DELETED || status == ERROR || status == PAUSED) {
                 return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
-            } else if (status == PAUSED) {
-                return NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
             } else {
                 return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -328,12 +328,12 @@ public final class DownloadManagerBuilder {
         }
 
         @Override
-        public NotificationStackState notificationStackState(DownloadBatchStatus payload) {
+        public NotificationDisplayState notificationDisplayState(DownloadBatchStatus payload) {
             DownloadBatchStatus.Status status = payload.status();
             if (status == DOWNLOADED || status == DELETED || status == ERROR || status == PAUSED) {
-                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+                return NotificationDisplayState.STACK_NOTIFICATION_DISMISSIBLE;
             } else {
-                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+                return NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
             }
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -131,8 +131,10 @@ public final class DownloadMigratorBuilder {
         public NotificationStackState notificationStackState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
 
-            if (status == MigrationStatus.Status.COMPLETE || status == MigrationStatus.Status.DB_NOT_PRESENT) {
+            if (status == MigrationStatus.Status.COMPLETE) {
                 return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+            } else if (status == MigrationStatus.Status.DB_NOT_PRESENT) {
+                return NotificationStackState.HIDDEN_NOTIFICATION;
             } else {
                 return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -128,15 +128,15 @@ public final class DownloadMigratorBuilder {
         }
 
         @Override
-        public NotificationStackState notificationStackState(MigrationStatus payload) {
+        public NotificationDisplayState notificationDisplayState(MigrationStatus payload) {
             MigrationStatus.Status status = payload.status();
 
             if (status == MigrationStatus.Status.COMPLETE) {
-                return NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
+                return NotificationDisplayState.STACK_NOTIFICATION_DISMISSIBLE;
             } else if (status == MigrationStatus.Status.DB_NOT_PRESENT) {
-                return NotificationStackState.HIDDEN_NOTIFICATION;
+                return NotificationDisplayState.HIDDEN_NOTIFICATION;
             } else {
-                return NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+                return NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
             }
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -38,8 +38,8 @@ class NotificationCreator<T> {
             }
 
             @Override
-            public NotificationCustomizer.NotificationStackState notificationStackState() {
-                return notificationCustomizer.notificationStackState(notificationPayload);
+            public NotificationCustomizer.NotificationDisplayState notificationDisplayState() {
+                return notificationCustomizer.notificationDisplayState(notificationPayload);
             }
         };
     }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
@@ -5,11 +5,11 @@ import android.support.v4.app.NotificationCompat;
 
 public interface NotificationCustomizer<T> {
 
-    NotificationStackState notificationStackState(T payload);
+    NotificationDisplayState notificationDisplayState(T payload);
 
     Notification customNotificationFrom(NotificationCompat.Builder builder, T payload);
 
-    enum NotificationStackState {
+    enum NotificationDisplayState {
         SINGLE_PERSISTENT_NOTIFICATION,
         STACK_NOTIFICATION_NOT_DISMISSIBLE,
         STACK_NOTIFICATION_DISMISSIBLE,

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
@@ -12,6 +12,7 @@ public interface NotificationCustomizer<T> {
     enum NotificationStackState {
         SINGLE_PERSISTENT_NOTIFICATION,
         STACK_NOTIFICATION_NOT_DISMISSIBLE,
-        STACK_NOTIFICATION_DISMISSIBLE
+        STACK_NOTIFICATION_DISMISSIBLE,
+        HIDDEN_NOTIFICATION
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationInformation.java
@@ -8,5 +8,5 @@ interface NotificationInformation {
 
     Notification getNotification();
 
-    NotificationCustomizer.NotificationStackState notificationStackState();
+    NotificationCustomizer.NotificationDisplayState notificationDisplayState();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -36,7 +36,7 @@ class ServiceNotificationDispatcher<T> {
 
             dismissStackedNotification(notificationInformation);
 
-            switch (notificationInformation.notificationStackState()) {
+            switch (notificationInformation.notificationDisplayState()) {
                 case SINGLE_PERSISTENT_NOTIFICATION:
                     updateNotification(notificationInformation);
                     break;
@@ -52,8 +52,8 @@ class ServiceNotificationDispatcher<T> {
                 default:
                     String message = String.format(
                             "%s: %s is not supported.",
-                            NotificationCustomizer.NotificationStackState.class.getSimpleName(),
-                            notificationInformation.notificationStackState()
+                            NotificationCustomizer.NotificationDisplayState.class.getSimpleName(),
+                            notificationInformation.notificationDisplayState()
                     );
                     throw new IllegalArgumentException(message);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -4,6 +4,8 @@ import android.app.Notification;
 import android.support.annotation.WorkerThread;
 import android.support.v4.app.NotificationManagerCompat;
 
+import com.novoda.notils.logger.simple.Log;
+
 class ServiceNotificationDispatcher<T> {
 
     private static final String NOTIFICATION_TAG = "download-manager";
@@ -43,6 +45,9 @@ class ServiceNotificationDispatcher<T> {
                     break;
                 case STACK_NOTIFICATION_DISMISSIBLE:
                     stackNotification(notificationInformation);
+                    break;
+                case HIDDEN_NOTIFICATION:
+                    Log.d("Notification not required, hiding.");
                     break;
                 default:
                     String message = String.format(

--- a/library/src/test/java/com/novoda/downloadmanager/NotificationInformationFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NotificationInformationFixtures.java
@@ -2,14 +2,14 @@ package com.novoda.downloadmanager;
 
 import android.app.Notification;
 
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
 import static org.mockito.Mockito.mock;
 
 class NotificationInformationFixtures {
 
     private int id = 0;
     private Notification notification = mock(Notification.class);
-    private NotificationCustomizer.NotificationStackState notificationStackState = SINGLE_PERSISTENT_NOTIFICATION;
+    private NotificationCustomizer.NotificationDisplayState notificationDisplayState = SINGLE_PERSISTENT_NOTIFICATION;
 
     static NotificationInformationFixtures notificationInformation() {
         return new NotificationInformationFixtures();
@@ -25,8 +25,8 @@ class NotificationInformationFixtures {
         return this;
     }
 
-    NotificationInformationFixtures withNotificationStackState(NotificationCustomizer.NotificationStackState notificationStackState) {
-        this.notificationStackState = notificationStackState;
+    NotificationInformationFixtures withNotificationDisplayState(NotificationCustomizer.NotificationDisplayState notificationDisplayState) {
+        this.notificationDisplayState = notificationDisplayState;
         return this;
     }
 
@@ -43,8 +43,8 @@ class NotificationInformationFixtures {
             }
 
             @Override
-            public NotificationCustomizer.NotificationStackState notificationStackState() {
-                return notificationStackState;
+            public NotificationCustomizer.NotificationDisplayState notificationDisplayState() {
+                return notificationDisplayState;
             }
         };
     }

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -11,9 +11,10 @@ import org.mockito.InOrder;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.SINGLE_PERSISTENT_NOTIFICATION;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_DISMISSIBLE;
-import static com.novoda.downloadmanager.NotificationCustomizer.NotificationStackState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationDisplayState.HIDDEN_NOTIFICATION;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationDisplayState.STACK_NOTIFICATION_DISMISSIBLE;
+import static com.novoda.downloadmanager.NotificationCustomizer.NotificationDisplayState.STACK_NOTIFICATION_NOT_DISMISSIBLE;
 import static com.novoda.downloadmanager.NotificationInformationFixtures.notificationInformation;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -28,9 +29,10 @@ public class ServiceNotificationDispatcherTest {
 
     private static final DownloadBatchStatus DOWNLOAD_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
 
-    private static final NotificationInformation STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_DISMISSIBLE).build();
-    private static final NotificationInformation STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(STACK_NOTIFICATION_NOT_DISMISSIBLE).build();
-    private static final NotificationInformation SINGLE_PERSISTENT_NOTIFICATION_INFORMATION = notificationInformation().withNotificationStackState(SINGLE_PERSISTENT_NOTIFICATION).build();
+    private static final NotificationInformation STACKABLE_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationDisplayState(STACK_NOTIFICATION_DISMISSIBLE).build();
+    private static final NotificationInformation STACKABLE_NON_DISMISSIBLE_NOTIFICATION_INFORMATION = notificationInformation().withNotificationDisplayState(STACK_NOTIFICATION_NOT_DISMISSIBLE).build();
+    private static final NotificationInformation SINGLE_PERSISTENT_NOTIFICATION_INFORMATION = notificationInformation().withNotificationDisplayState(SINGLE_PERSISTENT_NOTIFICATION).build();
+    private static final NotificationInformation HIDDEN_NOTIFICATION_INFORMATION = notificationInformation().withNotificationDisplayState(HIDDEN_NOTIFICATION).build();
 
     private final Object lock = spy(new Object());
     private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
@@ -95,6 +97,17 @@ public class ServiceNotificationDispatcherTest {
         notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
 
         verify(notificationManager).cancel(NOTIFICATION_TAG, SINGLE_PERSISTENT_NOTIFICATION_INFORMATION.getId());
+    }
+
+    @Test
+    public void doesNothing_whenNotificationIsHidden() {
+        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(HIDDEN_NOTIFICATION_INFORMATION);
+
+        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+        InOrder inOrder = inOrder(downloadService, notificationManager);
+        inOrder.verify(notificationManager).cancel(NOTIFICATION_TAG, HIDDEN_NOTIFICATION_INFORMATION.getId());
+        inOrder.verifyNoMoreInteractions();
     }
 
     @Test(timeout = 500)


### PR DESCRIPTION
## Problem
All of our `NotificationDisplayState`s assume that the client wants to display a notification 😱 

## Solution
Add an additional state that will not show a notification for the currently emitted status, `DownloadBatchStatus` or `MigrationStatus`.

Also updated the `DownloadBatchStatus` side to ensure that `PAUSED` batch notifications are dismissible. 

`NotificationStackState` has been renamed to `NotificationDisplayState` because it's not just the Stack state. 

## Screen Capture

#### Paused

Before | After
--- | ---
![before_paused](https://user-images.githubusercontent.com/3380092/36314814-dc138114-132d-11e8-8e11-f3a5efd7ccc3.gif) | ![after_paused](https://user-images.githubusercontent.com/3380092/36314813-dbfb5c2e-132d-11e8-8f63-86cdc586f252.gif)

#### DB migration

Before | After
--- | ---
![before_db_migrate](https://user-images.githubusercontent.com/3380092/36314844-f74c5758-132d-11e8-813e-dd28cd140b6a.gif) | ![after_db_migrate](https://user-images.githubusercontent.com/3380092/36314843-f731bef2-132d-11e8-9e54-f64c8b96f659.gif)
