### PR TITLE
Prevent re-queuing downloaded assets when awaiting network

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.android.support:support-v4:27.1.0'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
     implementation 'android.arch.persistence.room:runtime:1.0.0'
-    implementation 'com.evernote:android-job:1.2.4'
+    implementation 'com.evernote:android-job:1.2.5'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.15.0'
     testImplementation 'com.google.truth:truth:0.39'

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -122,6 +122,11 @@ class DownloadBatch {
             return true;
         }
 
+        if (downloadBatchStatus.status() == DOWNLOADED) {
+            notifyCallback(callback, downloadBatchStatus);
+            return true;
+        }
+
         return false;
     }
 

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -8,5 +8,4 @@
   <string name="download_notification_content_progress">%d%% downloaded</string>
 
   <string name="migration_notification_content_title">Migrating Download Manager V1</string>
-  <string name="migration_notification_content_progress">%d%% migrated</string>
 </resources>


### PR DESCRIPTION
## Problem
When queuing multiple jobs against an executor, say two calls to `submitAllStoredDownloads`, when the first finishes and the second executes the whole process of downloading the batch begins again. If we miss any checks in the initial `shouldAbortStartingBatch` then the batch continues to download 😬 

This occurs for the situation where an asset is `DOWNLOADED` and then we turn off `wifi`, the asset moves to `AWAITING_NETWORK_RECOVERY` because we do not include `DOWNLOADED` in this initial check.

## Solution
Add `DOWNLOADED` check to the initial `DownloadBatch.shouldAbortStartingBatch`.

Needed to update the android job dependency -> [release notes](https://github.com/evernote/android-job/releases/tag/v1.2.5)