### PR TITLE
Expose downloads dir

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -152,8 +152,12 @@ public class MainActivity extends AppCompatActivity {
     };
 
     private final View.OnClickListener logFileDirectoryOnClick = v -> {
-        File[] files = getFilesDir().listFiles();
-        logAllFiles(files);
+        LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();
+        File downloadsDir = downloadManagerCommands.getDownloadsDir();
+        Log.d("LogFileDirectory", "Downloads dir:", downloadsDir.getAbsolutePath());
+        if (downloadsDir.exists()) {
+            logAllFiles(downloadsDir.listFiles());
+        }
     };
 
     private void logAllFiles(File[] files) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -6,6 +6,7 @@ import android.support.annotation.WorkerThread;
 
 import com.novoda.notils.logger.simple.Log;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -201,6 +202,13 @@ class DownloadManager implements LiteDownloadManagerCommands {
                 downloadBatch.waitForNetwork();
             }
         }
+    }
+
+    @Override
+    public File getDownloadsDir() {
+        FilePersistence filePersistence = fileOperations.filePersistenceCreator().create();
+        FilePath filePath = filePersistence.basePath();
+        return new File(filePath.path());
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -30,7 +30,7 @@ class ExternalFilePersistence implements FilePersistence {
 
     @Override
     public FilePath basePath() {
-        return FilePathCreator.create(getExternalFileDirWithBiggerAvailableSpace().getAbsolutePath(), "/");
+        return FilePathCreator.create(getExternalFileDirWithBiggerAvailableSpace().getAbsolutePath(), "/downloads/");
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 class ExternalFilePersistence implements FilePersistence {
 
+    private static final String DOWNLOADS_DIR = "/downloads/";
     private static final String UNDEFINED_DIRECTORY_TYPE = null;
     private static final boolean APPEND = true;
 
@@ -30,7 +31,7 @@ class ExternalFilePersistence implements FilePersistence {
 
     @Override
     public FilePath basePath() {
-        return FilePathCreator.create(getExternalFileDirWithBiggerAvailableSpace().getAbsolutePath(), "/downloads/");
+        return FilePathCreator.create(getExternalFileDirWithBiggerAvailableSpace().getAbsolutePath(), DOWNLOADS_DIR);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -13,6 +13,8 @@ import java.io.IOException;
 
 class InternalFilePersistence implements FilePersistence {
 
+    private static final String DOWNLOADS_DIR = "/downloads/";
+
     private Context context;
 
     @Nullable
@@ -25,7 +27,7 @@ class InternalFilePersistence implements FilePersistence {
 
     @Override
     public FilePath basePath() {
-        return FilePathCreator.create(context.getFilesDir().getAbsolutePath(), "/downloads/");
+        return FilePathCreator.create(context.getFilesDir().getAbsolutePath(), DOWNLOADS_DIR);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -25,7 +25,7 @@ class InternalFilePersistence implements FilePersistence {
 
     @Override
     public FilePath basePath() {
-        return FilePathCreator.create(context.getFilesDir().getAbsolutePath(), "/");
+        return FilePathCreator.create(context.getFilesDir().getAbsolutePath(), "/downloads/");
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
+import java.io.File;
 import java.util.List;
 
 public interface LiteDownloadManagerCommands {
@@ -33,4 +34,6 @@ public interface LiteDownloadManagerCommands {
     void getDownloadStatusWithMatching(DownloadFileId downloadFileId, DownloadFileStatusCallback callback);
 
     void updateAllowedConnectionType(ConnectionType allowedConnectionType);
+
+    File getDownloadsDir();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -20,11 +20,11 @@ class MigrationExtractor {
     private static final int FILE_LOCATION_COLUMN = 1;
 
     private final SqlDatabaseWrapper database;
-    private final InternalFilePersistence internalFilePersistence;
+    private final FilePersistence filePersistence;
 
-    MigrationExtractor(SqlDatabaseWrapper database, InternalFilePersistence internalFilePersistence) {
+    MigrationExtractor(SqlDatabaseWrapper database, FilePersistence filePersistence) {
         this.database = database;
-        this.internalFilePersistence = internalFilePersistence;
+        this.filePersistence = filePersistence;
     }
 
     List<Migration> extractMigrations() {
@@ -71,7 +71,7 @@ class MigrationExtractor {
                 newBatchBuilder.addFile(originalNetworkAddress).apply();
 
                 FilePath filePath = new LiteFilePath(originalFileLocation);
-                long rawFileSize = internalFilePersistence.getCurrentSize(filePath);
+                long rawFileSize = filePersistence.getCurrentSize(filePath);
                 FileSize fileSize = new LiteFileSize(rawFileSize, rawFileSize);
                 Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileLocation, fileSize, originalNetworkAddress);
                 fileMetadataList.add(fileMetadata);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -41,7 +41,8 @@ class MigrationJob implements Runnable {
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
-        InternalFilePersistence internalFilePersistence = new InternalFilePersistence();
+        InternalFilePersistence internalFilePersistence =
+                (InternalFilePersistence) FilePersistenceCreator.newInternalFilePersistenceCreator(context).create();
         internalFilePersistence.initialiseWith(context);
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
         MigrationExtractor migrationExtractor = new MigrationExtractor(database, internalFilePersistence);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -41,11 +41,10 @@ class MigrationJob implements Runnable {
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
-        InternalFilePersistence internalFilePersistence =
-                (InternalFilePersistence) FilePersistenceCreator.newInternalFilePersistenceCreator(context).create();
-        internalFilePersistence.initialiseWith(context);
+        FilePersistence filePersistence = FilePersistenceCreator.newInternalFilePersistenceCreator(context).create();
+        filePersistence.initialiseWith(context);
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
-        MigrationExtractor migrationExtractor = new MigrationExtractor(database, internalFilePersistence);
+        MigrationExtractor migrationExtractor = new MigrationExtractor(database, filePersistence);
         DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(context);
         LocalFilesDirectory localFilesDirectory = new AndroidLocalFilesDirectory(context);
         UnlinkedDataRemover unlinkedDataRemover = new UnlinkedDataRemover(downloadsPersistence, localFilesDirectory);
@@ -56,7 +55,7 @@ class MigrationJob implements Runnable {
 
         Log.d(TAG, "about to extract migrations, time is " + System.nanoTime());
 
-        String basePath = internalFilePersistence.basePath().path();
+        String basePath = filePersistence.basePath().path();
         migratePartialDownloads(database, partialDownloadMigrationExtractor, downloadsPersistence, basePath);
         migrateCompleteDownloads(migrationStatus, database, migrationExtractor, downloadsPersistence, basePath);
     }


### PR DESCRIPTION
A client might want to keep download files separate from other files stored in internal storage, so by default we store files in a `downloads` directory, both for internal and external storage.
A client can always override this creating a custom FilePersistence.
Expose that directory through the `LiteDownloadManagerCommands` interface, for easier access for the clients