### PR TITLE
Flashing notification on 4.4.2

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,7 +35,7 @@ android {
 dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.0.0'
     implementation 'com.novoda:notils:2.2.16'
-    implementation 'com.novoda:merlin:1.1.4'
+    implementation 'com.novoda:merlin:1.1.6'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.android.support:support-v4:27.0.2'
     implementation 'com.squareup.okhttp:okhttp:2.7.5'

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -21,7 +21,6 @@ class NotificationCreator<T> {
     }
 
     private int notificationId;
-    private NotificationCustomizer.NotificationDisplayState notificationDisplayState;
     private NotificationCompat.Builder builder;
 
     NotificationInformation createNotification(final T notificationPayload) {
@@ -38,19 +37,13 @@ class NotificationCreator<T> {
             @Override
             public Notification getNotification() {
                 int newNotificationId = getId();
-                NotificationCustomizer.NotificationDisplayState newNotificationDisplayState = notificationDisplayState();
 
-                if (builder == null || hasChanged(newNotificationId, newNotificationDisplayState)) {
+                if (builder == null || newNotificationId != notificationId) {
                     builder = new NotificationCompat.Builder(applicationContext, notificationChannelProvider.channelId());
                     notificationId = newNotificationId;
-                    notificationDisplayState = newNotificationDisplayState;
                 }
 
                 return notificationCustomizer.customNotificationFrom(builder, notificationPayload);
-            }
-
-            private boolean hasChanged(int newNotificationId, NotificationCustomizer.NotificationDisplayState newNotificationDisplayState) {
-                return notificationId != newNotificationId && !notificationDisplayState.equals(newNotificationDisplayState);
             }
 
             @Override

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCreator.java
@@ -20,6 +20,10 @@ class NotificationCreator<T> {
         this.notificationChannelProvider = notificationChannelProvider;
     }
 
+    private int notificationId;
+    private NotificationCustomizer.NotificationDisplayState notificationDisplayState;
+    private NotificationCompat.Builder builder;
+
     NotificationInformation createNotification(final T notificationPayload) {
         return new NotificationInformation() {
             @Override
@@ -33,8 +37,20 @@ class NotificationCreator<T> {
 
             @Override
             public Notification getNotification() {
-                NotificationCompat.Builder builder = new NotificationCompat.Builder(applicationContext, notificationChannelProvider.channelId());
+                int newNotificationId = getId();
+                NotificationCustomizer.NotificationDisplayState newNotificationDisplayState = notificationDisplayState();
+
+                if (builder == null || hasChanged(newNotificationId, newNotificationDisplayState)) {
+                    builder = new NotificationCompat.Builder(applicationContext, notificationChannelProvider.channelId());
+                    notificationId = newNotificationId;
+                    notificationDisplayState = newNotificationDisplayState;
+                }
+
                 return notificationCustomizer.customNotificationFrom(builder, notificationPayload);
+            }
+
+            private boolean hasChanged(int newNotificationId, NotificationCustomizer.NotificationDisplayState newNotificationDisplayState) {
+                return notificationId != newNotificationId && !notificationDisplayState.equals(newNotificationDisplayState);
             }
 
             @Override


### PR DESCRIPTION
## Problem
QA on a client application has picked up that notifications flash on Android 4.4.2 for the persisted downloading state 😢 


## Solution
After some fixes that failed and more research into the issue I stumbled upon [this](https://stackoverflow.com/questions/19025056/how-can-i-avoid-blinking-notification-update-while-changing-button), which suggests that using the same `NotificationCompat.Builder` for similar notifications rectifies the issue, and indeed it does. 
