### PR TITLE
Partial migrations do not play

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -17,10 +17,10 @@ class PartialDownloadMigrationExtractor {
     private static final int TITLE_COLUMN = 1;
     private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
 
-    private static final String DOWNLOADS_QUERY = "SELECT uri, _data, notificationextras FROM Downloads WHERE batch_id = ?";
+    private static final String DOWNLOADS_QUERY = "SELECT uri, notificationextras FROM Downloads WHERE batch_id = ?";
     private static final int URI_COLUMN = 0;
-    private static final int FILE_NAME_COLUMN = 1;
-    private static final int FILE_ID_COLUMN = 2;
+    private static final int FILE_ID_COLUMN = 1;
+    private static final String UNKNOWN_ORIGINAL_LOCATION = "";
 
     private final SqlDatabaseWrapper database;
 
@@ -45,17 +45,16 @@ class PartialDownloadMigrationExtractor {
             while (downloadsCursor.moveToNext()) {
                 String originalFileId = downloadsCursor.getString(FILE_ID_COLUMN);
                 String uri = downloadsCursor.getString(URI_COLUMN);
-                String originalFileName = downloadsCursor.getString(FILE_NAME_COLUMN);
 
                 if (downloadsCursor.isFirst()) {
                     DownloadBatchId downloadBatchId = createDownloadBatchIdFrom(originalFileId, batchId);
                     newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                 }
 
-                newBatchBuilder.addFile(uri);
+                newBatchBuilder.addFile(uri).apply();
 
                 FileSize fileSize = FileSizeCreator.unknownFileSize();
-                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileId, originalFileName, fileSize, uri);
+                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(originalFileId, UNKNOWN_ORIGINAL_LOCATION, fileSize, uri);
                 fileMetadataList.add(fileMetadata);
             }
             downloadsCursor.close();


### PR DESCRIPTION
## Problem
It seems that partial migrations are unable to play in client applications 🤔 after some investigation the `originalFileLocation` was being supplied for `Partials` even though we retrigger these in the download-manager 😬 sometimes this `originalFileLocation` can be incorrect or missing 😱 

## Solution
Do not provide an `originalFileLocation` for partial migrations. 