### PR TITLE
Duplicated urls in migration

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -83,12 +83,12 @@ class MigrationExtractor {
                             fileIds.add(originalFileId);
                         }
 
-                        if (originalFileId != null) {
+                        if (originalFileId == null) {
                             newBatchBuilder.addFile(originalNetworkAddress)
-                                    .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                                     .apply();
                         } else {
                             newBatchBuilder.addFile(originalNetworkAddress)
+                                    .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                                     .apply();
                         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -61,6 +61,7 @@ class MigrationExtractor {
                 Batch.Builder newBatchBuilder = null;
                 List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
                 Set<String> uris = new HashSet<>();
+                Set<String> fileIds = new HashSet<>();
 
                 DownloadBatchId downloadBatchId = null;
                 try {
@@ -75,12 +76,21 @@ class MigrationExtractor {
                             newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                         }
 
-                        if (uris.contains(originalNetworkAddress)) {
+                        if (uris.contains(originalNetworkAddress) && fileIds.contains(originalFileId)) {
                             continue;
                         } else {
                             uris.add(originalNetworkAddress);
+                            fileIds.add(originalFileId);
                         }
-                        newBatchBuilder.addFile(originalNetworkAddress).apply();
+
+                        if (originalFileId != null) {
+                            newBatchBuilder.addFile(originalNetworkAddress)
+                                    .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
+                                    .apply();
+                        } else {
+                            newBatchBuilder.addFile(originalNetworkAddress)
+                                    .apply();
+                        }
 
                         FilePath originalFilePath = new LiteFilePath(sanitizedOriginalFileLocation);
                         FilePath newFilePath = MigrationPathExtractor.extractMigrationPath(basePath, originalFilePath.path(), downloadBatchId);

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -68,12 +68,12 @@ class PartialDownloadMigrationExtractor {
                     fileIds.add(originalFileId);
                 }
 
-                if (originalFileId != null) {
+                if (originalFileId == null) {
                     newBatchBuilder.addFile(uri)
-                            .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                             .apply();
                 } else {
                     newBatchBuilder.addFile(uri)
+                            .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                             .apply();
                 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -46,6 +46,7 @@ class PartialDownloadMigrationExtractor {
             Batch.Builder newBatchBuilder = null;
             List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
             Set<String> uris = new HashSet<>();
+            Set<String> fileIds = new HashSet<>();
 
             DownloadBatchId downloadBatchId = null;
             while (downloadsCursor.moveToNext()) {
@@ -60,12 +61,21 @@ class PartialDownloadMigrationExtractor {
                     newBatchBuilder = Batch.with(downloadBatchId, batchTitle);
                 }
 
-                if (uris.contains(uri)) {
+                if (uris.contains(uri) && fileIds.contains(originalFileId)) {
                     continue;
                 } else {
                     uris.add(uri);
+                    fileIds.add(originalFileId);
                 }
-                newBatchBuilder.addFile(uri).apply();
+
+                if (originalFileId != null) {
+                    newBatchBuilder.addFile(uri)
+                            .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
+                            .apply();
+                } else {
+                    newBatchBuilder.addFile(uri)
+                            .apply();
+                }
 
                 FilePath newFilePath = MigrationPathExtractor.extractMigrationPath(basePath, originalFilePath.path(), downloadBatchId);
 

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -75,8 +75,8 @@ public class MigrationExtractorTest {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
         Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_1".hashCode())), "title_1")
-                .addFile(firstUri).apply()
-                .addFile(secondUri).apply()
+                .addFile(firstUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_1")).apply()
+                .addFile(secondUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_2")).apply()
                 .build();
 
         List<Migration.FileMetadata> firstFileMetadata = new ArrayList<>();
@@ -86,8 +86,8 @@ public class MigrationExtractorTest {
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
         Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_3".hashCode())), "title_2")
-                .addFile(thirdUri).apply()
-                .addFile(fourthUri).apply()
+                .addFile(thirdUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_3")).apply()
+                .addFile(fourthUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_4")).apply()
                 .build();
 
         List<Migration.FileMetadata> secondFileMetadata = new ArrayList<>();


### PR DESCRIPTION

### Problem
Some client app might have the same URL multiple times in a single batch, with different file ids.
At the moment we filter these, resulting in missing download files.

### Solution
Check for only the pair (URL, FileId) and allow duplicated urls with different id on migration