### PR TITLE
fix file size request fails returning 0 length

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation 'com.novoda:merlin:1.1.6'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.android.support:support-v4:27.1.0'
-    implementation 'com.squareup.okhttp:okhttp:2.7.5'
+    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'android.arch.persistence.room:runtime:1.0.0'
     implementation 'com.evernote:android-job:1.2.4'
     testImplementation 'junit:junit:4.12'

--- a/library/proguard-rules.pro
+++ b/library/proguard-rules.pro
@@ -23,3 +23,11 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+#OkHttp rules from https://github.com/square/okhttp
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -150,6 +150,7 @@ class DownloadBatch {
                                             DownloadBatchStatusCallback callback,
                                             DownloadsBatchPersistence downloadsBatchPersistence) {
         if (downloadBatchStatus.status() == DELETING) {
+            Logger.v("abort processNetworkError, the batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " is deleting");
             return;
         }
         downloadBatchStatus.markAsWaitingForNetwork(downloadsBatchPersistence);
@@ -173,6 +174,10 @@ class DownloadBatch {
         for (DownloadFile downloadFile : downloadFiles) {
             DownloadBatchStatus.Status status = downloadBatchStatus.status();
             if (status == DELETING || status == DELETED || status == PAUSED) {
+                Logger.w("abort getTotalSize file " + downloadFile.id().rawId()
+                        + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                        + " with " + STATUS + " " + downloadBatchStatus.status()
+                        + " returns 0 as totalFileSize");
                 return 0;
             }
 
@@ -261,6 +266,10 @@ class DownloadBatch {
     }
 
     private static boolean networkError(InternalDownloadBatchStatus downloadBatchStatus) {
+        if (downloadBatchStatus.status() == DELETING) {
+            Logger.v("abort networkError check because the batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " is deleting");
+            return false;
+        }
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == WAITING_FOR_NETWORK) {
             return true;

--- a/library/src/main/java/com/novoda/downloadmanager/HttpClient.java
+++ b/library/src/main/java/com/novoda/downloadmanager/HttpClient.java
@@ -18,5 +18,7 @@ interface HttpClient {
         InputStream openByteStream() throws IOException;
 
         void closeByteStream() throws IOException;
+
+        long bodyContentLength();
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/HttpClientFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/HttpClientFactory.java
@@ -1,8 +1,9 @@
 package com.novoda.downloadmanager;
 
-import com.squareup.okhttp.OkHttpClient;
 
 import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
 
 final class HttpClientFactory {
 
@@ -21,10 +22,11 @@ final class HttpClientFactory {
         private static final HttpClient INSTANCE = createInstance();
 
         private static HttpClient createInstance() {
-            OkHttpClient okHttpClient = new OkHttpClient();
-            okHttpClient.setConnectTimeout(TIMEOUT, TimeUnit.SECONDS);
-            okHttpClient.setWriteTimeout(TIMEOUT, TimeUnit.SECONDS);
-            okHttpClient.setReadTimeout(TIMEOUT, TimeUnit.SECONDS);
+            OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                    .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .build();
             return new WrappedOkHttpClient(okHttpClient);
         }
     }

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
@@ -6,6 +6,7 @@ class NetworkFileSizeRequester implements FileSizeRequester {
 
     private static final String HEADER_CONTENT_LENGTH = "Content-Length";
     private static final int UNKNOWN_CONTENT_LENGTH = -1;
+    private static final int ZERO_FILE_SIZE = 0;
 
     private final HttpClient httpClient;
     private final NetworkRequestCreator requestCreator;
@@ -17,18 +18,53 @@ class NetworkFileSizeRequester implements FileSizeRequester {
 
     @Override
     public FileSize requestFileSize(String url) {
-        NetworkRequest fileSizeRequest = requestCreator.createFileSizeRequest(url);
-
         try {
-            HttpClient.NetworkResponse response = httpClient.execute(fileSizeRequest);
-            if (response.isSuccessful()) {
-                long totalFileSize = Long.parseLong(response.header(HEADER_CONTENT_LENGTH, String.valueOf(UNKNOWN_CONTENT_LENGTH)));
-                return FileSizeCreator.createFromTotalSize(totalFileSize);
+            long fileSize = executeRequestFileSize(url);
+            if (fileSize == 0) {
+                return FileSizeCreator.unknownFileSize();
+            } else {
+                return FileSizeCreator.createFromTotalSize(fileSize);
             }
         } catch (IOException e) {
             Logger.e(e, "Error requesting file size for " + url);
         }
 
         return FileSizeCreator.unknownFileSize();
+    }
+
+    private long executeRequestFileSize(String url) throws IOException {
+        long fileSize = requestFileSizeThroughHeaderRequest(url);
+        if (fileSize == 0) {
+            Logger.w("filesize request through header returned zero, we'll try again " + url);
+            fileSize = requestFileSizeThroughBodyRequest(url);
+            if (fileSize == 0) {
+                Logger.w("filesize request through body returned zero");
+            }
+        }
+
+        return fileSize;
+    }
+
+    private long requestFileSizeThroughHeaderRequest(String url) throws IOException {
+        NetworkRequest fileSizeRequest = requestCreator.createFileSizeRequest(url);
+        HttpClient.NetworkResponse response = httpClient.execute(fileSizeRequest);
+        long fileSize = ZERO_FILE_SIZE;
+        if (response.isSuccessful()) {
+            fileSize = Long.parseLong(response.header(HEADER_CONTENT_LENGTH, String.valueOf(UNKNOWN_CONTENT_LENGTH)));
+            response.closeByteStream();
+        }
+        return fileSize;
+    }
+
+    private long requestFileSizeThroughBodyRequest(String url) throws IOException {
+        NetworkRequest downloadRequest = requestCreator.createDownloadRequest(url);
+        HttpClient.NetworkResponse response = httpClient.execute(downloadRequest);
+        long fileSize = ZERO_FILE_SIZE;
+        if (response.isSuccessful()) {
+            fileSize = response.bodyContentLength();
+            response.closeByteStream();
+        }
+
+        return fileSize;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
+++ b/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
@@ -1,11 +1,11 @@
 package com.novoda.downloadmanager;
 
-import com.squareup.okhttp.Call;
-import com.squareup.okhttp.OkHttpClient;
-import com.squareup.okhttp.Request;
-
 import java.io.IOException;
 import java.util.Map;
+
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 class WrappedOkHttpClient implements HttpClient {
 

--- a/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpResponse.java
+++ b/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpResponse.java
@@ -1,9 +1,9 @@
 package com.novoda.downloadmanager;
 
-import com.squareup.okhttp.Response;
-
 import java.io.IOException;
 import java.io.InputStream;
+
+import okhttp3.Response;
 
 class WrappedOkHttpResponse implements HttpClient.NetworkResponse {
 
@@ -36,5 +36,10 @@ class WrappedOkHttpResponse implements HttpClient.NetworkResponse {
     @Override
     public void closeByteStream() throws IOException {
         response.body().close();
+    }
+
+    @Override
+    public long bodyContentLength() {
+        return response.body().contentLength();
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
@@ -1,9 +1,9 @@
 package com.novoda.downloadmanager;
 
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.NetworkResponseFixtures.aNetworkResponse;
@@ -39,6 +39,7 @@ public class NetworkFileSizeRequesterTest {
     @Test
     public void returnsUnknownSize_whenResponseIsUnsuccessful() throws IOException {
         given(httpClient.execute(requestCreator.createFileSizeRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
+        given(httpClient.execute(requestCreator.createDownloadRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkResponseFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkResponseFixtures.java
@@ -10,6 +10,7 @@ class NetworkResponseFixtures {
     private boolean isSuccessful = true;
     private String header = "header";
     private InputStream inputStream = new ByteArrayInputStream("input".getBytes());
+    private long bodyContentLength = 0;
 
     static NetworkResponseFixtures aNetworkResponse() {
         return new NetworkResponseFixtures();
@@ -34,6 +35,12 @@ class NetworkResponseFixtures {
         this.inputStream = inputStream;
         return this;
     }
+
+    NetworkResponseFixtures withBodyContentLength(long bodyContentLength) {
+        this.bodyContentLength = bodyContentLength;
+        return this;
+    }
+
 
     HttpClient.NetworkResponse build() {
         return new HttpClient.NetworkResponse() {
@@ -60,6 +67,11 @@ class NetworkResponseFixtures {
             @Override
             public void closeByteStream() throws IOException {
                 inputStream.close();
+            }
+
+            @Override
+            public long bodyContentLength() {
+                return bodyContentLength;
             }
         };
     }


### PR DESCRIPTION
**Problem**

We have noticed that for some file requests, our `head` method for returning the total file size does not always work. It returns `200` but with a length of `zero`.

**Solution**

We have implemented a fallback solution. When the `head` request fails, we then fall back to a standard `body` request and we will take the length of the body.

We have also updated the `okhttp` library to its latest version