### PR TITLE
Reschedule job improvements

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -181,7 +181,9 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     @Override
-    public void getDownloadFileStatusWithMatching(DownloadBatchId downloadBatchId, DownloadFileId downloadFileId, DownloadFileStatusCallback callback) {
+    public void getDownloadFileStatusWithMatching(DownloadBatchId downloadBatchId,
+                                                  DownloadFileId downloadFileId,
+                                                  DownloadFileStatusCallback callback) {
         executor.submit((Runnable) () -> Wait.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(() -> {
                     DownloadFileStatus downloadFileStatus = executeGetDownloadStatusWithMatching(downloadBatchId, downloadFileId);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -176,7 +176,11 @@ public final class DownloadManagerBuilder {
     }
 
     public DownloadManagerBuilder withNotification(NotificationCustomizer<DownloadBatchStatus> notificationCustomizer) {
-        this.notificationCreator = new DownloadBatchStatusNotificationCreator(applicationContext, notificationCustomizer, notificationChannelProvider);
+        this.notificationCreator = new DownloadBatchStatusNotificationCreator(
+                applicationContext,
+                notificationCustomizer,
+                notificationChannelProvider
+        );
         return this;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
@@ -12,6 +12,7 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
 
     private static final long ONE_SECOND_IN_MILLIS = TimeUnit.SECONDS.toMillis(1);
     private static final long FIVE_MINUTES_IN_MILLIS = TimeUnit.MINUTES.toMillis(5);
+    private static final boolean ENFORCE_NETWORK_REQUIREMENTS = true;
 
     private ConnectionType connectionType;
 
@@ -24,7 +25,8 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
     @Override
     public void scheduleRecovery() {
         JobRequest.Builder builder = new JobRequest.Builder(LiteJobCreator.TAG)
-                .setExecutionWindow(ONE_SECOND_IN_MILLIS, FIVE_MINUTES_IN_MILLIS);
+                .setExecutionWindow(ONE_SECOND_IN_MILLIS, FIVE_MINUTES_IN_MILLIS)
+                .setRequirementsEnforced(ENFORCE_NETWORK_REQUIREMENTS);
 
         switch (connectionType) {
             case ALL:

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
@@ -21,7 +21,7 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
     @Override
     public void scheduleRecovery() {
         JobRequest.Builder builder = new JobRequest.Builder(LiteJobCreator.TAG)
-                .setExecutionWindow(TimeUnit.SECONDS.toMillis(1), TimeUnit.DAYS.toMillis(1));
+                .setExecutionWindow(TimeUnit.SECONDS.toMillis(1), TimeUnit.MINUTES.toMillis(5));
 
         switch (connectionType) {
             case ALL:

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
@@ -10,6 +10,9 @@ import java.util.concurrent.TimeUnit;
 
 class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
 
+    private static final long ONE_SECOND_IN_MILLIS = TimeUnit.SECONDS.toMillis(1);
+    private static final long FIVE_MINUTES_IN_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
     private ConnectionType connectionType;
 
     LiteDownloadsNetworkRecoveryEnabled(Context context, DownloadManager downloadManager, ConnectionType connectionType) {
@@ -21,7 +24,7 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
     @Override
     public void scheduleRecovery() {
         JobRequest.Builder builder = new JobRequest.Builder(LiteJobCreator.TAG)
-                .setExecutionWindow(TimeUnit.SECONDS.toMillis(1), TimeUnit.MINUTES.toMillis(5));
+                .setExecutionWindow(ONE_SECOND_IN_MILLIS, FIVE_MINUTES_IN_MILLIS);
 
         switch (connectionType) {
             case ALL:

--- a/library/src/main/java/com/novoda/downloadmanager/LiteJobCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteJobCreator.java
@@ -5,7 +5,7 @@ import com.evernote.android.job.JobCreator;
 
 class LiteJobCreator implements JobCreator {
 
-    static final String TAG = "test";
+    static final String TAG = "download-manager-reschedule";
 
     private final DownloadManager downloadManager;
 
@@ -16,7 +16,7 @@ class LiteJobCreator implements JobCreator {
     @Override
     public Job create(String tag) {
         if (tag.equals(TAG)) {
-           return new LiteJobDownload(downloadManager);
+            return new LiteJobDownload(downloadManager);
         }
 
         return null;

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationStatusNotificationCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationStatusNotificationCreator.java
@@ -10,7 +10,9 @@ class MigrationStatusNotificationCreator implements NotificationCreator<Migratio
     private final NotificationCustomizer<MigrationStatus> notificationCustomizer;
     private NotificationChannelProvider notificationChannelProvider;
 
-    MigrationStatusNotificationCreator(Context context, NotificationCustomizer<MigrationStatus> customizer, NotificationChannelProvider notificationChannelProvider) {
+    MigrationStatusNotificationCreator(Context context,
+                                       NotificationCustomizer<MigrationStatus> customizer,
+                                       NotificationChannelProvider notificationChannelProvider) {
         this.applicationContext = context.getApplicationContext();
         this.notificationCustomizer = customizer;
         this.notificationChannelProvider = notificationChannelProvider;

--- a/library/src/main/java/com/novoda/downloadmanager/NotificationChannelProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationChannelProvider.java
@@ -8,6 +8,6 @@ interface NotificationChannelProvider {
 
     @RequiresApi(Build.VERSION_CODES.O)
     void registerNotificationChannel(Context context);
-    
+
     String channelId();
 }


### PR DESCRIPTION
## Problem
Network recovery jobs are taking a life time to execute and they ignore whether a network connection actually exists 😬 

According to the docs: 

```
 * Note that if the deadline is met and the requirements aren't enforced, then your job
 * will run and ignore this requirement.
```

```
 * <b>NOTE:</b> It's not recommended to have such big execution windows. The {@code AlarmManager} used
 * as fallback API doesn't allow setting a start date. Although being inexact, the execution time is
 * the arithmetic average of {@code startInMs} and {@code endInMs}. The result could be that your job never
 * runs on pre Android 5.0 devices, if one argument is too large.
```

## Solution
Ensure that we `enforceRequirements` so that the job does not run unless we have met the network requirements. 

Change the window end time to 5mins so that we don't take half a day for a job to start on pre-5 devices 😬 

Update the `Job.TAG` to something more meaningful than `test` 😄 