### PR TITLE
Use thread safe collections

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -73,13 +73,6 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void download(Batch batch) {
-        // if device is connected to the internet
-        // and the type of the connection is allowed
-        // then start immediately
-        // else, schedule a job with window 1ms-1day
-
-        // if the job fails because of network issues, then schedule a job with window 1ms-1day
-
         downloader.download(batch, downloadBatchMap);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -21,7 +21,9 @@ import com.novoda.notils.logger.simple.Log;
 import com.squareup.okhttp.OkHttpClient;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -236,7 +238,7 @@ public final class DownloadManagerBuilder {
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloader);
-        ArrayList<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
+        List<DownloadBatchStatusCallback> callbacks = Collections.synchronizedList(new ArrayList<>());
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(
                 callbackThrottleCreatorType,
@@ -289,7 +291,7 @@ public final class DownloadManagerBuilder {
                 LOCK,
                 EXECUTOR,
                 callbackHandler,
-                new HashMap<>(),
+                Collections.synchronizedMap(new HashMap<>()),
                 callbacks,
                 fileOperations,
                 downloadsBatchPersistence,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -21,9 +21,7 @@ import com.novoda.notils.logger.simple.Log;
 import com.squareup.okhttp.OkHttpClient;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -238,7 +236,7 @@ public final class DownloadManagerBuilder {
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloader);
-        List<DownloadBatchStatusCallback> callbacks = Collections.synchronizedList(new ArrayList<>());
+        ArrayList<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(
                 callbackThrottleCreatorType,
@@ -291,7 +289,7 @@ public final class DownloadManagerBuilder {
                 LOCK,
                 EXECUTOR,
                 callbackHandler,
-                Collections.synchronizedMap(new HashMap<>()),
+                new HashMap<>(),
                 callbacks,
                 fileOperations,
                 downloadsBatchPersistence,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
@@ -272,6 +273,8 @@ public final class DownloadManagerBuilder {
                 notificationDispatcher
         );
 
+        Semaphore semaphore = new Semaphore(1);
+
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 LOCK,
                 EXECUTOR,
@@ -282,7 +285,8 @@ public final class DownloadManagerBuilder {
                 batchStatusNotificationDispatcher,
                 connectionChecker,
                 callbacks,
-                callbackThrottleCreator
+                callbackThrottleCreator,
+                semaphore
         );
 
         downloadManager = new DownloadManager(
@@ -294,7 +298,8 @@ public final class DownloadManagerBuilder {
                 fileOperations,
                 downloadsBatchPersistence,
                 downloader,
-                connectionChecker
+                connectionChecker,
+                semaphore
         );
 
         return downloadManager;

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -24,7 +25,12 @@ import static com.novoda.downloadmanager.DownloadFileStatusFixtures.aDownloadFil
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class DownloadManagerTest {
 
@@ -51,8 +57,9 @@ public class DownloadManagerTest {
     private final FileDownloader fileDownloader = mock(FileDownloader.class);
     private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
     private final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
-
     private final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
+    private final Semaphore semaphore = mock(Semaphore.class);
+
     private DownloadManager downloadManager;
     private Map<DownloadBatchId, DownloadBatch> downloadBatches = new HashMap<>();
     private List<DownloadBatchStatus> downloadBatchStatuses = new ArrayList<>();
@@ -76,7 +83,8 @@ public class DownloadManagerTest {
                 fileOperations,
                 downloadsBatchPersistence,
                 downloadManagerDownloader,
-                connectionChecker
+                connectionChecker,
+                semaphore
         );
 
         setupDownloadBatchesResponse();


### PR DESCRIPTION
## Problem
Experiencing crashes on client application because we are iterating through the `BatchStatusCallback`s at the same time as trying to add them from different threads 😱 

## Solution
Use a synchronized block for accessing the `downloadBatchStatusCallback`s.