### PR TITLE
Check if a file is fully downloaded before creating a new file

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -30,7 +30,7 @@ public class CustomFilePersistence implements FilePersistence {
     @Override
     public FilePersistenceResult create(FilePath absoluteFilePath, FileSize fileSize) {
         Log.v("create " + absoluteFilePath.toString() + ", " + fileSize.toString());
-        return FilePersistenceResult.newInstance(FilePersistenceResult.Status.SUCCESS);
+        return FilePersistenceResult.SUCCESS;
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -46,7 +46,7 @@ class DownloadFile {
         this.downloadsFilePersistence = downloadsFilePersistence;
     }
 
-    void download(final Callback callback) {
+    void download(Callback callback) {
         downloadFileStatus.markAsDownloading();
 
         callback.onUpdate(downloadFileStatus);
@@ -58,14 +58,6 @@ class DownloadFile {
             return;
         }
 
-        FilePersistenceResult result = filePersistence.create(filePath, fileSize);
-        if (result.isMarkedAsError()) {
-            Error error = convertError(result.status());
-            updateAndFeedbackWithStatus(error, callback);
-            return;
-        }
-
-        filePath = result.filePath();
         fileSize.setCurrentSize(filePersistence.getCurrentSize(filePath));
 
         persistSync();
@@ -73,6 +65,13 @@ class DownloadFile {
         if (fileSize.currentSize() == fileSize.totalSize()) {
             downloadFileStatus.update(fileSize, filePath);
             callback.onUpdate(downloadFileStatus);
+            return;
+        }
+
+        FilePersistenceResult result = filePersistence.create(filePath, fileSize);
+        if (result != FilePersistenceResult.SUCCESS) {
+            Error error = convertError(result);
+            updateAndFeedbackWithStatus(error, callback);
             return;
         }
 
@@ -109,7 +108,7 @@ class DownloadFile {
         });
     }
 
-    private Error convertError(FilePersistenceResult.Status status) {
+    private Error convertError(FilePersistenceResult status) {
         switch (status) {
             case SUCCESS:
                 Log.e("Cannot convert success status to any DownloadError type");

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -5,7 +5,6 @@ import android.os.Environment;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 
-import com.novoda.downloadmanager.FilePersistenceResult.Status;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.File;
@@ -37,18 +36,18 @@ class ExternalFilePersistence implements FilePersistence {
     @Override
     public FilePersistenceResult create(FilePath absoluteFilePath, FileSize fileSize) {
         if (fileSize.isTotalSizeUnknown()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_UNKNOWN_TOTAL_FILE_SIZE);
+            return FilePersistenceResult.ERROR_UNKNOWN_TOTAL_FILE_SIZE;
         }
 
         if (!isExternalStorageWritable()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_EXTERNAL_STORAGE_NON_WRITABLE);
+            return FilePersistenceResult.ERROR_EXTERNAL_STORAGE_NON_WRITABLE;
         }
 
         File externalFileDir = getExternalFileDirWithBiggerAvailableSpace();
 
         long usableSpace = externalFileDir.getUsableSpace();
         if (usableSpace < fileSize.totalSize()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_INSUFFICIENT_SPACE);
+            return FilePersistenceResult.ERROR_INSUFFICIENT_SPACE;
         }
 
         return create(absoluteFilePath);
@@ -56,7 +55,7 @@ class ExternalFilePersistence implements FilePersistence {
 
     private FilePersistenceResult create(FilePath absoluteFilePath) {
         if (absoluteFilePath.isUnknown()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE, absoluteFilePath);
+            return FilePersistenceResult.ERROR_OPENING_FILE;
         }
 
         try {
@@ -64,16 +63,16 @@ class ExternalFilePersistence implements FilePersistence {
             boolean parentDirectoriesExist = ensureParentDirectoriesExistFor(file);
 
             if (!parentDirectoriesExist) {
-                return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE, absoluteFilePath);
+                return FilePersistenceResult.ERROR_OPENING_FILE;
             }
 
             fileOutputStream = new FileOutputStream(file, APPEND);
         } catch (FileNotFoundException e) {
             Log.e(e, "File could not be opened");
-            return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE);
+            return FilePersistenceResult.ERROR_OPENING_FILE;
         }
 
-        return FilePersistenceResult.newInstance(Status.SUCCESS, absoluteFilePath);
+        return FilePersistenceResult.SUCCESS;
     }
 
     private boolean ensureParentDirectoriesExistFor(File outputFile) {

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistenceResult.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistenceResult.java
@@ -1,40 +1,10 @@
 package com.novoda.downloadmanager;
 
-public final class FilePersistenceResult {
+public enum FilePersistenceResult {
 
-    public enum Status {
-        SUCCESS,
-        ERROR_UNKNOWN_TOTAL_FILE_SIZE,
-        ERROR_INSUFFICIENT_SPACE,
-        ERROR_EXTERNAL_STORAGE_NON_WRITABLE,
-        ERROR_OPENING_FILE
-    }
-
-    private final Status status;
-    private final FilePath filePath;
-
-    public static FilePersistenceResult newInstance(Status status) {
-        return new FilePersistenceResult(status, FilePathCreator.unknownFilePath());
-    }
-
-    public static FilePersistenceResult newInstance(Status status, FilePath filePath) {
-        return new FilePersistenceResult(status, filePath);
-    }
-
-    private FilePersistenceResult(Status status, FilePath filePath) {
-        this.status = status;
-        this.filePath = filePath;
-    }
-
-    boolean isMarkedAsError() {
-        return status != Status.SUCCESS;
-    }
-
-    public Status status() {
-        return status;
-    }
-
-    public FilePath filePath() {
-        return filePath;
-    }
+    SUCCESS,
+    ERROR_UNKNOWN_TOTAL_FILE_SIZE,
+    ERROR_INSUFFICIENT_SPACE,
+    ERROR_EXTERNAL_STORAGE_NON_WRITABLE,
+    ERROR_OPENING_FILE
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -3,7 +3,6 @@ package com.novoda.downloadmanager;
 import android.content.Context;
 import android.support.annotation.Nullable;
 
-import com.novoda.downloadmanager.FilePersistenceResult.Status;
 import com.novoda.notils.logger.simple.Log;
 
 import java.io.File;
@@ -33,12 +32,12 @@ class InternalFilePersistence implements FilePersistence {
     @Override
     public FilePersistenceResult create(FilePath absoluteFilePath, FileSize fileSize) {
         if (fileSize.isTotalSizeUnknown()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_UNKNOWN_TOTAL_FILE_SIZE);
+            return FilePersistenceResult.ERROR_UNKNOWN_TOTAL_FILE_SIZE;
         }
 
         long usableSpace = context.getFilesDir().getUsableSpace();
         if (usableSpace < fileSize.totalSize()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_INSUFFICIENT_SPACE);
+            return FilePersistenceResult.ERROR_INSUFFICIENT_SPACE;
         }
 
         return create(absoluteFilePath);
@@ -46,7 +45,7 @@ class InternalFilePersistence implements FilePersistence {
 
     private FilePersistenceResult create(FilePath absoluteFilePath) {
         if (absoluteFilePath.isUnknown()) {
-            return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE, absoluteFilePath);
+            return FilePersistenceResult.ERROR_OPENING_FILE;
         }
 
         try {
@@ -54,16 +53,16 @@ class InternalFilePersistence implements FilePersistence {
             boolean parentDirectoriesExist = ensureParentDirectoriesExistFor(outputFile);
 
             if (!parentDirectoriesExist) {
-                return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE, absoluteFilePath);
+                return FilePersistenceResult.ERROR_OPENING_FILE;
             }
 
             fileOutputStream = new FileOutputStream(outputFile, true);
         } catch (FileNotFoundException e) {
             Log.e(e, "File could not be opened");
-            return FilePersistenceResult.newInstance(Status.ERROR_OPENING_FILE);
+            return FilePersistenceResult.ERROR_OPENING_FILE;
         }
 
-        return FilePersistenceResult.newInstance(Status.SUCCESS, absoluteFilePath);
+        return FilePersistenceResult.SUCCESS;
     }
 
     private boolean ensureParentDirectoriesExistFor(File outputFile) {

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -4,7 +4,7 @@ import android.content.Context;
 
 class FilePersistenceFixtures {
 
-    private FilePersistenceResult filePersistenceResult = FilePersistenceResult.newInstance(FilePersistenceResult.Status.SUCCESS);
+    private FilePersistenceResult filePersistenceResult = FilePersistenceResult.SUCCESS;
     private boolean writeResult = true;
     private long currentSize = 100;
     private FilePersistenceType filePersistenceType = FilePersistenceType.INTERNAL;


### PR DESCRIPTION
**Problem**
Given one download has fully finished, and a second download runs out of space
when the download manager restarts
then the downloaded batch appears also as a failure

**Solution**
I have moved the check for the fully downloaded batch before the creation of the file, in the way I have realised that the `basePath` from the getter in the `FilePersistenceResult` has the same value passed in the constructor, so I've eliminated it altogether