### PR TITLE
Insufficient Storage Space

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager.demo;
 
 import android.content.Context;
+import android.support.annotation.FloatRange;
 import android.util.Log;
 
 import com.novoda.downloadmanager.FilePath;
@@ -18,7 +19,7 @@ public class CustomFilePersistence implements FilePersistence {
     private int currentSize;
 
     @Override
-    public void initialiseWith(Context context) {
+    public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         Log.v(TAG, "initialise");
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -1,7 +1,6 @@
 package com.novoda.downloadmanager.demo;
 
 import android.content.Context;
-import android.support.annotation.FloatRange;
 import android.util.Log;
 
 import com.novoda.downloadmanager.FilePath;
@@ -10,6 +9,7 @@ import com.novoda.downloadmanager.FilePersistence;
 import com.novoda.downloadmanager.FilePersistenceResult;
 import com.novoda.downloadmanager.FilePersistenceType;
 import com.novoda.downloadmanager.FileSize;
+import com.novoda.downloadmanager.StorageRequirementsRule;
 
 // Must be public
 public class CustomFilePersistence implements FilePersistence {
@@ -19,7 +19,7 @@ public class CustomFilePersistence implements FilePersistence {
     private int currentSize;
 
     @Override
-    public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+    public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
         Log.v(TAG, "initialise");
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -61,9 +61,9 @@ class ExternalFilePersistence implements FilePersistence {
         long usableStorageInBytes = storageDirectory.getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 
-        Logger.d("Storage capacity in bytes: ", storageCapacityInBytes);
-        Logger.d("Usable storage in bytes: ", usableStorageInBytes);
-        Logger.d("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
+        Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
+        Logger.v("Usable storage in bytes: ", usableStorageInBytes);
+        Logger.v("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
         return remainingStorageAfterDownloadInBytes < minimumStorageRequiredInBytes;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -54,10 +54,12 @@ class ExternalFilePersistence implements FilePersistence {
 
     private boolean hasViolatedStorageRequirements(File storageDirectory, FileSize downloadFileSize) {
         StatFs statFs = new StatFs(storageDirectory.getPath());
-        long minimumStorageRequiredInBytes = (long) (StorageCapacityReader.storageCapacityInBytes(statFs) * TEN_PERCENT);
+        long storageCapacityInBytes = StorageCapacityReader.storageCapacityInBytes(statFs);
+        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * TEN_PERCENT);
         long usableStorageInBytes = storageDirectory.getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 
+        Logger.d("Storage capacity in bytes: ", storageCapacityInBytes);
         Logger.d("Usable storage in bytes: ", usableStorageInBytes);
         Logger.d("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
         return remainingStorageAfterDownloadInBytes < minimumStorageRequiredInBytes;

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import android.content.Context;
 import android.os.Environment;
 import android.os.StatFs;
+import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
 import android.support.v4.content.ContextCompat;
 
@@ -15,17 +16,18 @@ class ExternalFilePersistence implements FilePersistence {
 
     private static final String DOWNLOADS_DIR = "/downloads/";
     private static final String UNDEFINED_DIRECTORY_TYPE = null;
-    private static final double TEN_PERCENT = 0.1;
     private static final boolean APPEND = true;
 
     private Context context;
+    private float percentageStorageRemaining;
 
     @Nullable
     private FileOutputStream fileOutputStream;
 
     @Override
-    public void initialiseWith(Context context) {
+    public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         this.context = context.getApplicationContext();
+        this.percentageStorageRemaining = percentageOfStorageRemaining;
     }
 
     @Override
@@ -55,7 +57,7 @@ class ExternalFilePersistence implements FilePersistence {
     private boolean hasViolatedStorageRequirements(File storageDirectory, FileSize downloadFileSize) {
         StatFs statFs = new StatFs(storageDirectory.getPath());
         long storageCapacityInBytes = StorageCapacityReader.storageCapacityInBytes(statFs);
-        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * TEN_PERCENT);
+        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageStorageRemaining);
         long usableStorageInBytes = storageDirectory.getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -5,7 +5,7 @@ import android.support.annotation.FloatRange;
 
 public interface FilePersistence {
 
-    void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining);
+    void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) StorageRequirementsRule storageRequirementsRule);
 
     FilePath basePath();
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -1,11 +1,10 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
-import android.support.annotation.FloatRange;
 
 public interface FilePersistence {
 
-    void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) StorageRequirementsRule storageRequirementsRule);
+    void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule);
 
     FilePath basePath();
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -1,10 +1,11 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
+import android.support.annotation.FloatRange;
 
 public interface FilePersistence {
 
-    void initialiseWith(Context context);
+    void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining);
 
     FilePath basePath();
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
@@ -1,7 +1,6 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
-import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
 
 class FilePersistenceCreator {
@@ -11,7 +10,7 @@ class FilePersistenceCreator {
     @Nullable
     private final Class<? extends FilePersistence> customClass;
 
-    private float percentageOfStorageRemaining;
+    private StorageRequirementsRule storageRequirementsRule;
 
     static FilePersistenceCreator newInternalFilePersistenceCreator(Context context) {
         return new FilePersistenceCreator(context, FilePersistenceType.INTERNAL, null);
@@ -31,8 +30,8 @@ class FilePersistenceCreator {
         this.customClass = customClass;
     }
 
-    void withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        this.percentageOfStorageRemaining = percentageOfStorageRemaining;
+    void withStorageRequirementsRule(StorageRequirementsRule storageRequirementsRule) {
+        this.storageRequirementsRule = storageRequirementsRule;
     }
 
     FilePersistence create() {
@@ -56,7 +55,7 @@ class FilePersistenceCreator {
                 throw new IllegalStateException("Persistence of type " + type + " is not supported");
         }
 
-        filePersistence.initialiseWith(context, percentageOfStorageRemaining);
+        filePersistence.initialiseWith(context, storageRequirementsRule);
         return filePersistence;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
+import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
 
 class FilePersistenceCreator {
@@ -9,6 +10,8 @@ class FilePersistenceCreator {
     private final FilePersistenceType type;
     @Nullable
     private final Class<? extends FilePersistence> customClass;
+
+    private float percentageOfStorageRemaining;
 
     static FilePersistenceCreator newInternalFilePersistenceCreator(Context context) {
         return new FilePersistenceCreator(context, FilePersistenceType.INTERNAL, null);
@@ -26,6 +29,10 @@ class FilePersistenceCreator {
         this.context = context.getApplicationContext();
         this.type = type;
         this.customClass = customClass;
+    }
+
+    void withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+        this.percentageOfStorageRemaining = percentageOfStorageRemaining;
     }
 
     FilePersistence create() {
@@ -49,7 +56,7 @@ class FilePersistenceCreator {
                 throw new IllegalStateException("Persistence of type " + type + " is not supported");
         }
 
-        filePersistence.initialiseWith(context);
+        filePersistence.initialiseWith(context, percentageOfStorageRemaining);
         return filePersistence;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -44,10 +44,12 @@ class InternalFilePersistence implements FilePersistence {
 
     private boolean hasViolatedStorageRequirements(File storageDirectory, FileSize downloadFileSize) {
         StatFs statFs = new StatFs(storageDirectory.getPath());
-        long minimumStorageRequiredInBytes = (long) (StorageCapacityReader.storageCapacityInBytes(statFs) * TEN_PERCENT);
+        long storageCapacityInBytes = StorageCapacityReader.storageCapacityInBytes(statFs);
+        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * TEN_PERCENT);
         long usableStorageInBytes = context.getFilesDir().getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 
+        Logger.d("Storage capacity in bytes: ", storageCapacityInBytes);
         Logger.d("Usable storage in bytes: ", usableStorageInBytes);
         Logger.d("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
         return remainingStorageAfterDownloadInBytes < minimumStorageRequiredInBytes;

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -2,6 +2,7 @@ package com.novoda.downloadmanager;
 
 import android.content.Context;
 import android.os.StatFs;
+import android.support.annotation.FloatRange;
 import android.support.annotation.Nullable;
 
 import java.io.File;
@@ -12,16 +13,17 @@ import java.io.IOException;
 class InternalFilePersistence implements FilePersistence {
 
     private static final String DOWNLOADS_DIR = "/downloads/";
-    private static final double TEN_PERCENT = 0.1;
 
     private Context context;
+    private float percentageOfStorageRemaining;
 
     @Nullable
     private FileOutputStream fileOutputStream;
 
     @Override
-    public void initialiseWith(Context context) {
+    public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         this.context = context.getApplicationContext();
+        this.percentageOfStorageRemaining = percentageOfStorageRemaining;
     }
 
     @Override
@@ -45,7 +47,7 @@ class InternalFilePersistence implements FilePersistence {
     private boolean hasViolatedStorageRequirements(File storageDirectory, FileSize downloadFileSize) {
         StatFs statFs = new StatFs(storageDirectory.getPath());
         long storageCapacityInBytes = StorageCapacityReader.storageCapacityInBytes(statFs);
-        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * TEN_PERCENT);
+        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageOfStorageRemaining);
         long usableStorageInBytes = context.getFilesDir().getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -51,9 +51,9 @@ class InternalFilePersistence implements FilePersistence {
         long usableStorageInBytes = context.getFilesDir().getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 
-        Logger.d("Storage capacity in bytes: ", storageCapacityInBytes);
-        Logger.d("Usable storage in bytes: ", usableStorageInBytes);
-        Logger.d("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
+        Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
+        Logger.v("Usable storage in bytes: ", usableStorageInBytes);
+        Logger.v("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
         return remainingStorageAfterDownloadInBytes < minimumStorageRequiredInBytes;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -29,12 +29,6 @@ class InternalFilePersistence implements FilePersistence {
         return FilePathCreator.create(context.getFilesDir().getAbsolutePath(), DOWNLOADS_DIR);
     }
 
-    private long minimumStorageRequiredAfterDownloadInBytes() {
-        File filesDir = context.getFilesDir();
-        StatFs statFs = new StatFs(filesDir.getPath());
-        return (long) (StorageCapacityReader.storageCapacityInBytes(statFs) * TEN_PERCENT);
-    }
-
     @Override
     public FilePersistenceResult create(FilePath absoluteFilePath, FileSize fileSize) {
         if (fileSize.isTotalSizeUnknown()) {
@@ -49,6 +43,12 @@ class InternalFilePersistence implements FilePersistence {
         }
 
         return create(absoluteFilePath);
+    }
+
+    private long minimumStorageRequiredAfterDownloadInBytes() {
+        File filesDir = context.getFilesDir();
+        StatFs statFs = new StatFs(filesDir.getPath());
+        return (long) (StorageCapacityReader.storageCapacityInBytes(statFs) * TEN_PERCENT);
     }
 
     private FilePersistenceResult create(FilePath absoluteFilePath) {

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -36,9 +36,9 @@ class InternalFilePersistence implements FilePersistence {
         }
 
         long usableSpaceInBytes = context.getFilesDir().getUsableSpace();
-        long remainingSpaceAfterDownload = usableSpaceInBytes - fileSize.totalSize();
+        long remainingSpaceAfterDownloadInBytes = usableSpaceInBytes - fileSize.totalSize();
 
-        if (remainingSpaceAfterDownload < minimumStorageRequiredAfterDownloadInBytes()) {
+        if (remainingSpaceAfterDownloadInBytes < minimumStorageRequiredAfterDownloadInBytes()) {
             return FilePersistenceResult.ERROR_INSUFFICIENT_SPACE;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -54,7 +54,8 @@ class MigrationJob implements Runnable {
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
-        filePersistenceCreator.withPercentageOfStorageRemaining(TEN_PERCENT);
+        StorageRequirementsRule storageRequirementsRule = StorageRequirementsRule.withPercentageOfStorageRemaining(TEN_PERCENT);
+        filePersistenceCreator.withStorageRequirementsRule(storageRequirementsRule);
         FilePersistence filePersistence = filePersistenceCreator.create();
 
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database, basePath);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -18,6 +18,7 @@ class MigrationJob implements Runnable {
     private static final int RANDOMLY_CHOSEN_BUFFER_SIZE_THAT_SEEMS_TO_WORK = 4096;
     private static final int NO_COMPLETED_MIGRATIONS = 0;
     private static final int NO_MIGRATIONS = 0;
+    private static final float TEN_PERCENT = 0.1f;
 
     private final Context context;
     private final String jobIdentifier;
@@ -52,8 +53,10 @@ class MigrationJob implements Runnable {
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
-        FilePersistence filePersistence = FilePersistenceCreator.newInternalFilePersistenceCreator(context).create();
-        filePersistence.initialiseWith(context);
+        FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
+        filePersistenceCreator.withPercentageOfStorageRemaining(TEN_PERCENT);
+        FilePersistence filePersistence = filePersistenceCreator.create();
+
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database, basePath);
         MigrationExtractor migrationExtractor = new MigrationExtractor(database, filePersistence, basePath);
         List<Migration> partialMigrations = partialDownloadMigrationExtractor.extractMigrations();

--- a/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
@@ -1,0 +1,20 @@
+package com.novoda.downloadmanager;
+
+import android.os.Build;
+import android.os.StatFs;
+
+final class StorageCapacityReader {
+
+    private StorageCapacityReader() {
+        // Uses static factory method.
+    }
+
+    static long storageCapacityInBytes(StatFs statFs) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            return statFs.getTotalBytes();
+        } else {
+            return (long) statFs.getBlockCount() * (long) statFs.getBlockSize();
+        }
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
@@ -3,13 +3,9 @@ package com.novoda.downloadmanager;
 import android.os.Build;
 import android.os.StatFs;
 
-final class StorageCapacityReader {
+class StorageCapacityReader {
 
-    private StorageCapacityReader() {
-        // Uses static factory method.
-    }
-
-    static long storageCapacityInBytes(StatFs statFs) {
+    long storageCapacityInBytes(StatFs statFs) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             return statFs.getTotalBytes();
         } else {

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementsRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementsRule.java
@@ -1,0 +1,37 @@
+package com.novoda.downloadmanager;
+
+import android.os.StatFs;
+import android.support.annotation.FloatRange;
+
+import java.io.File;
+
+public class StorageRequirementsRule {
+
+    private final StorageCapacityReader storageCapacityReader;
+    private final float percentageOfStorageRemaining;
+
+    public static StorageRequirementsRule withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+        return new StorageRequirementsRule(new StorageCapacityReader(), percentageOfStorageRemaining);
+    }
+
+    private StorageRequirementsRule(StorageCapacityReader storageCapacityReader,
+                                    @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+        this.storageCapacityReader = storageCapacityReader;
+        this.percentageOfStorageRemaining = percentageOfStorageRemaining;
+    }
+
+    boolean hasViolatedRule(File storageDirectory,
+                            FileSize downloadFileSize) {
+        StatFs statFs = new StatFs(storageDirectory.getPath());
+        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(statFs);
+        long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageOfStorageRemaining);
+        long usableStorageInBytes = storageDirectory.getUsableSpace();
+        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
+
+        Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
+        Logger.v("Usable storage in bytes: ", usableStorageInBytes);
+        Logger.v("Minimum required storage in bytes: ", minimumStorageRequiredInBytes);
+        return remainingStorageAfterDownloadInBytes < minimumStorageRequiredInBytes;
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementsRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementsRule.java
@@ -5,7 +5,7 @@ import android.support.annotation.FloatRange;
 
 import java.io.File;
 
-public class StorageRequirementsRule {
+public final class StorageRequirementsRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final float percentageOfStorageRemaining;

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -1,7 +1,6 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
-import android.support.annotation.FloatRange;
 
 class FilePersistenceFixtures {
 
@@ -37,7 +36,7 @@ class FilePersistenceFixtures {
     FilePersistence build() {
         return new FilePersistence() {
             @Override
-            public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) StorageRequirementsRule storageRequirementsRule) {
+            public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
 
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -37,7 +37,7 @@ class FilePersistenceFixtures {
     FilePersistence build() {
         return new FilePersistence() {
             @Override
-            public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+            public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) StorageRequirementsRule storageRequirementsRule) {
 
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -36,7 +36,7 @@ class FilePersistenceFixtures {
     FilePersistence build() {
         return new FilePersistence() {
             @Override
-            public void initialiseWith(Context context) {
+            public void initialiseWith(Context context, @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
 
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -1,6 +1,7 @@
 package com.novoda.downloadmanager;
 
 import android.content.Context;
+import android.support.annotation.FloatRange;
 
 class FilePersistenceFixtures {
 


### PR DESCRIPTION
## Problem
When a device becomes low on storage space we start to see crashes especially around the SQLite database. In an attempt to prevent this from happening we want to ensure a certain `buffer` is free to the system to ensure that this does not happen because of us 😄

## Solution
Add a buffer amount, default 10%, to which the system must have free in order to download a particular file. This is a simple check when creating the file to see if the available space is below this calculated threshold.
