### PR TITLE
Avoid duplicated fileId

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -1,7 +1,9 @@
 package com.novoda.downloadmanager;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class Batch {
 
@@ -105,7 +107,23 @@ public class Batch {
 
         @Override
         public Batch build() {
+            ensureNoFileIdDuplicates(batchFiles);
             return new Batch(downloadBatchId, title, batchFiles);
+        }
+
+        private void ensureNoFileIdDuplicates(List<BatchFile> batchFiles) {
+            Set<String> rawIdsWithoutDuplicates = new HashSet<>();
+            for (BatchFile batchFile : batchFiles) {
+                if (batchFile.downloadFileId().isPresent()) {
+                    rawIdsWithoutDuplicates.add(batchFile.downloadFileId().get().rawId());
+                } else {
+                    rawIdsWithoutDuplicates.add(batchFile.networkAddress());
+                }
+            }
+
+            if (rawIdsWithoutDuplicates.size() != batchFiles.size()) {
+                throw new IllegalArgumentException(String.format("Duplicated file for batch %s (batchId: %s)", title, downloadBatchId.rawId()));
+            }
         }
 
     }

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -112,13 +112,9 @@ public class Batch {
         }
 
         private void ensureNoFileIdDuplicates(List<BatchFile> batchFiles) {
-            Set<String> rawIdsWithoutDuplicates = new HashSet<>();
+            Set<DownloadFileId> rawIdsWithoutDuplicates = new HashSet<>();
             for (BatchFile batchFile : batchFiles) {
-                if (batchFile.downloadFileId().isPresent()) {
-                    rawIdsWithoutDuplicates.add(batchFile.downloadFileId().get().rawId());
-                } else {
-                    rawIdsWithoutDuplicates.add(batchFile.networkAddress());
-                }
+                rawIdsWithoutDuplicates.add(FallbackDownloadFileIdProvider.downloadFileIdFor(downloadBatchId, batchFile));
             }
 
             if (rawIdsWithoutDuplicates.size() != batchFiles.size()) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -37,7 +37,7 @@ final class DownloadBatchFactory {
             FilePath filePath = FilePathCreator.create(basePath, prependBatchIdTo(relativePathFrom(batchFile), downloadBatchId));
             FileName fileName = FileNameExtractor.extractFrom(filePath.path());
 
-            DownloadFileId downloadFileId = downloadFileIdFrom(batch, batchFile);
+            DownloadFileId downloadFileId = FallbackDownloadFileIdProvider.downloadFileIdFor(batch.downloadBatchId(), batchFile);
             InternalDownloadFileStatus downloadFileStatus = new LiteDownloadFileStatus(
                     downloadBatchId,
                     downloadFileId,
@@ -94,11 +94,6 @@ final class DownloadBatchFactory {
     private static String relativePathFrom(BatchFile batchFile) {
         String fileNameFromNetworkAddress = FileNameExtractor.extractFrom(batchFile.networkAddress()).name();
         return batchFile.relativePath().or(fileNameFromNetworkAddress);
-    }
-
-    private static DownloadFileId downloadFileIdFrom(Batch batch, BatchFile batchFile) {
-        String rawId = batch.downloadBatchId().rawId() + batchFile.networkAddress();
-        return batchFile.downloadFileId().or(DownloadFileIdCreator.createFrom(rawId));
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/FallbackDownloadFileIdProvider.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FallbackDownloadFileIdProvider.java
@@ -1,0 +1,13 @@
+package com.novoda.downloadmanager;
+
+final class FallbackDownloadFileIdProvider {
+
+    private FallbackDownloadFileIdProvider() {
+        // non instantiable
+    }
+
+    static DownloadFileId downloadFileIdFor(DownloadBatchId downloadBatchId, BatchFile batchFile) {
+        String fallbackId = downloadBatchId.rawId() + batchFile.networkAddress();
+        return batchFile.downloadFileId().or(DownloadFileIdCreator.createFrom(fallbackId));
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -55,6 +57,7 @@ class LiteDownloadManagerDownloader {
     public void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         DownloadBatch runningDownloadBatch = downloadBatchMap.get(batch.downloadBatchId());
         if (runningDownloadBatch != null) {
+            Log.w("Ignoring duplicate batch with id " + batch.downloadBatchId());
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -57,7 +57,10 @@ class LiteDownloadManagerDownloader {
     public void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         DownloadBatch runningDownloadBatch = downloadBatchMap.get(batch.downloadBatchId());
         if (runningDownloadBatch != null) {
-            Log.w("Ignoring duplicate batch with id " + batch.downloadBatchId());
+            Log.w(String.format(
+                    "Already running download for DownloadBatchId: %s, ensure you are not duplicating identifiers.",
+                    batch.downloadBatchId().rawId()
+            ));
             return;
         }
 

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -38,4 +38,20 @@ public class BatchBuilderTest {
         assertThat(batch).isEqualTo(expectedBatch);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsException_whenDuplicatedFileIDsAreSupplied() {
+        Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
+                .addFile("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
+                .addFile("another_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
+                .build();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void throwsException_whenDuplicatedNetworkAddressWithoutFileIDsAreSupplied() {
+        Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
+                .addFile("net_address").apply()
+                .addFile("net_address").apply()
+                .build();
+    }
+
 }


### PR DESCRIPTION
### Problem
Before it was possible for a client to pass the same FileId multiple times when creating a Batch.
This was causing the DownloadBatch download logic to fail when checking the total batch size.
The same was happening when adding multiple files to a Batch without FileId but with the same network address.

### Solution
We decided to fail fast during the `Batch` creation, checking if the builder is configured with duplicated file Ids.
Added tests about that.
