### PR TITLE
On network error, not all scenarios recovers

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -48,14 +48,15 @@ class NetworkFileDownloader implements FileDownloader {
 
     private void processResponse(Callback callback, HttpClient.NetworkResponse response, int responseCode) throws IOException {
         if (isValid(responseCode)) {
-            InputStream in = response.openByteStream();
             byte[] buffer = new byte[BUFFER_SIZE];
             int readLast = 0;
-            while (canDownload && readLast != -1) {
-                readLast = in.read(buffer);
+            try (InputStream in = response.openByteStream()) {
+                while (canDownload && readLast != -1) {
+                    readLast = in.read(buffer);
 
-                if (readLast != 0 && readLast != -1) {
-                    callback.onBytesRead(buffer, readLast);
+                    if (readLast != 0 && readLast != -1) {
+                        callback.onBytesRead(buffer, readLast);
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
When a batch has a network error, we currently submit the batch for recovery but we do not mark the batch as queued and keeps with an error.

The fix is to ensure that the batch is marked as queued and submitted for recovery when there is a network error. This solves all situations and the batch is able to continue even when there is an HTTP error produced while switching to airplane mode.

There was also a problem when retrieving the full size of the batch. When there was a network error we were not submitting the batch for recovery so that the batch was lost forever.

![after mp4](https://user-images.githubusercontent.com/2845931/36441360-4bde3d6a-166a-11e8-9993-0ff21121d910.gif)

