### PR TITLE
Register a notification channel for download migration

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -107,6 +107,10 @@ public final class DownloadMigratorBuilder {
         Intent serviceIntent = new Intent(applicationContext, LiteDownloadMigrationService.class);
         applicationContext.bindService(serviceIntent, serviceConnection, Context.BIND_AUTO_CREATE);
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationChannelProvider.registerNotificationChannel(applicationContext);
+        }
+
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(applicationContext);
         ServiceNotificationDispatcher<MigrationStatus> notificationDispatcher = new ServiceNotificationDispatcher<>(
                 LOCK,


### PR DESCRIPTION
## Problem
There's a crash when a custom notification channel is specified on the `DownloadMigratorBuilder`, there is no check in the `build` for android `Oreo` and we never register a `NotificationChannel` 😬 

I believe it works on the default cases in the demo because the `DownloadManager` and the `Migrator` share the same channel name.

## Solution
Add the check for `Oreo` and register a `NotificationChannel`.

❓ Should the `Migrator` and `DownloadManager` share the same notification channel by default? They do currently, which is why this doesn't show up unless you create a custom one. ❓ 