### PR TITLE
Fail fast when a file size request fails

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -64,7 +64,9 @@ class DownloadBatch {
             notifyCallback(downloadBatchStatus);
         }
 
-        totalBatchSizeBytes = getTotalSize(downloadFiles);
+        if (totalBatchSizeBytes == 0) {
+            totalBatchSizeBytes = getTotalSize(downloadFiles);
+        }
 
         if (totalBatchSizeBytes <= ZERO_BYTES) {
             processNetworkError();
@@ -156,20 +158,16 @@ class DownloadBatch {
     }
 
     private long getTotalSize(List<DownloadFile> downloadFiles) {
-        if (totalBatchSizeBytes == 0) {
-            int totalBatchSize = 0;
-            for (DownloadFile downloadFile : downloadFiles) {
-                long totalFileSize = downloadFile.getTotalSize();
-                if (totalFileSize == 0) {
-                    return 0;
-                }
-                
-                totalBatchSize += totalFileSize;
+        long totalBatchSize = 0;
+        for (DownloadFile downloadFile : downloadFiles) {
+            long totalFileSize = downloadFile.getTotalSize();
+            if (totalFileSize == 0) {
+                return 0;
             }
-            return totalBatchSize;
-        }
 
-        return totalBatchSizeBytes;
+            totalBatchSize += totalFileSize;
+        }
+        return totalBatchSize;
     }
 
     void pause() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -157,9 +157,16 @@ class DownloadBatch {
 
     private long getTotalSize(List<DownloadFile> downloadFiles) {
         if (totalBatchSizeBytes == 0) {
+            int totalBatchSize = 0;
             for (DownloadFile downloadFile : downloadFiles) {
-                totalBatchSizeBytes += downloadFile.getTotalSize();
+                long totalFileSize = downloadFile.getTotalSize();
+                if (totalFileSize == 0) {
+                    return 0;
+                }
+                
+                totalBatchSize += totalFileSize;
             }
+            return totalBatchSize;
         }
 
         return totalBatchSizeBytes;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -89,7 +89,14 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                 for (DownloadFile downloadFile : downloadFiles) {
                     downloadedFileSizeMap.put(downloadFile.id(), downloadFile.getCurrentDownloadedBytes());
                     currentBytesDownloaded += downloadFile.getCurrentDownloadedBytes();
-                    totalBatchSizeBytes += downloadFile.getTotalSize();
+                    long totalFileSize = downloadFile.getTotalSize();
+                    if (totalFileSize == 0) {
+                        totalBatchSizeBytes = 0;
+                        currentBytesDownloaded = 0;
+                        break;
+                    } else {
+                        totalBatchSizeBytes += totalFileSize;
+                    }
                 }
 
                 liteDownloadBatchStatus.update(currentBytesDownloaded, totalBatchSizeBytes);


### PR DESCRIPTION
**Problem**

When a file request files inside the general batch total size request, the batch ends up with the incorrect total batch size

**Solution**
Is it possible that if a batch has several files, one file size request but the others are ok. In this scenario, the total batch size will be wrong.

The solution has been to check if the file size request returns zero as a total file size, and return it back to the requester that will deal correctly with that scenario.