### PR TITLE
Submit all stored downloads after migration completed

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -119,7 +119,12 @@ public class MainActivity extends AppCompatActivity {
         versionOneDatabaseCloner.cloneDatabaseWithDownloadSize(selectedFileSize);
     };
 
-    private final MigrationCallback migrationCallback = migrationStatus -> databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
+    private final MigrationCallback migrationCallback = migrationStatus -> {
+        if (migrationStatus.status() == MigrationStatus.Status.COMPLETE) {
+            liteDownloadManagerCommands.submitAllStoredDownloads(() -> Log.d("Migration completed, submitting all downloads"));
+        }
+        databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
+    };
 
     private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration(getDatabasePath("downloads.db"));
 

--- a/library/src/main/java/com/novoda/downloadmanager/AllStoredDownloadsSubmittedCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/AllStoredDownloadsSubmittedCallback.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-interface AllStoredDownloadsSubmittedCallback {
+public interface AllStoredDownloadsSubmittedCallback {
 
     void onAllDownloadsSubmitted();
 }


### PR DESCRIPTION
This is needed because otherwise the migrated downloads are not gonna be available unless the user restarts the app