### PR TITLE
Fix crash with queue-delete-pause actions while in fast spamming

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomDownloadsPersistence.java
@@ -56,17 +56,20 @@ public class CustomDownloadsPersistence implements DownloadsPersistence {
     }
 
     @Override
-    public void delete(DownloadBatchId downloadBatchId) {
+    public boolean delete(DownloadBatchId downloadBatchId) {
         Log.v("Delete batch id: " + downloadBatchId.rawId());
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
+    public boolean update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         Log.v("update batch id: " + downloadBatchId.rawId() + " with status: " + status);
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+    public boolean update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
         Log.v("update batch id: " + downloadBatchId.rawId() + " with notificationSeen: " + notificationSeen);
+        return true;
     }
 }

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -24,6 +24,7 @@ public class DemoApplication extends Application {
 
         liteDownloadManagerCommands = DownloadManagerBuilder
                 .newInstance(this, handler, R.mipmap.ic_launcher_round)
+                .withLogs()
                 .build();
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -55,8 +55,6 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Log.setShowLogs(true);
-
         downloadMigrator = DownloadMigratorBuilder.newInstance(this, R.mipmap.ic_launcher_round)
                 .withNotificationChannel(
                         "chocolate",

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 
 import java.util.List;
 import java.util.Map;
@@ -261,6 +262,7 @@ class DownloadBatch {
         );
     }
 
+    @WorkerThread
     void persist() {
         downloadsBatchPersistence.persist(
                 downloadBatchStatus.getDownloadBatchTitle(),

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -55,15 +55,18 @@ class DownloadBatch {
 
         if (status == DELETED) {
             deleteBatchIfNeeded();
+            notifyCallback(downloadBatchStatus);
             return;
         }
 
         if (status == PAUSED) {
+            notifyCallback(downloadBatchStatus);
             return;
         }
 
         if (connectionNotAllowedForDownload(status)) {
             processNetworkError();
+            notifyCallback(downloadBatchStatus);
             return;
         }
 
@@ -79,6 +82,7 @@ class DownloadBatch {
         if (totalBatchSizeBytes <= ZERO_BYTES) {
             deleteBatchIfNeeded();
             processNetworkError();
+            notifyCallback(downloadBatchStatus);
             return;
         }
 
@@ -98,8 +102,9 @@ class DownloadBatch {
             processNetworkError();
         }
 
-        callbackThrottle.stopUpdates();
+        notifyCallback(downloadBatchStatus);
         deleteBatchIfNeeded();
+        callbackThrottle.stopUpdates();
     }
 
     private void deleteBatchIfNeeded() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.List;
 import java.util.Map;
 
@@ -250,8 +252,19 @@ class DownloadBatch {
         return null;
     }
 
-    void persist() {
+    void persistAsync() {
         downloadsBatchPersistence.persistAsync(
+                downloadBatchStatus.getDownloadBatchTitle(),
+                downloadBatchStatus.getDownloadBatchId(),
+                downloadBatchStatus.status(),
+                downloadFiles,
+                downloadBatchStatus.downloadedDateTimeInMillis(),
+                downloadBatchStatus.notificationSeen()
+        );
+    }
+
+    void persist() {
+        downloadsBatchPersistence.persist(
                 downloadBatchStatus.getDownloadBatchTitle(),
                 downloadBatchStatus.getDownloadBatchId(),
                 downloadBatchStatus.status(),

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -150,7 +150,7 @@ class DownloadBatch {
                                             DownloadsBatchPersistence downloadsBatchPersistence,
                                             DownloadBatchStatusCallback callback) {
         if (downloadBatchStatus.status() == DELETING) {
-            downloadsBatchPersistence.delete(downloadBatchStatus);
+            downloadsBatchPersistence.deleteSync(downloadBatchStatus);
             Log.v("deleteBatchIfNeeded markAsDeleted: " + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadBatchStatus.markAsDeleted();
             notifyCallback(callback, downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -182,7 +182,7 @@ class DownloadBatch {
             if (downloadBatchStatus.status() == DELETED) {
                 return 0;
             }
-            Log.v("Ferran, DownloadBatch.getTotalSize() " + downloadBatchStatus.getDownloadBatchId().rawId() + ", status: " + downloadBatchStatus.status());
+            Log.v("DownloadBatch.getTotalSize() " + downloadBatchStatus.getDownloadBatchId().rawId() + ", status: " + downloadBatchStatus.status());
             long totalFileSize = downloadFile.getTotalSize();
             if (totalFileSize == 0) {
                 return 0;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -155,9 +155,7 @@ class DownloadBatch {
     private static void deleteBatchIfNeeded(InternalDownloadBatchStatus downloadBatchStatus,
                                             DownloadsBatchPersistence downloadsBatchPersistence,
                                             DownloadBatchStatusCallback callback) {
-        if (downloadBatchStatus.status() == DELETING) {
-            Log.v("deleteBatchIfNeeded: " + downloadBatchStatus.getDownloadBatchId().rawId());
-            downloadsBatchPersistence.deleteSync(downloadBatchStatus);
+        if (downloadBatchStatus.status() == DELETING && downloadsBatchPersistence.deleteSync(downloadBatchStatus)) {
             downloadBatchStatus.markAsDeleted();
             notifyCallback(callback, downloadBatchStatus);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 
 import com.novoda.notils.logger.simple.Log;
 
@@ -352,6 +353,7 @@ class DownloadBatch {
         );
     }
 
+    @WorkerThread
     void persist() {
         downloadsBatchPersistence.persist(
                 downloadBatchStatus.getDownloadBatchTitle(),

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.List;
 import java.util.Map;
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -9,6 +9,9 @@ import java.util.List;
 final class DownloadBatchFactory {
 
     private static final boolean NOTIFICATION_NOT_SEEN = false;
+    private static final int BYTES_DOWNLOADED = 0;
+    private static final int TOTAL_BATCH_SIZE_BYTES = 0;
+    private static final Optional<DownloadError> DOWNLOAD_ERROR = Optional.absent();
 
     private DownloadBatchFactory() {
         // non instantiable factory class
@@ -72,8 +75,11 @@ final class DownloadBatchFactory {
                 downloadBatchId,
                 downloadBatchTitle,
                 downloadedDateTimeInMillis,
-                DownloadBatchStatus.Status.QUEUED,
-                NOTIFICATION_NOT_SEEN
+                BYTES_DOWNLOADED,
+                TOTAL_BATCH_SIZE_BYTES,
+                DownloadBatchStatus.Status.UNKNOWN,
+                NOTIFICATION_NOT_SEEN,
+                DOWNLOAD_ERROR
         );
 
         return new DownloadBatch(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -2,6 +2,7 @@ package com.novoda.downloadmanager;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -64,6 +65,8 @@ final class DownloadBatchFactory {
             );
             downloadFiles.add(downloadFile);
         }
+
+        downloadFiles = Collections.unmodifiableList(downloadFiles);
 
         InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                 downloadBatchId,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -11,9 +11,11 @@ public interface DownloadBatchStatus {
         DOWNLOADING,
         PAUSED,
         ERROR,
+        DELETING,
         DELETED,
         DOWNLOADED,
-        WAITING_FOR_NETWORK;
+        WAITING_FOR_NETWORK,
+        UNKNOWN;
 
         public String toRawValue() {
             return this.name();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -17,6 +17,7 @@ class DownloadBatchStatusNotificationDispatcher {
     }
 
     void updateNotification(DownloadBatchStatus downloadBatchStatus) {
+        Log.v("start updateNotification: " + downloadBatchStatus);
         if (downloadBatchStatus.notificationSeen()) {
             Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
             return;
@@ -27,6 +28,7 @@ class DownloadBatchStatusNotificationDispatcher {
         }
 
         notificationDispatcher.updateNotification(downloadBatchStatus);
+        Log.v("end updateNotification: " + downloadBatchStatus);
     }
 
     void setDownloadService(DownloadService downloadService) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -37,7 +37,9 @@ class DownloadBatchStatusNotificationDispatcher {
 
         if (notificationIsNotMarkedAsSeenYet(downloadBatchStatus, rawDownloadBatchId)) {
             downloadBatchIdNotificationSeen.add(rawDownloadBatchId);
-            Log.v("start updateNotificationSeenAsync " + rawDownloadBatchId + ", seen: " + NOTIFICATION_SEEN + ", status: " + downloadBatchStatus.status());
+            Log.v("start updateNotificationSeenAsync " + rawDownloadBatchId
+                    + ", seen: " + NOTIFICATION_SEEN
+                    + ", status: " + downloadBatchStatus.status());
             notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus, NOTIFICATION_SEEN);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -2,33 +2,50 @@ package com.novoda.downloadmanager;
 
 import com.novoda.notils.logger.simple.Log;
 
+import java.util.Set;
+
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 
 class DownloadBatchStatusNotificationDispatcher {
 
     private static final boolean NOTIFICATION_SEEN = true;
+
     private final DownloadsNotificationSeenPersistence notificationSeenPersistence;
     private final ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
+    private final Set<String> downloadBatchIdNotificationSeen;
 
     DownloadBatchStatusNotificationDispatcher(DownloadsNotificationSeenPersistence notificationSeenPersistence,
-                                              ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher) {
+                                              ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher,
+                                              Set<String> downloadBatchIdNotificationSeen) {
         this.notificationSeenPersistence = notificationSeenPersistence;
         this.notificationDispatcher = notificationDispatcher;
+        this.downloadBatchIdNotificationSeen = downloadBatchIdNotificationSeen;
     }
 
     void updateNotification(DownloadBatchStatus downloadBatchStatus) {
-        Log.v("start updateNotification: " + downloadBatchStatus);
         if (downloadBatchStatus.notificationSeen()) {
             Log.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
             return;
         }
 
-        if (downloadBatchStatus.status() == DOWNLOADED) {
+        String rawDownloadBatchId = downloadBatchStatus.getDownloadBatchId().rawId();
+
+        if (downloadBatchStatus.status() == DELETED) {
+            downloadBatchIdNotificationSeen.remove(rawDownloadBatchId);
+        }
+
+        if (notificationIsNotMarkedAsSeenYet(downloadBatchStatus, rawDownloadBatchId)) {
+            downloadBatchIdNotificationSeen.add(rawDownloadBatchId);
+            Log.v("start updateNotificationSeenAsync " + rawDownloadBatchId + ", seen: " + NOTIFICATION_SEEN + ", status: " + downloadBatchStatus.status());
             notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus, NOTIFICATION_SEEN);
         }
 
         notificationDispatcher.updateNotification(downloadBatchStatus);
-        Log.v("end updateNotification: " + downloadBatchStatus);
+    }
+
+    private boolean notificationIsNotMarkedAsSeenYet(DownloadBatchStatus downloadBatchStatus, String rawDownloadBatchId) {
+        return downloadBatchStatus.status() == DOWNLOADED && !downloadBatchIdNotificationSeen.contains(rawDownloadBatchId);
     }
 
     void setDownloadService(DownloadService downloadService) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -23,7 +23,7 @@ class DownloadBatchStatusNotificationDispatcher {
         }
 
         if (downloadBatchStatus.status() == DOWNLOADED) {
-            notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus.getDownloadBatchId(), NOTIFICATION_SEEN);
+            notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus, NOTIFICATION_SEEN);
         }
 
         notificationDispatcher.updateNotification(downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -180,27 +180,19 @@ class DownloadFile {
         }
     }
 
+    @WorkerThread
     long getTotalSize() {
         if (fileSize.isTotalSizeUnknown()) {
             FileSize requestFileSize = fileSizeRequester.requestFileSize(url);
             fileSize.setTotalSize(requestFileSize.totalSize());
             Log.v("file getTotalSize for batchId: " + downloadBatchId + ", status: " + fileStatus().status() + ", fileId: " + fileStatus().downloadFileId().rawId());
-            persistAsync();
+            if (fileStatus().status() == DownloadFileStatus.Status.DELETED) {
+                return 0;
+            }
+            persist();
         }
 
         return fileSize.totalSize();
-    }
-
-    private void persistAsync() {
-        downloadsFilePersistence.persistAsync(
-                downloadBatchId,
-                fileName,
-                filePath,
-                fileSize,
-                url,
-                downloadFileStatus,
-                filePersistence.getType()
-        );
     }
 
     @WorkerThread

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -66,6 +66,7 @@ class DownloadFile {
             return;
         }
 
+        Log.v("persist file " + downloadFileId.rawId() + ", with status: " + downloadFileStatus.status());
         persist();
 
         if (fileSize.currentSize() == fileSize.totalSize()) {
@@ -185,7 +186,9 @@ class DownloadFile {
         if (fileSize.isTotalSizeUnknown()) {
             FileSize requestFileSize = fileSizeRequester.requestFileSize(url);
             fileSize.setTotalSize(requestFileSize.totalSize());
-            Log.v("file getTotalSize for batchId: " + downloadBatchId + ", status: " + fileStatus().status() + ", fileId: " + fileStatus().downloadFileId().rawId());
+            Log.v("file getTotalSize for batchId: " + downloadBatchId
+                    + ", status: " + fileStatus().status()
+                    + ", fileId: " + fileStatus().downloadFileId().rawId());
             if (fileStatus().status() == DownloadFileStatus.Status.DELETED) {
                 return 0;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -65,9 +65,8 @@ class DownloadFile {
         if (downloadFileStatus.isMarkedAsDeleted()) {
             return;
         }
-        Log.v("start DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
-        persistAsync();
-        Log.v("end DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
+
+        persist();
 
         if (fileSize.currentSize() == fileSize.totalSize()) {
             downloadFileStatus.update(fileSize, filePath);
@@ -170,28 +169,29 @@ class DownloadFile {
     }
 
     void delete() {
-        Log.v("start DownloadFile.delete() with " + downloadBatchId.rawId());
         if (downloadFileStatus.isMarkedAsDownloading()) {
             downloadFileStatus.markAsDeleted();
+            Log.v("mark file as deleted for batchId: " + downloadBatchId.rawId());
             fileDownloader.stopDownloading();
         } else {
             downloadFileStatus.markAsDeleted();
+            Log.v("mark file as deleted for batchId: " + downloadBatchId.rawId());
             filePersistence.delete(filePath);
         }
-        Log.v("end DownloadFile.delete() with " + downloadBatchId.rawId());
     }
 
     long getTotalSize() {
         if (fileSize.isTotalSizeUnknown()) {
             FileSize requestFileSize = fileSizeRequester.requestFileSize(url);
             fileSize.setTotalSize(requestFileSize.totalSize());
+            Log.v("file getTotalSize for batchId: " + downloadBatchId + ", status: " + fileStatus().status() + ", fileId: " + fileStatus().downloadFileId().rawId());
             persistAsync();
         }
 
         return fileSize.totalSize();
     }
 
-    void persistAsync() {
+    private void persistAsync() {
         downloadsFilePersistence.persistAsync(
                 downloadBatchId,
                 fileName,
@@ -204,7 +204,7 @@ class DownloadFile {
     }
 
     @WorkerThread
-    void persistSync() {
+    void persist() {
         downloadsFilePersistence.persistSync(
                 downloadBatchId,
                 fileName,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -67,7 +67,9 @@ class DownloadFile {
         }
 
         Log.v("persist file " + downloadFileId.rawId() + ", with status: " + downloadFileStatus.status());
-        persist();
+        if (persist()) {
+            return;
+        }
 
         if (fileSize.currentSize() == fileSize.totalSize()) {
             downloadFileStatus.update(fileSize, filePath);
@@ -199,8 +201,8 @@ class DownloadFile {
     }
 
     @WorkerThread
-    void persist() {
-        downloadsFilePersistence.persistSync(
+    boolean persist() {
+        return downloadsFilePersistence.persistSync(
                 downloadBatchId,
                 fileName,
                 filePath,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -67,8 +67,7 @@ class DownloadFile {
         }
 
         Log.v("persist file " + downloadFileId.rawId() + ", with status: " + downloadFileStatus.status());
-        boolean persist = persist();
-        if (!persist) {
+        if (!persist()) {
             Log.e("persisting file " + downloadFileId.rawId() + " with status " + downloadFileStatus.status() + " failed");
             return;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -67,7 +67,9 @@ class DownloadFile {
         }
 
         Log.v("persist file " + downloadFileId.rawId() + ", with status: " + downloadFileStatus.status());
-        if (persist()) {
+        boolean persist = persist();
+        if (!persist) {
+            Log.e("persisting file " + downloadFileId.rawId() + " with status " + downloadFileStatus.status() + " failed");
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -65,9 +65,9 @@ class DownloadFile {
         if (downloadFileStatus.isMarkedAsDeleted()) {
             return;
         }
-        Log.v("Ferran, start DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
+        Log.v("start DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
         persistAsync();
-        Log.v("Ferran, end DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
+        Log.v("end DownloadFile.persistSync with " + downloadBatchId.rawId() + ", status: " + downloadFileStatus.status());
 
         if (fileSize.currentSize() == fileSize.totalSize()) {
             downloadFileStatus.update(fileSize, filePath);
@@ -170,7 +170,7 @@ class DownloadFile {
     }
 
     void delete() {
-        Log.v("Ferran, start DownloadFile.delete() with " + downloadBatchId.rawId());
+        Log.v("start DownloadFile.delete() with " + downloadBatchId.rawId());
         if (downloadFileStatus.isMarkedAsDownloading()) {
             downloadFileStatus.markAsDeleted();
             fileDownloader.stopDownloading();
@@ -178,7 +178,7 @@ class DownloadFile {
             downloadFileStatus.markAsDeleted();
             filePersistence.delete(filePath);
         }
-        Log.v("Ferran, end DownloadFile.delete() with " + downloadBatchId.rawId());
+        Log.v("end DownloadFile.delete() with " + downloadBatchId.rawId());
     }
 
     long getTotalSize() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -76,7 +76,12 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void download(Batch batch) {
-        downloader.download(batch, downloadBatchMap);
+        DownloadBatchId downloadBatchId = batch.downloadBatchId();
+        DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
+        if (downloadBatch == null) {
+            Log.v("download " + downloadBatchId);
+            downloader.download(batch, downloadBatchMap);
+        }
     }
 
     @Override
@@ -111,7 +116,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
         if (downloadBatch == null) {
             return;
         }
-        downloadBatchMap.remove(downloadBatchId);
+
         downloadBatch.delete();
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -22,6 +22,7 @@ import com.squareup.okhttp.OkHttpClient;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -29,6 +30,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
@@ -284,7 +286,8 @@ public final class DownloadManagerBuilder {
         );
         DownloadBatchStatusNotificationDispatcher batchStatusNotificationDispatcher = new DownloadBatchStatusNotificationDispatcher(
                 downloadsBatchPersistence,
-                notificationDispatcher
+                notificationDispatcher,
+                new HashSet<>()
         );
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
@@ -347,7 +350,7 @@ public final class DownloadManagerBuilder {
         @Override
         public NotificationDisplayState notificationDisplayState(DownloadBatchStatus payload) {
             DownloadBatchStatus.Status status = payload.status();
-            if (status == DOWNLOADED || status == DELETED || status == ERROR || status == PAUSED) {
+            if (status == DOWNLOADED || status == DELETED || status == DELETING || status == ERROR || status == PAUSED) {
                 return NotificationDisplayState.STACK_NOTIFICATION_DISMISSIBLE;
             } else {
                 return NotificationDisplayState.SINGLE_PERSISTENT_NOTIFICATION;
@@ -363,6 +366,7 @@ public final class DownloadManagerBuilder {
 
             switch (payload.status()) {
                 case DELETED:
+                case DELETING:
                     return createDeletedNotification(builder);
                 case ERROR:
                     return createErrorNotification(builder, payload.getDownloadErrorType());

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -34,6 +34,7 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
+@SuppressWarnings("PMD.ExcessiveImports")
 public final class DownloadManagerBuilder {
 
     private static final Object SERVICE_LOCK = new Object();
@@ -146,7 +147,8 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder withFileDownloaderCustom(FileSizeRequester fileSizeRequester, Class<? extends FileDownloader> customFileDownloaderClass) {
+    public DownloadManagerBuilder withFileDownloaderCustom(FileSizeRequester fileSizeRequester,
+                                                           Class<? extends FileDownloader> customFileDownloaderClass) {
         this.fileSizeRequester = fileSizeRequester;
         this.fileDownloaderCreator = FileDownloaderCreator.newCustomFileDownloaderCreator(customFileDownloaderClass);
         return this;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -255,10 +255,10 @@ public final class DownloadManagerBuilder {
                 customCallbackThrottle
         );
 
-        Executor executor = Executors.newSingleThreadExecutor();
-        DownloadsFilePersistence downloadsFilePersistence = new DownloadsFilePersistence(downloadsPersistence, executor);
+        DownloadsFilePersistence downloadsFilePersistence = new DownloadsFilePersistence(downloadsPersistence);
         MerlinsBeard merlinsBeard = MerlinsBeard.from(applicationContext);
         ConnectionChecker connectionChecker = new ConnectionChecker(merlinsBeard, connectionTypeAllowed);
+        Executor executor = Executors.newSingleThreadExecutor();
         DownloadsBatchPersistence downloadsBatchPersistence = new DownloadsBatchPersistence(
                 executor,
                 downloadsFilePersistence,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -57,9 +57,9 @@ public final class DownloadManagerBuilder {
     private CallbackThrottleCreator.Type callbackThrottleCreatorType;
     private TimeUnit timeUnit;
     private long frequency;
+    private boolean logs;
 
     public static DownloadManagerBuilder newInstance(Context context, Handler callbackHandler, @DrawableRes final int notificationIcon) {
-        Log.setShowLogs(true);
         Context applicationContext = context.getApplicationContext();
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(applicationContext);
@@ -96,6 +96,8 @@ public final class DownloadManagerBuilder {
 
         CallbackThrottleCreator.Type callbackThrottleCreatorType = CallbackThrottleCreator.Type.THROTTLE_BY_PROGRESS_INCREASE;
 
+        boolean logs = false;
+
         return new DownloadManagerBuilder(
                 applicationContext,
                 callbackHandler,
@@ -107,7 +109,8 @@ public final class DownloadManagerBuilder {
                 notificationCreator,
                 connectionTypeAllowed,
                 allowNetworkRecovery,
-                callbackThrottleCreatorType
+                callbackThrottleCreatorType,
+                logs
         );
     }
 
@@ -122,7 +125,8 @@ public final class DownloadManagerBuilder {
                                    NotificationCreator<DownloadBatchStatus> notificationCreator,
                                    ConnectionType connectionTypeAllowed,
                                    boolean allowNetworkRecovery,
-                                   CallbackThrottleCreator.Type callbackThrottleCreatorType) {
+                                   CallbackThrottleCreator.Type callbackThrottleCreatorType,
+                                   boolean logs) {
         this.applicationContext = applicationContext;
         this.callbackHandler = callbackHandler;
         this.filePersistenceCreator = filePersistenceCreator;
@@ -134,6 +138,7 @@ public final class DownloadManagerBuilder {
         this.connectionTypeAllowed = connectionTypeAllowed;
         this.allowNetworkRecovery = allowNetworkRecovery;
         this.callbackThrottleCreatorType = callbackThrottleCreatorType;
+        this.logs = logs;
     }
 
     public DownloadManagerBuilder withFilePersistenceInternal() {
@@ -212,7 +217,14 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
+    public DownloadManagerBuilder withLogs() {
+        this.logs = true;
+        return this;
+    }
+
     public DownloadManager build() {
+        Log.setShowLogs(logs);
+
         Intent intent = new Intent(applicationContext, LiteDownloadService.class);
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -249,7 +249,7 @@ public final class DownloadManagerBuilder {
         );
 
         Executor executor = Executors.newSingleThreadExecutor();
-        DownloadsFilePersistence downloadsFilePersistence = new DownloadsFilePersistence(downloadsPersistence);
+        DownloadsFilePersistence downloadsFilePersistence = new DownloadsFilePersistence(downloadsPersistence, executor);
         MerlinsBeard merlinsBeard = MerlinsBeard.from(applicationContext);
         ConnectionChecker connectionChecker = new ConnectionChecker(merlinsBeard, connectionTypeAllowed);
         DownloadsBatchPersistence downloadsBatchPersistence = new DownloadsBatchPersistence(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -14,7 +14,8 @@ import java.util.concurrent.Executor;
 
 class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, DownloadsNotificationSeenPersistence {
 
-    private static final Optional<DownloadError> DOWNLOAD_ERROR = Optional.absent();
+    private static final Optional<DownloadError> NO_DOWNLOAD_ERROR = Optional.absent();
+
     private final Executor executor;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final DownloadsPersistence downloadsPersistence;
@@ -131,7 +132,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                 totalBatchSizeBytes,
                 status,
                 notificationSeen,
-                DOWNLOAD_ERROR
+                NO_DOWNLOAD_ERROR
         );
 
         liteDownloadBatchStatus.update(currentBytesDownloaded, totalBatchSizeBytes);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -135,8 +135,6 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                 NO_DOWNLOAD_ERROR
         );
 
-        liteDownloadBatchStatus.update(currentBytesDownloaded, totalBatchSizeBytes);
-
         CallbackThrottle callbackThrottle = callbackThrottleCreator.create();
 
         return new DownloadBatch(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -37,7 +37,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                       boolean notificationSeen) {
         executor.execute(() -> {
             List<DownloadFile> downloadFilesToPersist = new ArrayList<>(downloadFiles);
-            Log.v("Ferran, start DownloadBatchPersistence persist full batch " + downloadBatchId + ", downloadFilesSize: " + downloadFilesToPersist.size());
+            Log.v("start DownloadBatchPersistence persist full batch " + downloadBatchId + ", downloadFilesSize: " + downloadFilesToPersist.size());
             downloadsPersistence.startTransaction();
 
             try {
@@ -56,7 +56,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
             } finally {
                 downloadsPersistence.endTransaction();
             }
-            Log.v("Ferran, end DownloadBatchPersistence persist full batch " + downloadBatchId);
+            Log.v("end DownloadBatchPersistence persist full batch " + downloadBatchId);
         });
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -153,6 +153,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
     @Override
     public void updateNotificationSeenAsync(DownloadBatchStatus downloadBatchStatus, boolean notificationSeen) {
         executor.execute(() -> {
+            Log.v("start updateNotificationSeenAsync with: " + downloadBatchStatus + ", notificationSeen: " + notificationSeen);
             if (downloadBatchStatus.status() == DownloadBatchStatus.Status.DOWNLOADED) {
                 downloadsPersistence.startTransaction();
                 try {
@@ -162,6 +163,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                     downloadsPersistence.endTransaction();
                 }
             }
+            Log.v("end updateNotificationSeenAsync with: " + downloadBatchStatus + ", notificationSeen: " + notificationSeen);
         });
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -1,5 +1,7 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.WorkerThread;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,11 +34,12 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                       List<DownloadFile> downloadFiles,
                       long downloadedDateTimeInMillis,
                       boolean notificationSeen) {
-        executor.execute(() -> {
-            persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen);
-        });
+        executor.execute(
+                () -> persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen)
+        );
     }
 
+    @WorkerThread
     void persist(DownloadBatchTitle downloadBatchTitle,
                  DownloadBatchId downloadBatchId,
                  DownloadBatchStatus.Status status,
@@ -127,6 +130,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         });
     }
 
+    @WorkerThread
     void delete(DownloadBatchId downloadBatchId) {
         downloadsPersistence.startTransaction();
         try {
@@ -146,6 +150,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         executor.execute(() -> updateStatusAsync(downloadBatchId, status));
     }
 
+    @WorkerThread
     @Override
     public void updateStatus(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         downloadsPersistence.startTransaction();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -151,14 +151,16 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
     }
 
     @Override
-    public void updateNotificationSeenAsync(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+    public void updateNotificationSeenAsync(DownloadBatchStatus downloadBatchStatus, boolean notificationSeen) {
         executor.execute(() -> {
-            downloadsPersistence.startTransaction();
-            try {
-                downloadsPersistence.update(downloadBatchId, notificationSeen);
-                downloadsPersistence.transactionSuccess();
-            } finally {
-                downloadsPersistence.endTransaction();
+            if (downloadBatchStatus.status() == DownloadBatchStatus.Status.DOWNLOADED) {
+                downloadsPersistence.startTransaction();
+                try {
+                    downloadsPersistence.update(downloadBatchStatus.getDownloadBatchId(), notificationSeen);
+                    downloadsPersistence.transactionSuccess();
+                } finally {
+                    downloadsPersistence.endTransaction();
+                }
             }
         });
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
@@ -3,6 +3,4 @@ package com.novoda.downloadmanager;
 interface DownloadsBatchStatusPersistence {
 
     void updateStatusAsync(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
-
-    void updateStatus(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
@@ -3,4 +3,6 @@ package com.novoda.downloadmanager;
 interface DownloadsBatchStatusPersistence {
 
     void updateStatusAsync(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
+
+    void updateStatus(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
@@ -119,6 +119,7 @@ class DownloadsFilePersistence {
             case ERROR:
                 return InternalDownloadFileStatus.Status.ERROR;
             case DELETED:
+            case DELETING:
                 return InternalDownloadFileStatus.Status.DELETED;
             case DOWNLOADED:
                 return InternalDownloadFileStatus.Status.DOWNLOADED;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsFilePersistence.java
@@ -5,26 +5,13 @@ import android.support.annotation.WorkerThread;
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executor;
 
 class DownloadsFilePersistence {
 
     private final DownloadsPersistence downloadsPersistence;
-    private final Executor executor;
 
-    DownloadsFilePersistence(DownloadsPersistence downloadsPersistence, Executor executor) {
+    DownloadsFilePersistence(DownloadsPersistence downloadsPersistence) {
         this.downloadsPersistence = downloadsPersistence;
-        this.executor = executor;
-    }
-
-    void persistAsync(DownloadBatchId downloadBatchId,
-                      FileName fileName,
-                      FilePath filePath,
-                      FileSize fileSize,
-                      String url,
-                      DownloadFileStatus downloadFileStatus,
-                      FilePersistenceType filePersistenceType) {
-        executor.execute(() -> persistSync(downloadBatchId, fileName, filePath, fileSize, url, downloadFileStatus, filePersistenceType));
     }
 
     @WorkerThread

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsNotificationSeenPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsNotificationSeenPersistence.java
@@ -2,5 +2,5 @@ package com.novoda.downloadmanager;
 
 interface DownloadsNotificationSeenPersistence {
 
-    void updateNotificationSeenAsync(DownloadBatchId downloadBatchId, boolean notificationSeen);
+    void updateNotificationSeenAsync(DownloadBatchStatus downloadBatchStatus, boolean notificationSeen);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsPersistence.java
@@ -20,10 +20,10 @@ public interface DownloadsPersistence {
 
     List<DownloadsFilePersisted> loadFiles(DownloadBatchId batchId);
 
-    void delete(DownloadBatchId downloadBatchId);
+    boolean delete(DownloadBatchId downloadBatchId);
 
-    void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
+    boolean update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 
-    void update(DownloadBatchId downloadBatchId, boolean notificationSeen);
+    boolean update(DownloadBatchId downloadBatchId, boolean notificationSeen);
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -10,6 +10,8 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markAsQueued(DownloadsBatchStatusPersistence persistence);
 
+    void markAsDeleting();
+
     void markAsDeleted();
 
     void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence);
@@ -17,4 +19,6 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
     void markAsDownloaded(DownloadsBatchStatusPersistence persistence);
 
     void markAsWaitingForNetwork(DownloadsBatchPersistence persistence);
+
+    InternalDownloadBatchStatus copy();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -19,6 +19,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     private int percentageDownloaded;
     private Optional<DownloadError> downloadError;
 
+    @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
     LiteDownloadBatchStatus(DownloadBatchId downloadBatchId,
                             DownloadBatchTitle downloadBatchTitle,
                             long downloadedDateTimeInMillis,

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,7 +1,6 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
-import android.support.annotation.WorkerThread;
 
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
@@ -89,7 +88,6 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         return downloadedDateTimeInMillis;
     }
 
-    @WorkerThread
     @Override
     public void markAsDownloading(DownloadsBatchStatusPersistence persistence) {
         status = Status.DOWNLOADING;
@@ -120,7 +118,6 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         notificationSeen = false;
     }
 
-    @WorkerThread
     @Override
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
@@ -128,14 +125,12 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         updateStatusAsync(status, persistence);
     }
 
-    @WorkerThread
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
         updateStatusAsync(status, persistence);
     }
 
-    @WorkerThread
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -86,7 +86,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public void markAsDownloading(DownloadsBatchStatusPersistence persistence) {
         status = Status.DOWNLOADING;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
@@ -112,29 +112,25 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @WorkerThread
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @WorkerThread
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     private void updateStatusAsync(Status status, DownloadsBatchStatusPersistence persistence) {
         persistence.updateStatusAsync(downloadBatchId, status);
-    }
-
-    private void updateStatus(Status status, DownloadsBatchStatusPersistence persistence) {
-        persistence.updateStatus(downloadBatchId, status);
     }
 
     @Nullable

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -90,13 +90,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public void markAsPaused(DownloadsBatchStatusPersistence persistence) {
         status = Status.PAUSED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsQueued(DownloadsBatchStatusPersistence persistence) {
         status = Status.QUEUED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
@@ -109,23 +109,27 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
     }
 
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
-        updateStatus(status, persistence);
+        updateStatusAsync(status, persistence);
+    }
+
+    private void updateStatusAsync(Status status, DownloadsBatchStatusPersistence persistence) {
+        persistence.updateStatusAsync(downloadBatchId, status);
     }
 
     private void updateStatus(Status status, DownloadsBatchStatusPersistence persistence) {
-        persistence.updateStatusAsync(downloadBatchId, status);
+        persistence.updateStatus(downloadBatchId, status);
     }
 
     @Nullable

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 
 class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
@@ -81,6 +82,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         return downloadedDateTimeInMillis;
     }
 
+    @WorkerThread
     @Override
     public void markAsDownloading(DownloadsBatchStatusPersistence persistence) {
         status = Status.DOWNLOADING;
@@ -105,23 +107,26 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         notificationSeen = false;
     }
 
+    @WorkerThread
     @Override
     public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
         this.status = Status.ERROR;
         this.downloadError = downloadError;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
+    @WorkerThread
     @Override
     public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
         this.status = Status.DOWNLOADED;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
+    @WorkerThread
     @Override
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
-        updateStatusAsync(status, persistence);
+        updateStatus(status, persistence);
     }
 
     private void updateStatusAsync(Status status, DownloadsBatchStatusPersistence persistence) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -2,10 +2,14 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
@@ -53,49 +57,50 @@ class LiteDownloadManagerDownloader {
     }
 
     public void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
-        DownloadBatch runningDownloadBatch = downloadBatchMap.get(batch.downloadBatchId());
-        if (runningDownloadBatch != null) {
-            return;
-        }
-
-        CallbackThrottle callbackThrottle = callbackThrottleCreator.create();
-
         DownloadBatch downloadBatch = DownloadBatchFactory.newInstance(
                 batch,
                 fileOperations,
                 downloadsBatchPersistence,
                 downloadsFilePersistence,
-                callbackThrottle,
+                callbackThrottleCreator.create(),
                 connectionChecker
         );
 
+        downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         download(downloadBatch, downloadBatchMap);
     }
 
     public void download(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         executor.submit(() -> Wait.<Void>waitFor(downloadService, waitForDownloadService)
-                .thenPerform(executeDownload(downloadBatch)));
+                .thenPerform(executeDownload(downloadBatch, downloadBatchMap)));
     }
 
-    private Wait.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
+    private Wait.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         return () -> {
             downloadBatch.persistAsync();
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
             updateStatusToQueuedIfNeeded(downloadBatchStatus);
-            downloadService.download(downloadBatch, downloadBatchCallback());
+            downloadService.download(downloadBatch, downloadBatchCallback(downloadBatchMap));
             return null;
         };
     }
 
     private void updateStatusToQueuedIfNeeded(InternalDownloadBatchStatus downloadBatchStatus) {
-        if (downloadBatchStatus.status() != PAUSED && downloadBatchStatus.status() != DOWNLOADED) {
+        DownloadBatchStatus.Status status = downloadBatchStatus.status();
+        if (status != PAUSED && status != DOWNLOADED && status != DELETING && status != DELETED) {
             downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
         }
     }
 
-    private DownloadBatchStatusCallback downloadBatchCallback() {
+    private DownloadBatchStatusCallback downloadBatchCallback(Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         return downloadBatchStatus -> callbackHandler.post(() -> {
+            DownloadBatchId downloadBatchId = downloadBatchStatus.getDownloadBatchId();
+            if (downloadBatchStatus.status() == DELETED) {
+                Log.v("batch " + downloadBatchId.rawId() + " is finally deleted, removing it from the map");
+                downloadBatchMap.remove(downloadBatchId);
+            }
+
             synchronized (waitForDownloadBatchStatusCallback) {
                 for (DownloadBatchStatusCallback callback : callbacks) {
                     callback.onUpdate(downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -69,7 +69,7 @@ class LiteDownloadManagerDownloader {
                 connectionChecker
         );
 
-        downloadBatch.persist();
+        downloadBatch.persistAsync();
         download(downloadBatch, downloadBatchMap);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -69,7 +69,6 @@ class LiteDownloadManagerDownloader {
                 connectionChecker
         );
 
-        downloadBatch.persistAsync();
         download(downloadBatch, downloadBatchMap);
     }
 
@@ -81,6 +80,7 @@ class LiteDownloadManagerDownloader {
 
     private Wait.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch) {
         return () -> {
+            downloadBatch.persistAsync();
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
             updateStatusToQueuedIfNeeded(downloadBatchStatus);
             downloadService.download(downloadBatch, downloadBatchCallback());

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -52,13 +52,12 @@ public class LiteDownloadService extends Service implements DownloadService {
 
     @Override
     public void download(DownloadBatch downloadBatch, DownloadBatchStatusCallback callback) {
-        callback.onUpdate(downloadBatch.status());
-
+        callback.onUpdate(downloadBatch.status().copy());
         downloadBatch.setCallback(callback);
 
         executor.execute(() -> {
             acquireCpuWakeLock();
-            downloadBatch.persistAsync();
+            downloadBatch.persist();
             downloadBatch.download();
             releaseHeldCpuWakeLock();
         });

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -51,13 +51,14 @@ public class LiteDownloadService extends Service implements DownloadService {
     }
 
     @Override
-    public void download(final DownloadBatch downloadBatch, final DownloadBatchStatusCallback callback) {
+    public void download(DownloadBatch downloadBatch, DownloadBatchStatusCallback callback) {
         callback.onUpdate(downloadBatch.status());
 
         downloadBatch.setCallback(callback);
 
         executor.execute(() -> {
             acquireCpuWakeLock();
+            downloadBatch.persist();
             downloadBatch.download();
             releaseHeldCpuWakeLock();
         });

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -58,7 +58,7 @@ public class LiteDownloadService extends Service implements DownloadService {
 
         executor.execute(() -> {
             acquireCpuWakeLock();
-            downloadBatch.persist();
+            downloadBatch.persistAsync();
             downloadBatch.download();
             releaseHeldCpuWakeLock();
         });

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,7 +36,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     }
 
     @Override
-    public void persistBatch(final DownloadsBatchPersisted batchPersisted) {
+    public void persistBatch(DownloadsBatchPersisted batchPersisted) {
         RoomBatch roomBatch = new RoomBatch();
         roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,6 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
+import com.novoda.notils.logger.simple.Log;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +37,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistBatch(DownloadsBatchPersisted batchPersisted) {
+        Log.v("Ferran, start persistBatch " + batchPersisted.downloadBatchId().rawId());
         RoomBatch roomBatch = new RoomBatch();
         roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
@@ -43,6 +46,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.notificationSeen = batchPersisted.notificationSeen();
 
         database.roomBatchDao().insert(roomBatch);
+        Log.v("Ferran, end persistBatch " + batchPersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -66,6 +70,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistFile(DownloadsFilePersisted filePersisted) {
+        Log.v("Ferran, start persistFile " + filePersisted.downloadBatchId().rawId());
         RoomFile roomFile = new RoomFile();
         roomFile.totalSize = filePersisted.totalFileSize();
         roomFile.batchId = filePersisted.downloadBatchId().rawId();
@@ -76,6 +81,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomFile.persistenceType = filePersisted.filePersistenceType().toRawValue();
 
         database.roomFileDao().insert(roomFile);
+        Log.v("Ferran, end persistFile " + filePersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -110,21 +116,27 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
+        Log.v("Ferran, start delete " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         database.roomBatchDao().delete(roomBatch);
+        Log.v("Ferran, end delete " + downloadBatchId.rawId());
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
+        Log.v("Ferran, start update " + downloadBatchId.rawId() + ", status: " + status);
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
+        Log.v("Ferran, end update " + downloadBatchId.rawId() + ", status: " + status);
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+        Log.v("Ferran, start update notification " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.notificationSeen = notificationSeen;
         database.roomBatchDao().update(roomBatch);
+        Log.v("Ferran, end update  notification" + downloadBatchId.rawId());
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -111,18 +111,12 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
-        if (roomBatch == null) {
-            return;
-        }
         database.roomBatchDao().delete(roomBatch);
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
-        if (roomBatch == null) {
-            return;
-        }
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -37,7 +37,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistBatch(DownloadsBatchPersisted batchPersisted) {
-        Log.v("Ferran, start persistBatch " + batchPersisted.downloadBatchId().rawId());
+        Log.v("start persistBatch " + batchPersisted.downloadBatchId().rawId());
         RoomBatch roomBatch = new RoomBatch();
         roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
@@ -46,7 +46,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.notificationSeen = batchPersisted.notificationSeen();
 
         database.roomBatchDao().insert(roomBatch);
-        Log.v("Ferran, end persistBatch " + batchPersisted.downloadBatchId().rawId());
+        Log.v("end persistBatch " + batchPersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -70,7 +70,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistFile(DownloadsFilePersisted filePersisted) {
-        Log.v("Ferran, start persistFile " + filePersisted.downloadBatchId().rawId());
+        Log.v("start persistFile " + filePersisted.downloadBatchId().rawId());
         RoomFile roomFile = new RoomFile();
         roomFile.totalSize = filePersisted.totalFileSize();
         roomFile.batchId = filePersisted.downloadBatchId().rawId();
@@ -81,7 +81,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomFile.persistenceType = filePersisted.filePersistenceType().toRawValue();
 
         database.roomFileDao().insert(roomFile);
-        Log.v("Ferran, end persistFile " + filePersisted.downloadBatchId().rawId());
+        Log.v("end persistFile " + filePersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -116,27 +116,27 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
-        Log.v("Ferran, start delete " + downloadBatchId.rawId());
+        Log.v("start delete " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         database.roomBatchDao().delete(roomBatch);
-        Log.v("Ferran, end delete " + downloadBatchId.rawId());
+        Log.v("end delete " + downloadBatchId.rawId());
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-        Log.v("Ferran, start update " + downloadBatchId.rawId() + ", status: " + status);
+        Log.v("start update " + downloadBatchId.rawId() + ", status: " + status);
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
-        Log.v("Ferran, end update " + downloadBatchId.rawId() + ", status: " + status);
+        Log.v("end update " + downloadBatchId.rawId() + ", status: " + status);
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
-        Log.v("Ferran, start update notification " + downloadBatchId.rawId());
+        Log.v("start update notification " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.notificationSeen = notificationSeen;
         database.roomBatchDao().update(roomBatch);
-        Log.v("Ferran, end update  notification" + downloadBatchId.rawId());
+        Log.v("end update  notification" + downloadBatchId.rawId());
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -109,22 +109,36 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     }
 
     @Override
-    public void delete(DownloadBatchId downloadBatchId) {
+    public boolean delete(DownloadBatchId downloadBatchId) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        if (roomBatch == null) {
+            return false;
+        }
+
         database.roomBatchDao().delete(roomBatch);
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
+    public boolean update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        if (roomBatch == null) {
+            return false;
+        }
+
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+    public boolean update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        if (roomBatch == null) {
+            return false;
+        }
         roomBatch.notificationSeen = notificationSeen;
         database.roomBatchDao().update(roomBatch);
+        return true;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -120,6 +120,9 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        if (roomBatch == null) {
+            return;
+        }
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,7 +35,6 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistBatch(DownloadsBatchPersisted batchPersisted) {
-        Log.v("start persistBatch " + batchPersisted.downloadBatchId().rawId());
         RoomBatch roomBatch = new RoomBatch();
         roomBatch.id = batchPersisted.downloadBatchId().rawId();
         roomBatch.status = batchPersisted.downloadBatchStatus().toRawValue();
@@ -46,7 +43,6 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.notificationSeen = batchPersisted.notificationSeen();
 
         database.roomBatchDao().insert(roomBatch);
-        Log.v("end persistBatch " + batchPersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -70,7 +66,6 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void persistFile(DownloadsFilePersisted filePersisted) {
-        Log.v("start persistFile " + filePersisted.downloadBatchId().rawId());
         RoomFile roomFile = new RoomFile();
         roomFile.totalSize = filePersisted.totalFileSize();
         roomFile.batchId = filePersisted.downloadBatchId().rawId();
@@ -81,7 +76,6 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomFile.persistenceType = filePersisted.filePersistenceType().toRawValue();
 
         database.roomFileDao().insert(roomFile);
-        Log.v("end persistFile " + filePersisted.downloadBatchId().rawId());
     }
 
     @Override
@@ -116,27 +110,24 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     @Override
     public void delete(DownloadBatchId downloadBatchId) {
-        Log.v("start delete " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
+        if (roomBatch == null) {
+            return;
+        }
         database.roomBatchDao().delete(roomBatch);
-        Log.v("end delete " + downloadBatchId.rawId());
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-        Log.v("start update " + downloadBatchId.rawId() + ", status: " + status);
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.status = status.toRawValue();
         database.roomBatchDao().update(roomBatch);
-        Log.v("end update " + downloadBatchId.rawId() + ", status: " + status);
     }
 
     @Override
     public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
-        Log.v("start update notification " + downloadBatchId.rawId());
         RoomBatch roomBatch = database.roomBatchDao().load(downloadBatchId.rawId());
         roomBatch.notificationSeen = notificationSeen;
         database.roomBatchDao().update(roomBatch);
-        Log.v("end update  notification" + downloadBatchId.rawId());
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 
-import com.novoda.notils.logger.simple.Log;
-
 import java.util.ArrayList;
 import java.util.List;
 

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
@@ -5,6 +5,8 @@ import com.novoda.notils.logger.simple.Log;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashSet;
+
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -20,7 +22,8 @@ public class DownloadBatchStatusNotificationDispatcherTest {
     @Before
     public void setUp() {
         Log.setShowLogs(false);
-        downloadBatchStatusNotificationDispatcher = new DownloadBatchStatusNotificationDispatcher(persistence, notificationDispatcher);
+        HashSet<String> downloadBatchIdNotificationSeen = new HashSet<>();
+        downloadBatchStatusNotificationDispatcher = new DownloadBatchStatusNotificationDispatcher(persistence, notificationDispatcher, downloadBatchIdNotificationSeen);
     }
 
     @Test
@@ -29,7 +32,7 @@ public class DownloadBatchStatusNotificationDispatcherTest {
 
         downloadBatchStatusNotificationDispatcher.updateNotification(downloadedBatchStatus);
 
-        verify(persistence).updateNotificationSeenAsync(downloadedBatchStatus.getDownloadBatchId(), true);
+        verify(persistence).updateNotificationSeenAsync(downloadedBatchStatus, true);
     }
 
     @Test

--- a/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FakeDownloadsPersistence.java
@@ -65,17 +65,17 @@ class FakeDownloadsPersistence implements DownloadsPersistence {
     }
 
     @Override
-    public void delete(DownloadBatchId downloadBatchId) {
-        // no-op.
+    public boolean delete(DownloadBatchId downloadBatchId) {
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
-        // no-op.
+    public boolean update(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status) {
+        return true;
     }
 
     @Override
-    public void update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
-        // no-op.
+    public boolean update(DownloadBatchId downloadBatchId, boolean notificationSeen) {
+        return true;
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -158,7 +158,7 @@ class InternalDownloadBatchStatusFixtures {
 
             @Override
             public InternalDownloadBatchStatus copy() {
-                return null;
+                return build();
             }
 
             @Override

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -128,6 +128,11 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
+            public void markAsDeleting() {
+                status = Status.DELETING;
+            }
+
+            @Override
             public void markAsDeleted() {
                 status = Status.DELETED;
             }
@@ -149,6 +154,11 @@ class InternalDownloadBatchStatusFixtures {
             public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
                 status = Status.WAITING_FOR_NETWORK;
                 persistence.updateStatusAsync(downloadBatchId, status);
+            }
+
+            @Override
+            public InternalDownloadBatchStatus copy() {
+                return null;
             }
 
             @Override


### PR DESCRIPTION
**Problem**

In the demo application, if you spam the buttons `start downloading` + `delete all` + `pause` or any combination between them, the library will eventually crash.

**Solution**

I have enabled logs through the `DownloadManagerBuilder` with `.withLogs()` so now all the logs can be toggled from any client.

I have added a new state `DELETING` so that the batch being deleted its only removed from the main downloading map when the status finishes with `DELETED`.

I have refactored the main `DownloadBatch.download()` method with more explicit names and making its method static so that it has a lower memory footprint.

I have added checks for when a download should not continue.

I have added status checks after long performing operations such as `getTotalSize()`. This is due to the `pause` and `delete` methods that can be called at any point from the main thread and are immediate actions.

I have created a `copy` method for the `DownloadBatchStatus` so that it can be passed safely to the callbacks and no further async modification of the status will be affected.

In the `DownloadBatchStatusNotificationDispatcher` I have added a `set` in order to prevent the same batch to be stored in the db for the same values.

For operations against the database, I've made sure that all the operations that can be done synchronously are properly tagged and created. This avoids issues by which a submission of an operation is outdates respected from where it has been issued. Following this, I have protected asynchronous operations that can crash with a `try-catch` block.

