### PR TITLE
Queueing and deleting the same batches crashes the application

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 
 import java.util.List;
 import java.util.Map;
@@ -261,6 +262,7 @@ class DownloadBatch {
         );
     }
 
+    @WorkerThread
     void persist() {
         downloadsBatchPersistence.persist(
                 downloadBatchStatus.getDownloadBatchTitle(),

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.List;
 import java.util.Map;
 
@@ -250,8 +252,19 @@ class DownloadBatch {
         return null;
     }
 
-    void persist() {
+    void persistAsync() {
         downloadsBatchPersistence.persistAsync(
+                downloadBatchStatus.getDownloadBatchTitle(),
+                downloadBatchStatus.getDownloadBatchId(),
+                downloadBatchStatus.status(),
+                downloadFiles,
+                downloadBatchStatus.downloadedDateTimeInMillis(),
+                downloadBatchStatus.notificationSeen()
+        );
+    }
+
+    void persist() {
+        downloadsBatchPersistence.persist(
                 downloadBatchStatus.getDownloadBatchTitle(),
                 downloadBatchStatus.getDownloadBatchId(),
                 downloadBatchStatus.status(),

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.List;
 import java.util.Map;
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -46,7 +46,7 @@ final class DownloadBatchFactory {
                     filePath
             );
 
-            FileDownloader fileDownloader = fileOperations.fileDownloader();
+            FileDownloader fileDownloader = fileOperations.fileDownloaderCreator().create();
             FileSizeRequester fileSizeRequester = fileOperations.fileSizeRequester();
 
             DownloadFile downloadFile = new DownloadFile(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -18,7 +18,6 @@ import android.support.v4.app.NotificationManagerCompat;
 
 import com.novoda.merlin.MerlinsBeard;
 import com.novoda.notils.logger.simple.Log;
-import com.squareup.okhttp.OkHttpClient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,14 +37,13 @@ public final class DownloadManagerBuilder {
     private static final Object SERVICE_LOCK = new Object();
     private static final Object CALLBACK_LOCK = new Object();
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
-    private static final int TIMEOUT = 5;
 
     private final Context applicationContext;
     private final Handler callbackHandler;
 
     private FilePersistenceCreator filePersistenceCreator;
     private FileSizeRequester fileSizeRequester;
-    private FileDownloader fileDownloader;
+    private FileDownloaderCreator fileDownloaderCreator;
     private DownloadService downloadService;
     private DownloadManager downloadManager;
     private NotificationCreator<DownloadBatchStatus> notificationCreator;
@@ -63,18 +61,13 @@ public final class DownloadManagerBuilder {
         Context applicationContext = context.getApplicationContext();
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(applicationContext);
-
-        DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(applicationContext);
-
-        OkHttpClient okHttpClient = new OkHttpClient();
-        okHttpClient.setConnectTimeout(TIMEOUT, TimeUnit.SECONDS);
-        okHttpClient.setWriteTimeout(TIMEOUT, TimeUnit.SECONDS);
-        okHttpClient.setReadTimeout(TIMEOUT, TimeUnit.SECONDS);
-        HttpClient httpClient = new WrappedOkHttpClient(okHttpClient);
+        FileDownloaderCreator fileDownloaderCreator = FileDownloaderCreator.newNetworkFileDownloaderCreator();
 
         NetworkRequestCreator requestCreator = new NetworkRequestCreator();
+        HttpClient httpClient = HttpClientFactory.getInstance();
         FileSizeRequester fileSizeRequester = new NetworkFileSizeRequester(httpClient, requestCreator);
-        FileDownloader fileDownloader = new NetworkFileDownloader(httpClient, requestCreator);
+
+        DownloadsPersistence downloadsPersistence = RoomDownloadsPersistence.newInstance(applicationContext);
 
         NotificationChannelProvider notificationChannelProvider = new DefaultNotificationChannelProvider(
                 context.getResources().getString(R.string.download_notification_channel_name),
@@ -102,7 +95,7 @@ public final class DownloadManagerBuilder {
                 filePersistenceCreator,
                 downloadsPersistence,
                 fileSizeRequester,
-                fileDownloader,
+                fileDownloaderCreator,
                 notificationChannelProvider,
                 notificationCreator,
                 connectionTypeAllowed,
@@ -117,7 +110,7 @@ public final class DownloadManagerBuilder {
                                    FilePersistenceCreator filePersistenceCreator,
                                    DownloadsPersistence downloadsPersistence,
                                    FileSizeRequester fileSizeRequester,
-                                   FileDownloader fileDownloader,
+                                   FileDownloaderCreator fileDownloaderCreator,
                                    NotificationChannelProvider notificationChannelProvider,
                                    NotificationCreator<DownloadBatchStatus> notificationCreator,
                                    ConnectionType connectionTypeAllowed,
@@ -128,7 +121,7 @@ public final class DownloadManagerBuilder {
         this.filePersistenceCreator = filePersistenceCreator;
         this.downloadsPersistence = downloadsPersistence;
         this.fileSizeRequester = fileSizeRequester;
-        this.fileDownloader = fileDownloader;
+        this.fileDownloaderCreator = fileDownloaderCreator;
         this.notificationChannelProvider = notificationChannelProvider;
         this.notificationCreator = notificationCreator;
         this.connectionTypeAllowed = connectionTypeAllowed;
@@ -146,9 +139,9 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder withFileDownloaderCustom(FileSizeRequester fileSizeRequester, FileDownloader fileDownloader) {
+    public DownloadManagerBuilder withFileDownloaderCustom(FileSizeRequester fileSizeRequester, Class<? extends FileDownloader> customFileDownloaderClass) {
         this.fileSizeRequester = fileSizeRequester;
-        this.fileDownloader = fileDownloader;
+        this.fileDownloaderCreator = FileDownloaderCreator.newCustomFileDownloaderCreator(customFileDownloaderClass);
         return this;
     }
 
@@ -238,7 +231,7 @@ public final class DownloadManagerBuilder {
 
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
-        FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloader);
+        FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloaderCreator);
         List<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.WorkerThread;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,11 +34,12 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                       List<DownloadFile> downloadFiles,
                       long downloadedDateTimeInMillis,
                       boolean notificationSeen) {
-        executor.execute(() -> {
-            persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen);
-        });
+        executor.execute(
+                () -> persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen)
+        );
     }
 
+    @WorkerThread
     void persist(DownloadBatchTitle downloadBatchTitle,
                  DownloadBatchId downloadBatchId,
                  DownloadBatchStatus.Status status,
@@ -127,6 +130,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         });
     }
 
+    @WorkerThread
     void delete(DownloadBatchId downloadBatchId) {
         downloadsPersistence.startTransaction();
         try {
@@ -146,6 +150,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         executor.execute(() -> updateStatusAsync(downloadBatchId, status));
     }
 
+    @WorkerThread
     @Override
     public void updateStatus(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         downloadsPersistence.startTransaction();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
@@ -3,4 +3,6 @@ package com.novoda.downloadmanager;
 interface DownloadsBatchStatusPersistence {
 
     void updateStatusAsync(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
+
+    void updateStatus(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
@@ -67,7 +67,8 @@ class DownloadsFilePersistence {
             );
 
             FileSizeRequester fileSizeRequester = fileOperations.fileSizeRequester();
-            FileDownloader fileDownloader = fileOperations.fileDownloader();
+            FileDownloaderCreator fileDownloaderCreator = fileOperations.fileDownloaderCreator();
+            FileDownloader fileDownloader = fileDownloaderCreator.create();
 
             DownloadFile downloadFile = new DownloadFile(
                     batchId,

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloaderCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloaderCreator.java
@@ -1,0 +1,74 @@
+package com.novoda.downloadmanager;
+
+import android.support.annotation.Nullable;
+
+class FileDownloaderCreator {
+
+    private final FileDownloaderType type;
+    @Nullable
+    private final Class<? extends FileDownloader> customClass;
+
+    static FileDownloaderCreator newNetworkFileDownloaderCreator() {
+        return new FileDownloaderCreator(FileDownloaderType.NETWORK, null);
+    }
+
+    static FileDownloaderCreator newCustomFileDownloaderCreator(Class<? extends FileDownloader> customClass) {
+        return new FileDownloaderCreator(FileDownloaderType.CUSTOM, customClass);
+    }
+
+    FileDownloaderCreator(FileDownloaderType type, @Nullable Class<? extends FileDownloader> customClass) {
+        this.type = type;
+        this.customClass = customClass;
+    }
+
+    FileDownloader create() {
+        return create(type);
+    }
+
+    private FileDownloader create(FileDownloaderType type) {
+        FileDownloader fileDownloader;
+
+        switch (type) {
+            case NETWORK:
+                HttpClient httpClient = HttpClientFactory.getInstance();
+                NetworkRequestCreator requestCreator = new NetworkRequestCreator();
+                fileDownloader = new NetworkFileDownloader(httpClient, requestCreator);
+                break;
+            case CUSTOM:
+                fileDownloader = createCustomFileDownloader();
+                break;
+            default:
+                throw new IllegalStateException("Persistence of type " + type + " is not supported");
+        }
+
+        return fileDownloader;
+    }
+
+    private FileDownloader createCustomFileDownloader() {
+        if (customClass == null) {
+            throw new CustomFilePersistenceException("CustomFilePersistence class cannot be accessed, is it public?");
+        }
+
+        try {
+            ClassLoader systemClassLoader = getClass().getClassLoader();
+            Class<?> customFilePersistenceClass = systemClassLoader.loadClass(customClass.getCanonicalName());
+            return (FileDownloader) customFilePersistenceClass.newInstance();
+        } catch (IllegalAccessException e) {
+            throw new CustomFilePersistenceException(customClass, "Class cannot be accessed, is it public?", e);
+        } catch (ClassNotFoundException e) {
+            throw new CustomFilePersistenceException(customClass, "Class does not exist", e);
+        } catch (InstantiationException e) {
+            throw new CustomFilePersistenceException(customClass, "Class cannot be instantiated", e);
+        }
+    }
+
+    private static class CustomFilePersistenceException extends RuntimeException {
+        CustomFilePersistenceException(Class customClass, String message, Exception cause) {
+            super(customClass.getSimpleName() + ": " + message, cause);
+        }
+
+        CustomFilePersistenceException(String message) {
+            super(message);
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloaderType.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloaderType.java
@@ -1,0 +1,28 @@
+package com.novoda.downloadmanager;
+
+import java.security.InvalidParameterException;
+
+public enum FileDownloaderType {
+    NETWORK("network"),
+    CUSTOM("custom");
+
+    private final String rawValue;
+
+    FileDownloaderType(String rawValue) {
+        this.rawValue = rawValue;
+    }
+
+    static FileDownloaderType from(String rawValue) {
+        for (FileDownloaderType filePersistenceType : values()) {
+            if (filePersistenceType.rawValue.equals(rawValue)) {
+                return filePersistenceType;
+            }
+        }
+
+        throw new InvalidParameterException("Type " + rawValue + " is not supported");
+    }
+
+    String toRawValue() {
+        return rawValue;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/FileOperations.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileOperations.java
@@ -4,12 +4,12 @@ class FileOperations {
 
     private final FilePersistenceCreator filePersistenceCreator;
     private final FileSizeRequester fileSizeRequester;
-    private final FileDownloader fileDownloader;
+    private final FileDownloaderCreator fileDownloaderCreator;
 
-    FileOperations(FilePersistenceCreator filePersistenceCreator, FileSizeRequester fileSizeRequester, FileDownloader fileDownloader) {
+    FileOperations(FilePersistenceCreator filePersistenceCreator, FileSizeRequester fileSizeRequester, FileDownloaderCreator fileDownloaderCreator) {
         this.filePersistenceCreator = filePersistenceCreator;
         this.fileSizeRequester = fileSizeRequester;
-        this.fileDownloader = fileDownloader;
+        this.fileDownloaderCreator = fileDownloaderCreator;
     }
 
     FilePersistenceCreator filePersistenceCreator() {
@@ -20,7 +20,7 @@ class FileOperations {
         return fileSizeRequester;
     }
 
-    FileDownloader fileDownloader() {
-        return fileDownloader;
+    FileDownloaderCreator fileDownloaderCreator() {
+        return fileDownloaderCreator;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/HttpClientFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/HttpClientFactory.java
@@ -1,0 +1,31 @@
+package com.novoda.downloadmanager;
+
+import com.squareup.okhttp.OkHttpClient;
+
+import java.util.concurrent.TimeUnit;
+
+final class HttpClientFactory {
+
+    private static final int TIMEOUT = 5;
+
+    private HttpClientFactory() {
+        // non-instantiable class
+    }
+
+    public static HttpClient getInstance() {
+        return LazySingleton.INSTANCE;
+    }
+
+    private static class LazySingleton {
+
+        private static final HttpClient INSTANCE = createInstance();
+
+        private static HttpClient createInstance() {
+            OkHttpClient okHttpClient = new OkHttpClient();
+            okHttpClient.setConnectTimeout(TIMEOUT, TimeUnit.SECONDS);
+            okHttpClient.setWriteTimeout(TIMEOUT, TimeUnit.SECONDS);
+            okHttpClient.setReadTimeout(TIMEOUT, TimeUnit.SECONDS);
+            return new WrappedOkHttpClient(okHttpClient);
+        }
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -90,13 +90,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public void markAsPaused(DownloadsBatchStatusPersistence persistence) {
         status = Status.PAUSED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsQueued(DownloadsBatchStatusPersistence persistence) {
         status = Status.QUEUED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
@@ -109,23 +109,27 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
+    }
+
+    private void updateStatusAsync(Status status, DownloadsBatchStatusPersistence persistence) {
+        persistence.updateStatusAsync(downloadBatchId, status);
     }
 
     private void updateStatus(Status status, DownloadsBatchStatusPersistence persistence) {
-        persistence.updateStatusAsync(downloadBatchId, status);
+        persistence.updateStatus(downloadBatchId, status);
     }
 
     @Nullable

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
@@ -81,6 +82,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         return downloadedDateTimeInMillis;
     }
 
+    @WorkerThread
     @Override
     public void markAsDownloading(DownloadsBatchStatusPersistence persistence) {
         status = Status.DOWNLOADING;
@@ -105,23 +107,26 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         notificationSeen = false;
     }
 
+    @WorkerThread
     @Override
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
+    @WorkerThread
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
+    @WorkerThread
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
     private void updateStatusAsync(Status status, DownloadsBatchStatusPersistence persistence) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -69,7 +69,7 @@ class LiteDownloadManagerDownloader {
                 connectionChecker
         );
 
-        downloadBatch.persist();
+        downloadBatch.persistAsync();
         download(downloadBatch, downloadBatchMap);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -51,13 +51,14 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void download(final DownloadBatch downloadBatch, final DownloadBatchStatusCallback callback) {
+    public void download(DownloadBatch downloadBatch, DownloadBatchStatusCallback callback) {
         callback.onUpdate(downloadBatch.status());
 
         downloadBatch.setCallback(callback);
 
         executor.execute(() -> {
             acquireCpuWakeLock();
+            downloadBatch.persist();
             downloadBatch.download();
             releaseHeldCpuWakeLock();
         });

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +36,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     }
 
     @Override
-    public void persistBatch(final DownloadsBatchPersisted batchPersisted) {
+    public void persistBatch(DownloadsBatchPersisted batchPersisted) {
         RoomBatch roomBatch = new RoomBatch();
         roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -4,6 +4,11 @@ import android.os.Handler;
 
 import com.novoda.notils.logger.simple.Log;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,11 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InOrder;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.DownloadBatchIdFixtures.aDownloadBatchId;
@@ -55,6 +55,7 @@ public class DownloadManagerTest {
     private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
     private final FileOperations fileOperations = mock(FileOperations.class);
     private final FileDownloader fileDownloader = mock(FileDownloader.class);
+    private final FileDownloaderCreator fileDownloaderCreator = mock(FileDownloaderCreator.class);
     private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
     private final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
     private final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
@@ -136,7 +137,8 @@ public class DownloadManagerTest {
     }
 
     private void setupFileOperations() {
-        given(fileOperations.fileDownloader()).willReturn(fileDownloader);
+        given(fileOperations.fileDownloaderCreator()).willReturn(fileDownloaderCreator);
+        given(fileDownloaderCreator.create()).willReturn(fileDownloader);
     }
 
     @Test


### PR DESCRIPTION
**Problem**
1. Start the demo app
2. Click on download add
3. Click very fast delete and then download all again
4. Crash

**Solution**
The problem was that the deletion of a queued batch occurs in the batch thread and only happens when the batch finishes. But when we enqueue a new batch we immediately persist it.

When the same batch is queued -> deleted -> queued again very fast, the delayed deletion occurs after the second enqueue happens, then the second enqueue wants to use the database but the batch was previously deleted.

The solution is to ensure that the batch is persisted when the batch starts to download.