### PR TITLE
Use file system for file size

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -15,15 +15,16 @@ class MigrationExtractor {
     private static final int TITLE_COLUMN = 1;
     private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
 
-    private static final String DOWNLOADS_QUERY = "SELECT uri, _data, total_bytes FROM Downloads WHERE batch_id = ?";
+    private static final String DOWNLOADS_QUERY = "SELECT uri, _data FROM Downloads WHERE batch_id = ?";
     private static final int NETWORK_ADDRESS_COLUMN = 0;
     private static final int FILE_LOCATION_COLUMN = 1;
-    private static final int FILE_SIZE_COLUMN = 2;
 
     private final SqlDatabaseWrapper database;
+    private final InternalFilePersistence internalFilePersistence;
 
-    MigrationExtractor(SqlDatabaseWrapper database) {
+    MigrationExtractor(SqlDatabaseWrapper database, InternalFilePersistence internalFilePersistence) {
         this.database = database;
+        this.internalFilePersistence = internalFilePersistence;
     }
 
     List<Migration> extractMigrations() {
@@ -69,7 +70,8 @@ class MigrationExtractor {
                 String originalFileLocation = downloadsCursor.getString(FILE_LOCATION_COLUMN);
                 newBatchBuilder.addFile(originalNetworkAddress).apply();
 
-                long rawFileSize = downloadsCursor.getLong(FILE_SIZE_COLUMN);
+                FilePath filePath = new LiteFilePath(originalFileLocation);
+                long rawFileSize = internalFilePersistence.getCurrentSize(filePath);
                 FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
                 Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileLocation, fileSize, originalNetworkAddress);
                 fileMetadataList.add(fileMetadata);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -41,11 +41,11 @@ class MigrationJob implements Runnable {
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
-        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
-        MigrationExtractor migrationExtractor = new MigrationExtractor(database);
-        DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(context);
         InternalFilePersistence internalFilePersistence = new InternalFilePersistence();
         internalFilePersistence.initialiseWith(context);
+        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
+        MigrationExtractor migrationExtractor = new MigrationExtractor(database, internalFilePersistence);
+        DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(context);
         LocalFilesDirectory localFilesDirectory = new AndroidLocalFilesDirectory(context);
         UnlinkedDataRemover unlinkedDataRemover = new UnlinkedDataRemover(downloadsPersistence, localFilesDirectory);
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -16,7 +16,7 @@ class MigrationJob implements Runnable {
 
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
-    private static final boolean NOTIFICATION_NOT_SEEN = false;
+    private static final boolean NOTIFICATION_SEEN = true;
 
     private final Context context;
     private final File databasePath;
@@ -100,7 +100,7 @@ class MigrationJob implements Runnable {
                 downloadBatchId,
                 downloadBatchStatus,
                 downloadedDateTimeInMillis,
-                NOTIFICATION_NOT_SEEN
+                NOTIFICATION_SEEN
         );
         downloadsPersistence.persistBatch(persistedBatch);
 


### PR DESCRIPTION
## Problem
- When performing a migration from the demo the db transitions to error when in airplane mode. This occurs because the library determines the file size as being incorrect 😬 after some investigation this occurs because we rely on the v1 db as the source of truth for a file size when we should use the file system instead 🎉 

- Notifications are showing for all migrated downloads when restarting the demo application. This will affect production too. This happens because we are marking downloads from the migrator with the `notificationSeen = false` 😬 

## Solution
- Use the file system as a means to determining a file size.

- All migrated files should be marked with `notificationSeen = true` to prevent notifications showing on app restart.

