### PR TITLE
Stop service in case of hidden notification

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -37,7 +37,7 @@ class ServiceNotificationDispatcher<T> {
 
             switch (notificationInformation.notificationDisplayState()) {
                 case SINGLE_PERSISTENT_NOTIFICATION:
-                    updateNotification(notificationInformation);
+                    updatePersistentNotification(notificationInformation);
                     break;
                 case STACK_NOTIFICATION_NOT_DISMISSIBLE:
                     stackNotificationNotDismissible(notificationInformation);
@@ -65,7 +65,7 @@ class ServiceNotificationDispatcher<T> {
         notificationManager.cancel(NOTIFICATION_TAG, notificationInformation.getId());
     }
 
-    private void updateNotification(NotificationInformation notificationInformation) {
+    private void updatePersistentNotification(NotificationInformation notificationInformation) {
         persistentNotificationId = notificationInformation.getId();
         service.start(notificationInformation.getId(), notificationInformation.getNotification());
     }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -4,8 +4,6 @@ import android.app.Notification;
 import android.support.annotation.WorkerThread;
 import android.support.v4.app.NotificationManagerCompat;
 
-import com.novoda.notils.logger.simple.Log;
-
 class ServiceNotificationDispatcher<T> {
 
     private static final String NOTIFICATION_TAG = "download-manager";
@@ -47,7 +45,7 @@ class ServiceNotificationDispatcher<T> {
                     stackNotification(notificationInformation);
                     break;
                 case HIDDEN_NOTIFICATION:
-                    Log.d("Notification not required, hiding.");
+                    service.stop(true);
                     break;
                 default:
                     String message = String.format(

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -100,14 +100,12 @@ public class ServiceNotificationDispatcherTest {
     }
 
     @Test
-    public void doesNothing_whenNotificationIsHidden() {
+    public void stopsService_whenNotificationIsHidden() {
         given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(HIDDEN_NOTIFICATION_INFORMATION);
 
         notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
 
-        InOrder inOrder = inOrder(downloadService, notificationManager);
-        inOrder.verify(notificationManager).cancel(NOTIFICATION_TAG, HIDDEN_NOTIFICATION_INFORMATION.getId());
-        inOrder.verifyNoMoreInteractions();
+        verify(downloadService).stop(true);
     }
 
     @Test(timeout = 500)

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -57,10 +57,8 @@ public class ServiceNotificationDispatcherTest {
 
         notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
 
-        InOrder inOrder = inOrder(downloadService, notificationManager);
-        inOrder.verify(downloadService, never()).stop(true);
-        inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
-        inOrder.verifyNoMoreInteractions();
+        verify(downloadService, never()).stop(true);
+        verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
     }
 
     @Test
@@ -86,10 +84,8 @@ public class ServiceNotificationDispatcherTest {
 
         notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
 
-        InOrder inOrder = inOrder(downloadService, notificationManager);
-        inOrder.verify(downloadService, never()).stop(true);
-        inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
-        inOrder.verifyNoMoreInteractions();
+        verify(downloadService, never()).stop(true);
+        verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
     }
 
     @Test


### PR DESCRIPTION
This is done in order to dismiss previously ongoing notifications, for example when coming from a DOWNLOADING state (with not dismissible notification) to a PAUSED one (which a client might not want to display).

Before stopping the service (and then dismissing persistent notification) we check the notification id, and we stop only if the current one is the same as the last persisted notification.
