### PR TITLE
Migration Fixes

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -120,7 +120,7 @@ public class MainActivity extends AppCompatActivity {
         databaseMigrationUpdates.setText(migrationStatus.status().toRawValue());
     };
 
-    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration(getDatabasePath("downloads.db"));
+    private final View.OnClickListener startMigrationOnClick = v -> downloadMigrator.startMigration("migrationJob", getDatabasePath("downloads.db"));
 
     private final CompoundButton.OnCheckedChangeListener wifiOnlyOnCheckedChange = (buttonView, isChecked) -> {
         LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigrator.java
@@ -4,6 +4,6 @@ import java.io.File;
 
 public interface DownloadMigrator {
 
-    void startMigration(File databaseFile);
+    void startMigration(String jobIdentifier, File databaseFile);
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -151,7 +151,7 @@ public final class DownloadMigratorBuilder {
 
         @Override
         public Notification customNotificationFrom(NotificationCompat.Builder builder, MigrationStatus migrationStatus) {
-            String title = migrationStatus.status().toRawValue();
+            String title = resources.getString(R.string.migration_notification_content_title);
             builder.setSmallIcon(notificationIcon)
                     .setContentTitle(title);
 

--- a/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 interface InternalMigrationStatus extends MigrationStatus {
 
-    void update(int numberOfMigrationsCompleted, int totalNumberOfMigrations);
-
     void migrationComplete();
 
     void markAsExtracting();

--- a/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
@@ -14,6 +14,6 @@ interface InternalMigrationStatus extends MigrationStatus {
 
     void markAsComplete();
 
-    VersionOneToVersionTwoMigrationStatus copy();
+    InternalMigrationStatus copy();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
@@ -2,7 +2,9 @@ package com.novoda.downloadmanager;
 
 interface InternalMigrationStatus extends MigrationStatus {
 
-    void update(int currentBatch, int numberOfBatches);
+    void update(int numberOfMigrationsCompleted, int totalNumberOfMigrations);
+
+    void migrationComplete();
 
     void markAsExtracting();
 
@@ -11,5 +13,7 @@ interface InternalMigrationStatus extends MigrationStatus {
     void markAsDeleting();
 
     void markAsComplete();
+
+    VersionOneToVersionTwoMigrationStatus copy();
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalMigrationStatus.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager;
 
 interface InternalMigrationStatus extends MigrationStatus {
 
-    void migrationComplete();
+    void onSingleBatchMigrated();
 
     void markAsExtracting();
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadMigrator.java
@@ -42,14 +42,14 @@ class LiteDownloadMigrator implements DownloadMigrator {
     }
 
     @Override
-    public void startMigration(File databaseFile) {
+    public void startMigration(String jobIdentifier, File databaseFile) {
         executor.submit(() -> Wait.<Void>waitFor(migrationService, waitForMigrationService)
-                .thenPerform(executeMigrationFor(databaseFile)));
+                .thenPerform(executeMigrationFor(jobIdentifier, databaseFile)));
     }
 
-    private Wait.ThenPerform.Action<Void> executeMigrationFor(File databaseFile) {
+    private Wait.ThenPerform.Action<Void> executeMigrationFor(String jobIdentifier, File databaseFile) {
         return () -> {
-            migrationService.startMigration(new MigrationJob(applicationContext, databaseFile), migrationCallback());
+            migrationService.startMigration(new MigrationJob(applicationContext, jobIdentifier, databaseFile), migrationCallback());
             return null;
         };
     }

--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -5,14 +5,21 @@ import java.util.List;
 
 class Migration {
 
+    enum Type {
+        COMPLETE,
+        PARTIAL
+    }
+
     private final Batch batch;
     private final List<FileMetadata> fileMetadata;
     private final long downloadedDateTimeInMillis;
+    private final Type type;
 
-    Migration(Batch batch, List<FileMetadata> fileMetadata, long downloadedDateTimeInMillis) {
+    Migration(Batch batch, List<FileMetadata> fileMetadata, long downloadedDateTimeInMillis, Type type) {
         this.batch = batch;
         this.fileMetadata = Collections.unmodifiableList(fileMetadata);
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
+        this.type = type;
     }
 
     Batch batch() {
@@ -27,13 +34,8 @@ class Migration {
         return downloadedDateTimeInMillis;
     }
 
-    boolean hasDownloadedBatch() {
-        for (FileMetadata fileMetadatum : fileMetadata) {
-            if (fileMetadatum.fileSize().currentSize() != fileMetadatum.fileSize().totalSize()) {
-                return false;
-            }
-        }
-        return true;
+    Type type() {
+        return type;
     }
 
     @Override
@@ -50,17 +52,21 @@ class Migration {
         if (downloadedDateTimeInMillis != migration.downloadedDateTimeInMillis) {
             return false;
         }
-        if (!batch.equals(migration.batch)) {
+        if (batch != null ? !batch.equals(migration.batch) : migration.batch != null) {
             return false;
         }
-        return fileMetadata.equals(migration.fileMetadata);
+        if (fileMetadata != null ? !fileMetadata.equals(migration.fileMetadata) : migration.fileMetadata != null) {
+            return false;
+        }
+        return type == migration.type;
     }
 
     @Override
     public int hashCode() {
-        int result = batch.hashCode();
-        result = 31 * result + fileMetadata.hashCode();
+        int result = batch != null ? batch.hashCode() : 0;
+        result = 31 * result + (fileMetadata != null ? fileMetadata.hashCode() : 0);
         result = 31 * result + (int) (downloadedDateTimeInMillis ^ (downloadedDateTimeInMillis >>> 32));
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         return result;
     }
 
@@ -70,6 +76,7 @@ class Migration {
                 + "batch=" + batch
                 + ", fileMetadata=" + fileMetadata
                 + ", downloadedDateTimeInMillis=" + downloadedDateTimeInMillis
+                + ", type=" + type
                 + '}';
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -92,9 +92,11 @@ class MigrationExtractor {
 
     private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {
         if (originalFileId == null || originalFileId.isEmpty()) {
-            return DownloadBatchIdCreator.createFrom(batchId);
+            String hashedString = String.valueOf(batchId.hashCode());
+            return DownloadBatchIdCreator.createFrom(hashedString);
         }
-        return DownloadBatchIdCreator.createFrom(originalFileId);
+        String hashedString = String.valueOf(originalFileId.hashCode());
+        return DownloadBatchIdCreator.createFrom(hashedString);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -47,7 +47,7 @@ class MigrationExtractor {
                 List<Migration.FileMetadata> fileMetadataList = extractFileMetadataFrom(batchId, newBatchBuilder);
 
                 Batch batch = newBatchBuilder.build();
-                migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis));
+                migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis, Migration.Type.COMPLETE));
             }
 
             return migrations;

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -40,14 +40,14 @@ class MigrationExtractor {
 
             while (batchesCursor.moveToNext()) {
                 String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
-                String batchTitle = batchesCursor.getString(TITLE_COLUMN);
-                long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
-
                 Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
 
                 if (downloadsCursor == null) {
                     return Collections.emptyList();
                 }
+
+                String batchTitle = batchesCursor.getString(TITLE_COLUMN);
+                long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
 
                 Batch.Builder newBatchBuilder = null;
                 List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -94,7 +94,7 @@ class MigrationJob implements Runnable {
 
         DownloadBatchId downloadBatchId = batch.downloadBatchId();
         DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle(batch.title());
-        Status downloadBatchStatus = migration.hasDownloadedBatch() ? Status.DOWNLOADED : Status.QUEUED;
+        Status downloadBatchStatus = batchStatusFrom(migration);
         long downloadedDateTimeInMillis = migration.downloadedDateTimeInMillis();
 
         DownloadsBatchPersisted persistedBatch = new LiteDownloadsBatchPersisted(
@@ -129,6 +129,10 @@ class MigrationJob implements Runnable {
             );
             downloadsPersistence.persistFile(persistedFile);
         }
+    }
+
+    private Status batchStatusFrom(Migration migration) {
+        return migration.type() == Migration.Type.COMPLETE ? Status.DOWNLOADED : Status.QUEUED;
     }
 
     private String rawFileIdFrom(Batch batch, Migration.FileMetadata fileMetadata) {

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -13,17 +13,18 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status;
 class MigrationJob implements Runnable {
 
     private static final String TAG = "V1 to V2 migrator";
-    private static final String MIGRATION_ID = "migration" + System.nanoTime();
 
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
 
     private final Context context;
+    private final String jobIdentifier;
     private final File databasePath;
     private final List<MigrationCallback> migrationCallbacks = new ArrayList<>();
 
-    MigrationJob(Context context, File databasePath) {
+    MigrationJob(Context context, String jobIdentifier, File databasePath) {
         this.context = context;
+        this.jobIdentifier = jobIdentifier;
         this.databasePath = databasePath;
     }
 
@@ -32,7 +33,14 @@ class MigrationJob implements Runnable {
     }
 
     public void run() {
-        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(MIGRATION_ID, MigrationStatus.Status.DB_NOT_PRESENT, 0, 0, 0);
+        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(
+                jobIdentifier,
+                MigrationStatus.Status.DB_NOT_PRESENT,
+                0,
+                0,
+                0
+        );
+
         if (!databasePath.exists()) {
             onUpdate(migrationStatus);
             return;

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -31,7 +31,7 @@ class MigrationJob implements Runnable {
     }
 
     public void run() {
-        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(MigrationStatus.Status.DB_NOT_PRESENT);
+        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(MigrationStatus.Status.DB_NOT_PRESENT, 0, 0, 0);
         if (!databasePath.exists()) {
             onUpdate(migrationStatus);
             return;
@@ -60,8 +60,15 @@ class MigrationJob implements Runnable {
     }
 
     private void onUpdate(MigrationStatus migrationStatus) {
+        MigrationStatus clonedMigrationStatus = new VersionOneToVersionTwoMigrationStatus(
+                migrationStatus.status(),
+                migrationStatus.numberOfMigratedBatches(),
+                migrationStatus.totalNumberOfBatchesToMigrate(),
+                migrationStatus.percentageMigrated()
+        );
+
         for (MigrationCallback migrationCallback : migrationCallbacks) {
-            migrationCallback.onUpdate(migrationStatus);
+            migrationCallback.onUpdate(clonedMigrationStatus);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -108,7 +108,7 @@ class MigrationJob implements Runnable {
             downloadsPersistence.endTransaction();
             database.setTransactionSuccessful();
             database.endTransaction();
-            migrationStatus.migrationComplete();
+            migrationStatus.onSingleBatchMigrated();
             onUpdate(migrationStatus);
         }
         Log.d(TAG, "Partial migrations complete " + System.nanoTime());
@@ -204,7 +204,7 @@ class MigrationJob implements Runnable {
             downloadsPersistence.endTransaction();
             database.setTransactionSuccessful();
             database.endTransaction();
-            migrationStatus.migrationComplete();
+            migrationStatus.onSingleBatchMigrated();
             onUpdate(migrationStatus);
         }
         Log.d(TAG, "Complete migrations complete " + System.nanoTime());

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -13,6 +13,7 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status;
 class MigrationJob implements Runnable {
 
     private static final String TAG = "V1 to V2 migrator";
+    private static final String MIGRATION_ID = "migration" + System.nanoTime();
 
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
@@ -31,7 +32,7 @@ class MigrationJob implements Runnable {
     }
 
     public void run() {
-        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(MigrationStatus.Status.DB_NOT_PRESENT, 0, 0, 0);
+        InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(MIGRATION_ID, MigrationStatus.Status.DB_NOT_PRESENT, 0, 0, 0);
         if (!databasePath.exists()) {
             onUpdate(migrationStatus);
             return;
@@ -61,6 +62,7 @@ class MigrationJob implements Runnable {
 
     private void onUpdate(MigrationStatus migrationStatus) {
         MigrationStatus clonedMigrationStatus = new VersionOneToVersionTwoMigrationStatus(
+                migrationStatus.migrationId(),
                 migrationStatus.status(),
                 migrationStatus.numberOfMigratedBatches(),
                 migrationStatus.totalNumberOfBatchesToMigrate(),

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -16,6 +16,8 @@ class MigrationJob implements Runnable {
 
     private static final String TABLE_BATCHES = "batches";
     private static final String WHERE_CLAUSE_ID = "_id = ?";
+    private static final int NO_COMPLETED_MIGRATIONS = 0;
+    private static final int NO_MIGRATIONS = 0;
 
     private final Context context;
     private final String jobIdentifier;
@@ -37,8 +39,8 @@ class MigrationJob implements Runnable {
             InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(
                     jobIdentifier,
                     MigrationStatus.Status.DB_NOT_PRESENT,
-                    0,
-                    0
+                    NO_COMPLETED_MIGRATIONS,
+                    NO_MIGRATIONS
             );
 
             onUpdate(migrationStatus);
@@ -63,7 +65,7 @@ class MigrationJob implements Runnable {
         InternalMigrationStatus migrationStatus = new VersionOneToVersionTwoMigrationStatus(
                 jobIdentifier,
                 MigrationStatus.Status.DB_NOT_PRESENT,
-                0,
+                NO_COMPLETED_MIGRATIONS,
                 totalNumberOfMigrations
         );
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -188,13 +188,12 @@ class MigrationJob implements Runnable {
         onUpdate(migrationStatus);
         Log.d(TAG, "about to migrate the files, time is " + System.nanoTime());
 
-        for (int i = 0, size = completeMigrations.size(); i < size; i++) {
-            Migration migration = completeMigrations.get(i);
+        for (Migration completeMigration : completeMigrations) {
             downloadsPersistence.startTransaction();
             database.startTransaction();
 
-            migrateV1DataToV2Database(downloadsPersistence, migration, basePath, true);
-            deleteFrom(database, migration);
+            migrateV1DataToV2Database(downloadsPersistence, completeMigration, basePath, true);
+            deleteFrom(database, completeMigration);
 
             downloadsPersistence.transactionSuccess();
             downloadsPersistence.endTransaction();

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationStatus.java
@@ -16,6 +16,8 @@ public interface MigrationStatus {
 
     }
 
+    String migrationId();
+
     int numberOfMigratedBatches();
 
     int totalNumberOfBatchesToMigrate();

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationStatusNotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationStatusNotificationCreator.java
@@ -29,7 +29,7 @@ class MigrationStatusNotificationCreator implements NotificationCreator<Migratio
         return new NotificationInformation() {
             @Override
             public int getId() {
-                return migrationStatus.hashCode();
+                return migrationStatus.migrationId().hashCode();
             }
 
             @Override

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -36,13 +36,17 @@ class PartialDownloadMigrationExtractor {
             long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
 
             Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
-            Batch.Builder newBatchBuilder = Batch.with(DownloadBatchIdCreator.createFrom(batchId), batchTitle);
+            Batch.Builder newBatchBuilder = null;
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
 
             while (downloadsCursor.moveToNext()) {
                 String originalFileId = downloadsCursor.getString(FILE_ID_COLUMN);
                 String uri = downloadsCursor.getString(URI_COLUMN);
                 String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
+
+                if (downloadsCursor.isFirst()) {
+                    newBatchBuilder = Batch.with(DownloadBatchIdCreator.createFrom(originalFileId), batchTitle);
+                }
 
                 newBatchBuilder.addFile(uri);
 

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -66,8 +66,10 @@ class PartialDownloadMigrationExtractor {
 
     private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {
         if (originalFileId == null || originalFileId.isEmpty()) {
-            return DownloadBatchIdCreator.createFrom(batchId);
+            String hashedString = String.valueOf(batchId.hashCode());
+            return DownloadBatchIdCreator.createFrom(hashedString);
         }
-        return DownloadBatchIdCreator.createFrom(originalFileId);
+        String hashedString = String.valueOf(originalFileId.hashCode());
+        return DownloadBatchIdCreator.createFrom(hashedString);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -45,7 +45,8 @@ class PartialDownloadMigrationExtractor {
                 String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
 
                 if (downloadsCursor.isFirst()) {
-                    newBatchBuilder = Batch.with(DownloadBatchIdCreator.createFrom(originalFileId), batchTitle);
+                    DownloadBatchId downloadBatchId = createDownloadBatchIdFrom(originalFileId, batchId);
+                    newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                 }
 
                 newBatchBuilder.addFile(uri);
@@ -61,5 +62,12 @@ class PartialDownloadMigrationExtractor {
         }
         batchesCursor.close();
         return migrations;
+    }
+
+    private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {
+        if (originalFileId == null || originalFileId.isEmpty()) {
+            return DownloadBatchIdCreator.createFrom(batchId);
+        }
+        return DownloadBatchIdCreator.createFrom(originalFileId);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -9,29 +9,26 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     private Status status;
     private int numberOfMigrationsCompleted;
     private int totalNumberOfMigrations;
-    private int percentageMigrated;
 
     VersionOneToVersionTwoMigrationStatus(String migrationId,
                                           Status status,
                                           int numberOfMigrationsCompleted,
-                                          int totalNumberOfMigrations,
-                                          int percentageMigrated) {
+                                          int totalNumberOfMigrations) {
         this.migrationId = migrationId;
         this.status = status;
         this.numberOfMigrationsCompleted = numberOfMigrationsCompleted;
         this.totalNumberOfMigrations = totalNumberOfMigrations;
-        this.percentageMigrated = percentageMigrated;
     }
 
     @Override
-    public void update(int currentBatch, int numberOfBatches) {
-        this.numberOfMigrationsCompleted = currentBatch;
-        this.totalNumberOfMigrations = numberOfBatches;
-        this.percentageMigrated = getPercentageFrom(currentBatch, numberOfBatches);
+    public void update(int numberOfMigrationsCompleted, int totalNumberOfMigrations) {
+        this.numberOfMigrationsCompleted = numberOfMigrationsCompleted;
+        this.totalNumberOfMigrations = totalNumberOfMigrations;
     }
 
-    private int getPercentageFrom(int numberOfBatches, int totalNumberOfBatches) {
-        return (int) ((((float) numberOfBatches) / ((float) totalNumberOfBatches)) * TOTAL_PERCENTAGE);
+    @Override
+    public void migrationComplete() {
+        numberOfMigrationsCompleted++;
     }
 
     @Override
@@ -71,12 +68,22 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
 
     @Override
     public int percentageMigrated() {
-        return percentageMigrated;
+        return (int) ((((float) numberOfMigrationsCompleted) / ((float) totalNumberOfMigrations)) * TOTAL_PERCENTAGE);
     }
 
     @Override
     public Status status() {
         return status;
+    }
+
+    @Override
+    public VersionOneToVersionTwoMigrationStatus copy() {
+        return new VersionOneToVersionTwoMigrationStatus(
+                migrationId,
+                status,
+                numberOfMigrationsCompleted,
+                totalNumberOfMigrations
+        );
     }
 
     @Override
@@ -96,9 +103,6 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
         if (totalNumberOfMigrations != that.totalNumberOfMigrations) {
             return false;
         }
-        if (percentageMigrated != that.percentageMigrated) {
-            return false;
-        }
         if (migrationId != null ? !migrationId.equals(that.migrationId) : that.migrationId != null) {
             return false;
         }
@@ -111,18 +115,16 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
         result = 31 * result + (status != null ? status.hashCode() : 0);
         result = 31 * result + numberOfMigrationsCompleted;
         result = 31 * result + totalNumberOfMigrations;
-        result = 31 * result + percentageMigrated;
         return result;
     }
 
     @Override
     public String toString() {
-        return "VersionOneToVersionTwoMigrationStatus{" +
-                "migrationId='" + migrationId + '\'' +
-                ", status=" + status +
-                ", numberOfMigrationsCompleted=" + numberOfMigrationsCompleted +
-                ", totalNumberOfMigrations=" + totalNumberOfMigrations +
-                ", percentageMigrated=" + percentageMigrated +
-                '}';
+        return "VersionOneToVersionTwoMigrationStatus{"
+                + "migrationId='" + migrationId + '\''
+                + ", status=" + status
+                + ", numberOfMigrationsCompleted=" + numberOfMigrationsCompleted
+                + ", totalNumberOfMigrations=" + totalNumberOfMigrations
+                + '}';
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -21,12 +21,6 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     }
 
     @Override
-    public void update(int numberOfMigrationsCompleted, int totalNumberOfMigrations) {
-        this.numberOfMigrationsCompleted = numberOfMigrationsCompleted;
-        this.totalNumberOfMigrations = totalNumberOfMigrations;
-    }
-
-    @Override
     public void migrationComplete() {
         numberOfMigrationsCompleted++;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -21,7 +21,7 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     }
 
     @Override
-    public void migrationComplete() {
+    public void onSingleBatchMigrated() {
         numberOfMigrationsCompleted++;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -9,8 +9,11 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     private int totalNumberOfBatches;
     private int percentageMigrated;
 
-    VersionOneToVersionTwoMigrationStatus(Status status) {
+    VersionOneToVersionTwoMigrationStatus(Status status, int numberOfBatches, int totalNumberOfBatches, int percentageMigrated) {
         this.status = status;
+        this.numberOfBatches = numberOfBatches;
+        this.totalNumberOfBatches = totalNumberOfBatches;
+        this.percentageMigrated = percentageMigrated;
     }
 
     @Override
@@ -62,5 +65,47 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     @Override
     public Status status() {
         return status;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        VersionOneToVersionTwoMigrationStatus that = (VersionOneToVersionTwoMigrationStatus) o;
+
+        if (numberOfBatches != that.numberOfBatches) {
+            return false;
+        }
+        if (totalNumberOfBatches != that.totalNumberOfBatches) {
+            return false;
+        }
+        if (percentageMigrated != that.percentageMigrated) {
+            return false;
+        }
+        return status == that.status;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = status != null ? status.hashCode() : 0;
+        result = 31 * result + numberOfBatches;
+        result = 31 * result + totalNumberOfBatches;
+        result = 31 * result + percentageMigrated;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "VersionOneToVersionTwoMigrationStatus{"
+                + "status=" + status
+                + ", numberOfBatches=" + numberOfBatches
+                + ", totalNumberOfBatches=" + totalNumberOfBatches
+                + ", percentageMigrated=" + percentageMigrated
+                + '}';
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -7,22 +7,26 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     private final String migrationId;
 
     private Status status;
-    private int numberOfBatches;
-    private int totalNumberOfBatches;
+    private int numberOfMigrationsCompleted;
+    private int totalNumberOfMigrations;
     private int percentageMigrated;
 
-    VersionOneToVersionTwoMigrationStatus(String migrationId, Status status, int numberOfBatches, int totalNumberOfBatches, int percentageMigrated) {
+    VersionOneToVersionTwoMigrationStatus(String migrationId,
+                                          Status status,
+                                          int numberOfMigrationsCompleted,
+                                          int totalNumberOfMigrations,
+                                          int percentageMigrated) {
         this.migrationId = migrationId;
         this.status = status;
-        this.numberOfBatches = numberOfBatches;
-        this.totalNumberOfBatches = totalNumberOfBatches;
+        this.numberOfMigrationsCompleted = numberOfMigrationsCompleted;
+        this.totalNumberOfMigrations = totalNumberOfMigrations;
         this.percentageMigrated = percentageMigrated;
     }
 
     @Override
     public void update(int currentBatch, int numberOfBatches) {
-        this.numberOfBatches = currentBatch;
-        this.totalNumberOfBatches = numberOfBatches;
+        this.numberOfMigrationsCompleted = currentBatch;
+        this.totalNumberOfMigrations = numberOfBatches;
         this.percentageMigrated = getPercentageFrom(currentBatch, numberOfBatches);
     }
 
@@ -57,12 +61,12 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
 
     @Override
     public int numberOfMigratedBatches() {
-        return numberOfBatches;
+        return numberOfMigrationsCompleted;
     }
 
     @Override
     public int totalNumberOfBatchesToMigrate() {
-        return totalNumberOfBatches;
+        return totalNumberOfMigrations;
     }
 
     @Override
@@ -86,10 +90,10 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
 
         VersionOneToVersionTwoMigrationStatus that = (VersionOneToVersionTwoMigrationStatus) o;
 
-        if (numberOfBatches != that.numberOfBatches) {
+        if (numberOfMigrationsCompleted != that.numberOfMigrationsCompleted) {
             return false;
         }
-        if (totalNumberOfBatches != that.totalNumberOfBatches) {
+        if (totalNumberOfMigrations != that.totalNumberOfMigrations) {
             return false;
         }
         if (percentageMigrated != that.percentageMigrated) {
@@ -105,8 +109,8 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     public int hashCode() {
         int result = migrationId != null ? migrationId.hashCode() : 0;
         result = 31 * result + (status != null ? status.hashCode() : 0);
-        result = 31 * result + numberOfBatches;
-        result = 31 * result + totalNumberOfBatches;
+        result = 31 * result + numberOfMigrationsCompleted;
+        result = 31 * result + totalNumberOfMigrations;
         result = 31 * result + percentageMigrated;
         return result;
     }
@@ -116,8 +120,8 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
         return "VersionOneToVersionTwoMigrationStatus{" +
                 "migrationId='" + migrationId + '\'' +
                 ", status=" + status +
-                ", numberOfBatches=" + numberOfBatches +
-                ", totalNumberOfBatches=" + totalNumberOfBatches +
+                ", numberOfMigrationsCompleted=" + numberOfMigrationsCompleted +
+                ", totalNumberOfMigrations=" + totalNumberOfMigrations +
                 ", percentageMigrated=" + percentageMigrated +
                 '}';
     }

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -77,7 +77,7 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     }
 
     @Override
-    public VersionOneToVersionTwoMigrationStatus copy() {
+    public InternalMigrationStatus copy() {
         return new VersionOneToVersionTwoMigrationStatus(
                 migrationId,
                 status,

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -5,10 +5,10 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     private static final int TOTAL_PERCENTAGE = 100;
 
     private final String migrationId;
+    private final int totalNumberOfMigrations;
 
     private Status status;
     private int numberOfMigrationsCompleted;
-    private int totalNumberOfMigrations;
 
     VersionOneToVersionTwoMigrationStatus(String migrationId,
                                           Status status,

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOneToVersionTwoMigrationStatus.java
@@ -4,12 +4,15 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
 
     private static final int TOTAL_PERCENTAGE = 100;
 
+    private final String migrationId;
+
     private Status status;
     private int numberOfBatches;
     private int totalNumberOfBatches;
     private int percentageMigrated;
 
-    VersionOneToVersionTwoMigrationStatus(Status status, int numberOfBatches, int totalNumberOfBatches, int percentageMigrated) {
+    VersionOneToVersionTwoMigrationStatus(String migrationId, Status status, int numberOfBatches, int totalNumberOfBatches, int percentageMigrated) {
+        this.migrationId = migrationId;
         this.status = status;
         this.numberOfBatches = numberOfBatches;
         this.totalNumberOfBatches = totalNumberOfBatches;
@@ -45,6 +48,11 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
     @Override
     public void markAsComplete() {
         status = Status.COMPLETE;
+    }
+
+    @Override
+    public String migrationId() {
+        return migrationId;
     }
 
     @Override
@@ -87,12 +95,16 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
         if (percentageMigrated != that.percentageMigrated) {
             return false;
         }
+        if (migrationId != null ? !migrationId.equals(that.migrationId) : that.migrationId != null) {
+            return false;
+        }
         return status == that.status;
     }
 
     @Override
     public int hashCode() {
-        int result = status != null ? status.hashCode() : 0;
+        int result = migrationId != null ? migrationId.hashCode() : 0;
+        result = 31 * result + (status != null ? status.hashCode() : 0);
         result = 31 * result + numberOfBatches;
         result = 31 * result + totalNumberOfBatches;
         result = 31 * result + percentageMigrated;
@@ -101,11 +113,12 @@ class VersionOneToVersionTwoMigrationStatus implements InternalMigrationStatus {
 
     @Override
     public String toString() {
-        return "VersionOneToVersionTwoMigrationStatus{"
-                + "status=" + status
-                + ", numberOfBatches=" + numberOfBatches
-                + ", totalNumberOfBatches=" + totalNumberOfBatches
-                + ", percentageMigrated=" + percentageMigrated
-                + '}';
+        return "VersionOneToVersionTwoMigrationStatus{" +
+                "migrationId='" + migrationId + '\'' +
+                ", status=" + status +
+                ", numberOfBatches=" + numberOfBatches +
+                ", totalNumberOfBatches=" + totalNumberOfBatches +
+                ", percentageMigrated=" + percentageMigrated +
+                '}';
     }
 }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -7,5 +7,6 @@
   <string name="download_notification_content_completed">Completed</string>
   <string name="download_notification_content_progress">%d%% downloaded</string>
 
+  <string name="migration_notification_content_title">Migrating Download Manager V1</string>
   <string name="migration_notification_content_progress">%d%% migrated</string>
 </resources>

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -94,8 +94,8 @@ public class MigrationExtractorTest {
         secondFileMetadata.add(new Migration.FileMetadata("file_4", "data_4", new LiteFileSize(750, 750), fourthUri));
 
         return Arrays.asList(
-                new Migration(firstBatch, firstFileMetadata, 12345),
-                new Migration(secondBatch, secondFileMetadata, 67890)
+                new Migration(firstBatch, firstFileMetadata, 12345, Migration.Type.COMPLETE),
+                new Migration(secondBatch, secondFileMetadata, 67890, Migration.Type.COMPLETE)
         );
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -73,7 +73,7 @@ public class MigrationExtractorTest {
     private List<Migration> expectedMigrations() {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
-        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom("file_1"), "title_1")
+        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_1".hashCode())), "title_1")
                 .addFile(firstUri).apply()
                 .addFile(secondUri).apply()
                 .build();
@@ -84,7 +84,7 @@ public class MigrationExtractorTest {
 
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
-        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom("file_3"), "title_2")
+        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_3".hashCode())), "title_2")
                 .addFile(thirdUri).apply()
                 .addFile(fourthUri).apply()
                 .build();

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -73,7 +73,7 @@ public class MigrationExtractorTest {
     private List<Migration> expectedMigrations() {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
-        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom("1"), "title_1")
+        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom("file_1"), "title_1")
                 .addFile(firstUri).apply()
                 .addFile(secondUri).apply()
                 .build();
@@ -84,7 +84,7 @@ public class MigrationExtractorTest {
 
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
-        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom("2"), "title_2")
+        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom("file_3"), "title_2")
                 .addFile(thirdUri).apply()
                 .addFile(fourthUri).apply()
                 .build();


### PR DESCRIPTION
## Problem
This PR fixes a few problems with the `MigrationJob`:

- A client application needs to be able to specify the `DownloadBatchId` from version one 😬 otherwise it is unable to locate some additional data that is required to work with a download.
- The `MigrationJob` completes too quickly and relies on mutation of a `MigrationStatus`. If the `Migration` occurs too fast, given that we are reporting back to the `main-thread` using a `Handler` we could be potentially emitting the same status multiple times. It's mutated before the handler posts to the `main-thread`, modifying an already existing reference 😬 
- The `MigrationJob` uses the `hashcode` of the entire `MigrationStatus` object when posting notifications 😬 so it will recreate notifications each and every time / may not remove persistent notifications etc because they all rely on the notification ids being the same! 
- Partial migrations were never taken into account when updating the migration percentage 😬 

## Solution

- For now we are using the `notificationExtras` from the first `file` retrieved from the `Downloads` table in v1 for the `DownloadBatchId`. We will need to provide a different mechanism for specifying the mapping before we release this library publicly. 
- It's ok to mutate the `MigrationStatus` anywhere we have control of it **BUT** before we give control of it over to clients we should create an `ImmutableCopy`.
- Use the `hashcode` of the migration job identifier as the notification id. So all notifications from a given `MigrationJob` share the same notification. 
- Ensure that the `total` and `current` completed migrations and the associated migration percentage is driven by both the partial and complete migrations. 

## Screen Capture
![migration mp4](https://user-images.githubusercontent.com/3380092/37150664-6d600d8a-22ca-11e8-8d6a-8e9b51229563.gif)

