### PR TITLE
Awaiting network file size incorrect

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -67,8 +67,8 @@ class DownloadBatch {
         }
 
         Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                + " " + STATUS + " " + downloadBatchStatus.status()
-                + " totalBatchSize " + totalBatchSizeBytes);
+                         + " " + STATUS + " " + downloadBatchStatus.status()
+                         + " totalBatchSize " + totalBatchSizeBytes);
 
         if (shouldAbortAfterGettingTotalBatchSize(downloadBatchStatus, downloadsBatchPersistence, callback, totalBatchSizeBytes)) {
             Logger.v("abort after getting total batch size download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
@@ -175,18 +175,18 @@ class DownloadBatch {
             DownloadBatchStatus.Status status = downloadBatchStatus.status();
             if (status == DELETING || status == DELETED || status == PAUSED) {
                 Logger.w("abort getTotalSize file " + downloadFile.id().rawId()
-                        + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                        + " with " + STATUS + " " + downloadBatchStatus.status()
-                        + " returns 0 as totalFileSize");
+                                 + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                                 + " with " + STATUS + " " + downloadBatchStatus.status()
+                                 + " returns 0 as totalFileSize");
                 return 0;
             }
 
             long totalFileSize = downloadFile.getTotalSize();
             if (totalFileSize == 0) {
                 Logger.w("file " + downloadFile.id().rawId()
-                        + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                        + " with " + STATUS + " " + downloadBatchStatus.status()
-                        + " returns 0 as totalFileSize");
+                                 + " from batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                                 + " with " + STATUS + " " + downloadBatchStatus.status()
+                                 + " returns 0 as totalFileSize");
                 return 0;
             }
 
@@ -328,15 +328,15 @@ class DownloadBatch {
 
         downloadBatchStatus.markAsDeleting();
         Logger.v("delete request for batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                + ", " + STATUS + " " + downloadBatchStatus.status()
-                + ", should be deleting");
+                         + ", " + STATUS + " " + downloadBatchStatus.status()
+                         + ", should be deleting");
         notifyCallback(callback, downloadBatchStatus);
 
         for (DownloadFile downloadFile : downloadFiles) {
             downloadFile.delete();
         }
 
-        if (status == PAUSED || status == DOWNLOADED) {
+        if (status == PAUSED || status == DOWNLOADED || status == WAITING_FOR_NETWORK) {
             Logger.v("delete async paused or downloaded batch " + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadsBatchPersistence.deleteAsync(downloadBatchStatus, downloadBatchId -> {
                 Logger.v("delete paused or downloaded mark as deleted: " + downloadBatchId.rawId());
@@ -346,8 +346,8 @@ class DownloadBatch {
         }
 
         Logger.v("delete request for batch end " + downloadBatchStatus.getDownloadBatchId().rawId()
-                + ", " + STATUS + ": " + downloadBatchStatus.status()
-                + ", should be deleting");
+                         + ", " + STATUS + ": " + downloadBatchStatus.status()
+                         + ", should be deleting");
     }
 
     DownloadBatchId getId() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -65,6 +65,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     private DownloadsBatchPersistence.LoadBatchesCallback loadBatchesCallback(AllStoredDownloadsSubmittedCallback callback) {
         return downloadBatches -> {
             for (DownloadBatch downloadBatch : downloadBatches) {
+                downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
                 downloader.download(downloadBatch, downloadBatchMap);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -10,7 +10,6 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
 
 class LiteDownloadManagerDownloader {
 
@@ -103,8 +102,8 @@ class LiteDownloadManagerDownloader {
             }
 
             DownloadBatchId downloadBatchId = downloadBatchStatus.getDownloadBatchId();
-            if (downloadBatchStatus.status() == DELETED || downloadBatchStatus.status() == WAITING_FOR_NETWORK) {
-                Logger.v("batch " + downloadBatchId.rawId() + " is finally" + downloadBatchStatus.status() + ", removing it from the map");
+            if (downloadBatchStatus.status() == DELETED) {
+                Logger.v("batch " + downloadBatchId.rawId() + " is finally deleted, removing it from the map");
                 downloadBatchMap.remove(downloadBatchId);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -10,6 +10,7 @@ import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
 
 class LiteDownloadManagerDownloader {
 
@@ -102,8 +103,8 @@ class LiteDownloadManagerDownloader {
             }
 
             DownloadBatchId downloadBatchId = downloadBatchStatus.getDownloadBatchId();
-            if (downloadBatchStatus.status() == DELETED) {
-                Logger.v("batch " + downloadBatchId.rawId() + " is finally deleted, removing it from the map");
+            if (downloadBatchStatus.status() == DELETED || downloadBatchStatus.status() == WAITING_FOR_NETWORK) {
+                Logger.v("batch " + downloadBatchId.rawId() + " is finally" + downloadBatchStatus.status() + ", removing it from the map");
                 downloadBatchMap.remove(downloadBatchId);
             }
 


### PR DESCRIPTION
## Problem
- After queuing a download and forcing the await network path, when retrieving the `DownloadFileStatus` it will be incorrect. The `DownloadFileStatus` will return `0` even after triggering the download. This happens because we never remove the batch from the `DownloadManager` map when awaiting network, so it always has the incorrect size 😬 

- Turns out that it is impossible to delete a download that is awaiting network 😬 The files are marked as deleted but the batch is not. Ordinarily for `Downloading` we tell the downloader to stop, which will then check the status and force the batch to be updated. In the scenario for `DOWNLOADED` and `PAUSED` batches we check during the `delete` method call and update the batch, we need to do the same for `WAITING_FOR_NETWORK`. 

## Solution
- Update the map whenever we trigger a `submitAllStoredDownloads`. 

- Add `WAITING_FOR_NETWORK` to the delete statements that update the batch.