### PR TITLE
Fix delete status is ignored by download abort checks

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -22,6 +22,7 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_
 class DownloadBatch {
 
     private static final int ZERO_BYTES = 0;
+    private static final String STATUS = "status";
 
     private final Map<DownloadFileId, Long> fileBytesDownloadedMap;
     private final InternalDownloadBatchStatus downloadBatchStatus;
@@ -54,10 +55,10 @@ class DownloadBatch {
 
     void download() {
         String rawBatchId = downloadBatchStatus.getDownloadBatchId().rawId();
-        Log.v("start download " + rawBatchId + ", status: " + downloadBatchStatus.status());
+        Log.v("start sync download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
 
         if (shouldAbortStartingBatch(connectionChecker, callback, downloadBatchStatus, downloadsBatchPersistence)) {
-            Log.v("abort starting download " + rawBatchId);
+            Log.v("abort starting download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
             return;
         }
 
@@ -67,8 +68,12 @@ class DownloadBatch {
             totalBatchSizeBytes = getTotalSize(downloadFiles, downloadBatchStatus);
         }
 
+        Log.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                + " " + STATUS + " " + downloadBatchStatus.status()
+                + " totalBatchSize " + totalBatchSizeBytes);
+
         if (shouldAbortAfterGettingTotalBatchSize(downloadBatchStatus, downloadsBatchPersistence, callback, totalBatchSizeBytes)) {
-            Log.v("abort after getting total batch size download " + rawBatchId);
+            Log.v("abort after getting total batch size download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
             return;
         }
 
@@ -86,31 +91,34 @@ class DownloadBatch {
         deleteBatchIfNeeded(downloadBatchStatus, downloadsBatchPersistence, callback);
         notifyCallback(callback, downloadBatchStatus);
         callbackThrottle.stopUpdates();
-        Log.v("end download " + rawBatchId);
+        Log.v("end sync download " + rawBatchId);
     }
 
     private static boolean shouldAbortStartingBatch(ConnectionChecker connectionChecker,
                                                     DownloadBatchStatusCallback callback,
                                                     InternalDownloadBatchStatus downloadBatchStatus,
                                                     DownloadsBatchPersistence downloadsBatchPersistence) {
-        DownloadBatchStatus.Status status = downloadBatchStatus.status();
-
-        if (status == DELETED) {
+        // WARNING: do not extract downloadBatchStatus.status() as a local variable, this will
+        // invalidate the checks when a batch is deleted from the main thread, as this code
+        // runs in a thread and its status can change at any point.
+        // deleteBatchIfNeeded() is an expensive task that will take few milliseconds, after that
+        // time the status might be different
+        if (downloadBatchStatus.status() == DELETED) {
             return true;
         }
 
-        if (status == DELETING) {
+        if (downloadBatchStatus.status() == DELETING) {
             deleteBatchIfNeeded(downloadBatchStatus, downloadsBatchPersistence, callback);
             notifyCallback(callback, downloadBatchStatus);
             return true;
         }
 
-        if (status == PAUSED) {
+        if (downloadBatchStatus.status() == PAUSED) {
             notifyCallback(callback, downloadBatchStatus);
             return true;
         }
 
-        if (connectionNotAllowedForDownload(connectionChecker, status)) {
+        if (connectionNotAllowedForDownload(connectionChecker, downloadBatchStatus.status())) {
             processNetworkError(downloadBatchStatus, callback, downloadsBatchPersistence);
             notifyCallback(callback, downloadBatchStatus);
             return true;
@@ -122,8 +130,10 @@ class DownloadBatch {
     private static void deleteBatchIfNeeded(InternalDownloadBatchStatus downloadBatchStatus,
                                             DownloadsBatchPersistence downloadsBatchPersistence,
                                             DownloadBatchStatusCallback callback) {
-        if (downloadBatchStatus.status() == DELETING && downloadsBatchPersistence.deleteSync(downloadBatchStatus)) {
+        if (downloadBatchStatus.status() == DELETING) {
+            Log.v("sync delete and mark as deleted batch " + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadBatchStatus.markAsDeleted();
+            downloadsBatchPersistence.deleteSync(downloadBatchStatus);
             notifyCallback(callback, downloadBatchStatus);
         }
     }
@@ -146,6 +156,7 @@ class DownloadBatch {
         }
         downloadBatchStatus.markAsWaitingForNetwork(downloadsBatchPersistence);
         notifyCallback(callback, downloadBatchStatus);
+        Log.v("scheduleRecovery for batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", " + STATUS + " " + downloadBatchStatus.status());
         DownloadsNetworkRecoveryCreator.getInstance().scheduleRecovery();
     }
 
@@ -153,6 +164,7 @@ class DownloadBatch {
                                                   DownloadsBatchPersistence downloadsBatchPersistence,
                                                   DownloadBatchStatusCallback callback) {
         if (downloadBatchStatus.status() != DOWNLOADED) {
+            Log.v("mark " + downloadBatchStatus.getDownloadBatchId().rawId() + " from " + downloadBatchStatus.status() + " to DOWNLOADING");
             downloadBatchStatus.markAsDownloading(downloadsBatchPersistence);
             notifyCallback(callback, downloadBatchStatus);
         }
@@ -166,10 +178,12 @@ class DownloadBatch {
                 return 0;
             }
 
-            Log.v("batch id: " + downloadBatchStatus.getDownloadBatchId().rawId() + ", status: " + status + ", file: " + downloadFile.id().rawId());
-
             long totalFileSize = downloadFile.getTotalSize();
             if (totalFileSize == 0) {
+                Log.w("file " + downloadFile.id().rawId()
+                        + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                        + " with " + STATUS + " " + downloadBatchStatus.status()
+                        + " returns 0 as totalFileSize");
                 return 0;
             }
 
@@ -262,7 +276,7 @@ class DownloadBatch {
     }
 
     void pause() {
-        Log.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", status: " + downloadBatchStatus.status());
+        Log.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", " + STATUS + " " + downloadBatchStatus.status());
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
             return;
@@ -301,11 +315,15 @@ class DownloadBatch {
     void delete() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == DELETING || status == DELETED) {
+            Log.v("abort delete batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
             return;
         }
 
-        Log.v("delete batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", mark as deleting from " + downloadBatchStatus.status());
+        Log.v("delete request for batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", mark as deleting from " + downloadBatchStatus.status());
         downloadBatchStatus.markAsDeleting();
+        Log.v("delete request for batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                + ", " + STATUS + " " + downloadBatchStatus.status()
+                + ", should be deleting");
         notifyCallback(callback, downloadBatchStatus);
 
         for (DownloadFile downloadFile : downloadFiles) {
@@ -313,13 +331,17 @@ class DownloadBatch {
         }
 
         if (status == PAUSED || status == DOWNLOADED) {
-            Log.v("delete paused or downloaded batch " + downloadBatchStatus.getDownloadBatchId().rawId());
+            Log.v("delete async paused or downloaded batch " + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadsBatchPersistence.deleteAsync(downloadBatchStatus, downloadBatchId -> {
                 Log.v("delete paused or downloaded mark as deleted: " + downloadBatchId.rawId());
                 downloadBatchStatus.markAsDeleted();
                 notifyCallback(callback, downloadBatchStatus);
             });
         }
+
+        Log.v("delete request for batch end " + downloadBatchStatus.getDownloadBatchId().rawId()
+                + ", " + STATUS + ": " + downloadBatchStatus.status()
+                + ", should be deleting");
     }
 
     DownloadBatchId getId() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -2,7 +2,6 @@ package com.novoda.downloadmanager;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -27,15 +26,15 @@ final class DownloadBatchFactory {
         DownloadBatchId downloadBatchId = batch.downloadBatchId();
         long downloadedDateTimeInMillis = System.currentTimeMillis();
 
-        List<DownloadFile> downloadFiles = new ArrayList<>(batch.batchFiles().size());
+        List<BatchFile> batchFiles = batch.batchFiles();
+        List<DownloadFile> downloadFiles = new ArrayList<>(batchFiles.size());
 
-        for (BatchFile batchFile : batch.batchFiles()) {
+        for (BatchFile batchFile : batchFiles) {
             String networkAddress = batchFile.networkAddress();
 
             InternalFileSize fileSize = InternalFileSizeCreator.unknownFileSize();
 
-            FilePersistenceCreator filePersistenceCreator = fileOperations.filePersistenceCreator();
-            FilePersistence filePersistence = filePersistenceCreator.create();
+            FilePersistence filePersistence = fileOperations.filePersistenceCreator().create();
 
             String basePath = filePersistence.basePath().path();
             FilePath filePath = FilePathCreator.create(basePath, prependBatchIdTo(relativePathFrom(batchFile), downloadBatchId));
@@ -68,8 +67,6 @@ final class DownloadBatchFactory {
             );
             downloadFiles.add(downloadFile);
         }
-
-        downloadFiles = Collections.unmodifiableList(downloadFiles);
 
         InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                 downloadBatchId,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -189,10 +189,10 @@ class DownloadFile {
         if (fileSize.isTotalSizeUnknown()) {
             FileSize requestFileSize = fileSizeRequester.requestFileSize(url);
             fileSize.setTotalSize(requestFileSize.totalSize());
-            Log.v("file getTotalSize for batchId: " + downloadBatchId
-                    + ", status: " + fileStatus().status()
-                    + ", fileId: " + fileStatus().downloadFileId().rawId());
             if (fileStatus().status() == DownloadFileStatus.Status.DELETED) {
+                Log.e("file getTotalSize return zero because is deleted, " + downloadFileId.rawId()
+                        + " from batch " + downloadBatchId.rawId()
+                        + " with file status " + fileStatus().status());
                 return 0;
             }
             persist();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -79,8 +79,9 @@ class DownloadManager implements LiteDownloadManagerCommands {
         DownloadBatchId downloadBatchId = batch.downloadBatchId();
         DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
         if (downloadBatch == null) {
-            Log.v("download " + downloadBatchId);
             downloader.download(batch, downloadBatchMap);
+        } else {
+            Log.v("abort download batch " + downloadBatchId + " will not download as exists already in the running batches map");
         }
     }
 
@@ -88,6 +89,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     public void pause(DownloadBatchId downloadBatchId) {
         DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
         if (downloadBatch == null) {
+            Log.v("abort pause batch " + downloadBatchId + " will not be paused as it does not exists in the running batches map");
             return;
         }
         downloadBatch.pause();
@@ -97,16 +99,16 @@ class DownloadManager implements LiteDownloadManagerCommands {
     public void resume(DownloadBatchId downloadBatchId) {
         DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
         if (downloadBatch == null) {
+            Log.v("abort resume batch " + downloadBatchId + " will not be resume as it does not exists in the running batches map");
             return;
         }
 
         if (downloadBatch.status().status() == DownloadBatchStatus.Status.DOWNLOADING) {
+            Log.v("abort resume batch " + downloadBatchId + " will not be resume as it's already downloading");
             return;
         }
 
-        downloadBatchMap.remove(downloadBatchId);
         downloadBatch.resume();
-
         downloader.download(downloadBatch, downloadBatchMap);
     }
 
@@ -114,6 +116,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     public void delete(DownloadBatchId downloadBatchId) {
         DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
         if (downloadBatch == null) {
+            Log.v("abort delete batch " + downloadBatchId + " will not be deleted as it does not exists in the running batches map");
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -71,7 +71,11 @@ class LiteDownloadManagerDownloader {
     }
 
     public void download(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
-        downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
+        DownloadBatchId downloadBatchId = downloadBatch.getId();
+        if (!downloadBatchMap.containsKey(downloadBatchId)) {
+            downloadBatchMap.put(downloadBatchId, downloadBatch);
+        }
+
         executor.submit(() -> Wait.<Void>waitFor(downloadService, waitForDownloadService)
                 .thenPerform(executeDownload(downloadBatch, downloadBatchMap)));
     }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -223,15 +223,6 @@ public class DownloadManagerTest {
     }
 
     @Test
-    public void removesBatchFromInternalList_whenResuming() {
-        given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
-
-        downloadManager.resume(DOWNLOAD_BATCH_ID);
-
-        assertThat(downloadingBatches).doesNotContainEntry(DOWNLOAD_BATCH_ID, downloadBatch);
-    }
-
-    @Test
     public void resumesBatch() {
         given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
 


### PR DESCRIPTION
**Problem**

A queue batch is marked for deletion when the queue starts should be deleted (as should be marked for deletion) but the check says that is downloading

```
delete request for batch -468903206, mark as deleting from QUEUED 
delete request for batch -468903206, status: DELETING, should be deleting 
mark file as deleted for batchId: -468903206 
mark file as deleted for batchId: -468903206 
mark file as deleted for batchId: -468903206 
mark file as deleted for batchId: -468903206 
mark file as deleted for batchId: -468903206 
mark file as deleted for batchId: -468903206 
delete request for batch end -468903206, status: DOWNLOADING, should be deleting 
```

**Solution**

The check that says that is downloading is due to the fact that there is a local variable extracting the status for the entire check method `shouldAbortStartingBatch`, so when the status has changed in the main thread, and the check is finally executed, the status is outdated.

The solution has been to actually check the real status of all the checks and avoid creating a local variable.

The rest of the code changes have been small code improvements, remove unnecessary code and add better logging