### PR TITLE
Code against the interface

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -218,7 +218,7 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManager build() {
+    public LiteDownloadManagerCommands build() {
         if (logHandle.isPresent()) {
             Logger.attach(logHandle.get());
         }


### PR DESCRIPTION
## Problem
#377 the builder is coded against the concrete class rather than the interface.

## Solution
Use the interface.