### PR TITLE
Migration with duplicated files

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -4,7 +4,9 @@ import android.database.Cursor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class MigrationExtractor {
 
@@ -56,6 +58,7 @@ class MigrationExtractor {
 
                 Batch.Builder newBatchBuilder = null;
                 List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
+                Set<String> uris = new HashSet<>();
 
                 try {
                     while (downloadsCursor.moveToNext()) {
@@ -68,6 +71,11 @@ class MigrationExtractor {
                             newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                         }
 
+                        if (uris.contains(originalNetworkAddress)) {
+                            continue;
+                        } else {
+                            uris.add(originalNetworkAddress);
+                        }
                         newBatchBuilder.addFile(originalNetworkAddress).apply();
 
                         FilePath filePath = new LiteFilePath(originalFileLocation);

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -3,7 +3,9 @@ package com.novoda.downloadmanager;
 import android.database.Cursor;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 class PartialDownloadMigrationExtractor {
 
@@ -41,6 +43,7 @@ class PartialDownloadMigrationExtractor {
             Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
             Batch.Builder newBatchBuilder = null;
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
+            Set<String> uris = new HashSet<>();
 
             while (downloadsCursor.moveToNext()) {
                 String originalFileId = downloadsCursor.getString(FILE_ID_COLUMN);
@@ -52,6 +55,11 @@ class PartialDownloadMigrationExtractor {
                     newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                 }
 
+                if (uris.contains(uri)) {
+                    continue;
+                } else {
+                    uris.add(uri);
+                }
                 newBatchBuilder.addFile(uri);
 
                 FileSize fileSize = FileSizeCreator.unknownFileSize();


### PR DESCRIPTION
### Problem
The client app crashes if migrating batches with duplicated files within.
This is due to the changes done in https://github.com/novoda/download-manager/pull/365

### Solution
Migrate files only once if already present with same URL