### PR TITLE
Use CopyOnWriteArrayList in order to avoid using a synchronized object

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -15,7 +15,6 @@ import java.util.concurrent.ExecutorService;
 class DownloadManager implements LiteDownloadManagerCommands {
 
     private final Object waitForDownloadService;
-    private final Object waitForDownloadBatchStatusCallback;
     private final ExecutorService executor;
     private final Handler callbackHandler;
     private final Map<DownloadBatchId, DownloadBatch> downloadBatchMap;
@@ -30,7 +29,6 @@ class DownloadManager implements LiteDownloadManagerCommands {
     // DownloadManager is a complex object.
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
     DownloadManager(Object waitForDownloadService,
-                    Object waitForDownloadBatchStatusCallback,
                     ExecutorService executor,
                     Handler callbackHandler,
                     Map<DownloadBatchId, DownloadBatch> downloadBatchMap,
@@ -40,7 +38,6 @@ class DownloadManager implements LiteDownloadManagerCommands {
                     LiteDownloadManagerDownloader downloader,
                     ConnectionChecker connectionChecker) {
         this.waitForDownloadService = waitForDownloadService;
-        this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;
         this.callbackHandler = callbackHandler;
         this.downloadBatchMap = downloadBatchMap;
@@ -117,17 +114,13 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void addDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback) {
-        synchronized (waitForDownloadBatchStatusCallback) {
-            callbacks.add(downloadBatchCallback);
-        }
+        callbacks.add(downloadBatchCallback);
     }
 
     @Override
     public void removeDownloadBatchCallback(DownloadBatchStatusCallback downloadBatchCallback) {
-        synchronized (waitForDownloadBatchStatusCallback) {
-            if (callbacks.contains(downloadBatchCallback)) {
-                callbacks.remove(downloadBatchCallback);
-            }
+        if (callbacks.contains(downloadBatchCallback)) {
+            callbacks.remove(downloadBatchCallback);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -20,8 +20,9 @@ import com.novoda.merlin.MerlinsBeard;
 import com.novoda.notils.logger.simple.Log;
 import com.squareup.okhttp.OkHttpClient;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -35,7 +36,6 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 public final class DownloadManagerBuilder {
 
     private static final Object SERVICE_LOCK = new Object();
-    private static final Object CALLBACK_LOCK = new Object();
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
     private static final int TIMEOUT = 5;
 
@@ -237,7 +237,7 @@ public final class DownloadManagerBuilder {
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloader);
-        ArrayList<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
+        List<DownloadBatchStatusCallback> callbacks = new CopyOnWriteArrayList<>();
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(
                 callbackThrottleCreatorType,
@@ -275,7 +275,6 @@ public final class DownloadManagerBuilder {
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 SERVICE_LOCK,
-                CALLBACK_LOCK,
                 EXECUTOR,
                 callbackHandler,
                 fileOperations,
@@ -289,7 +288,6 @@ public final class DownloadManagerBuilder {
 
         downloadManager = new DownloadManager(
                 SERVICE_LOCK,
-                CALLBACK_LOCK,
                 EXECUTOR,
                 callbackHandler,
                 new HashMap<>(),

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -12,7 +12,6 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 class LiteDownloadManagerDownloader {
 
     private final Object waitForDownloadService;
-    private final Object waitForDownloadBatchStatusCallback;
     private final ExecutorService executor;
     private final Handler callbackHandler;
     private final FileOperations fileOperations;
@@ -29,7 +28,6 @@ class LiteDownloadManagerDownloader {
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
 // Can't group anymore these are customisable options.
     LiteDownloadManagerDownloader(Object waitForDownloadService,
-                                  Object waitForDownloadBatchStatusCallback,
                                   ExecutorService executor,
                                   Handler callbackHandler,
                                   FileOperations fileOperations,
@@ -40,7 +38,6 @@ class LiteDownloadManagerDownloader {
                                   List<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {
         this.waitForDownloadService = waitForDownloadService;
-        this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;
         this.callbackHandler = callbackHandler;
         this.fileOperations = fileOperations;
@@ -96,12 +93,10 @@ class LiteDownloadManagerDownloader {
 
     private DownloadBatchStatusCallback downloadBatchCallback() {
         return downloadBatchStatus -> callbackHandler.post(() -> {
-            synchronized (waitForDownloadBatchStatusCallback) {
-                for (DownloadBatchStatusCallback callback : callbacks) {
-                    callback.onUpdate(downloadBatchStatus);
-                }
-                notificationDispatcher.updateNotification(downloadBatchStatus);
+            for (DownloadBatchStatusCallback callback : callbacks) {
+                callback.onUpdate(downloadBatchStatus);
             }
+            notificationDispatcher.updateNotification(downloadBatchStatus);
         });
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -4,6 +4,11 @@ import android.os.Handler;
 
 import com.novoda.notils.logger.simple.Log;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,11 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InOrder;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.DownloadBatchIdFixtures.aDownloadBatchId;
@@ -47,7 +47,6 @@ public class DownloadManagerTest {
     private final DownloadFileStatusCallback downloadFileStatusCallback = mock(DownloadFileStatusCallback.class);
     private final DownloadService downloadService = mock(DownloadService.class);
     private final Object serviceLock = spy(new Object());
-    private final Object callbackLock = spy(new Object());
     private final ExecutorService executorService = mock(ExecutorService.class);
     private final Handler handler = mock(Handler.class);
     private final DownloadBatch downloadBatch = mock(DownloadBatch.class);
@@ -75,7 +74,6 @@ public class DownloadManagerTest {
 
         downloadManager = new DownloadManager(
                 serviceLock,
-                callbackLock,
                 executorService,
                 handler,
                 downloadBatches,


### PR DESCRIPTION
This is a simplification of the previously implemented solution using a synchronized object, in this way we have less code and it won't block. The tradeoff is memory consumption.