### PR TITLE
Rename methods on Batch.Builder fluent api

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final View.OnClickListener downloadBatchesOnClick = v -> {
         Batch batch = Batch.with(BATCH_ID_1, "Made in chelsea")
-                .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar/5mb.zip").withIdentifier(FILE_ID_1).apply()
+                .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar/", "5mb.zip").withIdentifier(FILE_ID_1).apply()
                 .downloadFrom(TEN_MB_FILE_URL).apply()
                 .build();
         liteDownloadManagerCommands.download(batch);

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final View.OnClickListener downloadBatchesOnClick = v -> {
         Batch batch = Batch.with(BATCH_ID_1, "Made in chelsea")
-                .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar/5mb.zip").withDownloadFileId(FILE_ID_1).apply()
+                .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar/5mb.zip").withIdentifier(FILE_ID_1).apply()
                 .downloadFrom(TEN_MB_FILE_URL).apply()
                 .build();
         liteDownloadManagerCommands.download(batch);

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -137,7 +137,7 @@ public class MainActivity extends AppCompatActivity {
 
     private final View.OnClickListener downloadBatchesOnClick = v -> {
         Batch batch = Batch.with(BATCH_ID_1, "Made in chelsea")
-                .downloadFrom(FIVE_MB_FILE_URL).withDownloadFileId(FILE_ID_1).withRelativePath("foo/bar/5mb.zip").apply()
+                .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar/5mb.zip").withDownloadFileId(FILE_ID_1).apply()
                 .downloadFrom(TEN_MB_FILE_URL).apply()
                 .build();
         liteDownloadManagerCommands.download(batch);

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -137,14 +137,14 @@ public class MainActivity extends AppCompatActivity {
 
     private final View.OnClickListener downloadBatchesOnClick = v -> {
         Batch batch = Batch.with(BATCH_ID_1, "Made in chelsea")
-                .addFile(FIVE_MB_FILE_URL).withDownloadFileId(FILE_ID_1).withRelativePath("foo/bar/5mb.zip").apply()
-                .addFile(TEN_MB_FILE_URL).apply()
+                .downloadFrom(FIVE_MB_FILE_URL).withDownloadFileId(FILE_ID_1).withRelativePath("foo/bar/5mb.zip").apply()
+                .downloadFrom(TEN_MB_FILE_URL).apply()
                 .build();
         liteDownloadManagerCommands.download(batch);
 
         batch = Batch.with(BATCH_ID_2, "Hollyoaks")
-                .addFile(TEN_MB_FILE_URL).apply()
-                .addFile(TWENTY_MB_FILE_URL).apply()
+                .downloadFrom(TEN_MB_FILE_URL).apply()
+                .downloadFrom(TWENTY_MB_FILE_URL).apply()
                 .build();
         liteDownloadManagerCommands.download(batch);
     };

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -71,7 +71,7 @@ public class Batch {
     }
 
     public interface Builder {
-        BatchFile.Builder addFile(String networkAddress);
+        BatchFile.Builder downloadFrom(String networkAddress);
 
         Batch build();
     }
@@ -100,8 +100,8 @@ public class Batch {
         private BatchFile.Builder fileBuilder;
 
         @Override
-        public BatchFile.Builder addFile(String networkAddress) {
-            this.fileBuilder = BatchFile.with(networkAddress).withParentBuilder(this);
+        public BatchFile.Builder downloadFrom(String networkAddress) {
+            this.fileBuilder = BatchFile.downloadFrom(networkAddress).withParentBuilder(this);
             return this.fileBuilder;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
@@ -70,6 +70,8 @@ public class BatchFile {
 
         Builder saveTo(String path);
 
+        Builder saveTo(String path, String fileName);
+
         Batch.Builder apply();
     }
 
@@ -103,7 +105,16 @@ public class BatchFile {
 
         @Override
         public Builder saveTo(String path) {
-            this.path = Optional.fromNullable(path);
+            String networkAddressDerivedFileName = FileNameExtractor.extractFrom(networkAddress);
+            return saveTo(path, networkAddressDerivedFileName);
+        }
+
+        @Override
+        public Builder saveTo(String path, String fileName) {
+            if (path != null && fileName != null) {
+                this.path = Optional.of(path + fileName);
+            }
+
             return this;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
@@ -12,7 +12,7 @@ public class BatchFile {
         this.relativePath = relativePath;
     }
 
-    static InternalBuilder with(String networkAddress) {
+    static InternalBuilder downloadFrom(String networkAddress) {
         return new LiteFileBuilder(networkAddress);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
@@ -66,7 +66,7 @@ public class BatchFile {
     }
 
     public interface Builder {
-        Builder withDownloadFileId(DownloadFileId downloadFileId);
+        Builder withIdentifier(DownloadFileId downloadFileId);
 
         Builder saveTo(String path);
 
@@ -96,7 +96,7 @@ public class BatchFile {
         }
 
         @Override
-        public Builder withDownloadFileId(DownloadFileId downloadFileId) {
+        public Builder withIdentifier(DownloadFileId downloadFileId) {
             this.downloadFileId = Optional.fromNullable(downloadFileId);
             return this;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchFile.java
@@ -4,12 +4,12 @@ public class BatchFile {
 
     private final String networkAddress;
     private final Optional<DownloadFileId> downloadFileId;
-    private final Optional<String> relativePath;
+    private final Optional<String> path;
 
-    BatchFile(String networkAddress, Optional<DownloadFileId> downloadFileId, Optional<String> relativePath) {
+    BatchFile(String networkAddress, Optional<DownloadFileId> downloadFileId, Optional<String> path) {
         this.networkAddress = networkAddress;
         this.downloadFileId = downloadFileId;
-        this.relativePath = relativePath;
+        this.path = path;
     }
 
     static InternalBuilder downloadFrom(String networkAddress) {
@@ -24,8 +24,8 @@ public class BatchFile {
         return downloadFileId;
     }
 
-    public Optional<String> relativePath() {
-        return relativePath;
+    public Optional<String> path() {
+        return path;
     }
 
     @Override
@@ -45,14 +45,14 @@ public class BatchFile {
         if (downloadFileId != null ? !downloadFileId.equals(batchFile.downloadFileId) : batchFile.downloadFileId != null) {
             return false;
         }
-        return relativePath != null ? relativePath.equals(batchFile.relativePath) : batchFile.relativePath == null;
+        return path != null ? path.equals(batchFile.path) : batchFile.path == null;
     }
 
     @Override
     public int hashCode() {
         int result = networkAddress != null ? networkAddress.hashCode() : 0;
         result = 31 * result + (downloadFileId != null ? downloadFileId.hashCode() : 0);
-        result = 31 * result + (relativePath != null ? relativePath.hashCode() : 0);
+        result = 31 * result + (path != null ? path.hashCode() : 0);
         return result;
     }
 
@@ -61,14 +61,14 @@ public class BatchFile {
         return "BatchFile{"
                 + "networkAddress='" + networkAddress + '\''
                 + ", downloadFileId=" + downloadFileId
-                + ", relativePath=" + relativePath
+                + ", path=" + path
                 + '}';
     }
 
     public interface Builder {
         Builder withDownloadFileId(DownloadFileId downloadFileId);
 
-        Builder withRelativePath(String relativePath);
+        Builder saveTo(String path);
 
         Batch.Builder apply();
     }
@@ -81,7 +81,7 @@ public class BatchFile {
 
         private final String networkAddress;
         private Optional<DownloadFileId> downloadFileId = Optional.absent();
-        private Optional<String> relativePath = Optional.absent();
+        private Optional<String> path = Optional.absent();
 
         private Batch.InternalBuilder parentBuilder;
 
@@ -102,14 +102,14 @@ public class BatchFile {
         }
 
         @Override
-        public Builder withRelativePath(String relativePath) {
-            this.relativePath = Optional.fromNullable(relativePath);
+        public Builder saveTo(String path) {
+            this.path = Optional.fromNullable(path);
             return this;
         }
 
         @Override
         public Batch.Builder apply() {
-            parentBuilder.withFile(new BatchFile(networkAddress, downloadFileId, relativePath));
+            parentBuilder.withFile(new BatchFile(networkAddress, downloadFileId, path));
             return parentBuilder;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -97,7 +97,7 @@ final class DownloadBatchFactory {
 
     private static String relativePathFrom(BatchFile batchFile) {
         String fileNameFromNetworkAddress = FileNameExtractor.extractFrom(batchFile.networkAddress());
-        return batchFile.relativePath().or(fileNameFromNetworkAddress);
+        return batchFile.path().or(fileNameFromNetworkAddress);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -91,10 +91,10 @@ class MigrationExtractor {
                         }
 
                         if (originalFileId == null) {
-                            newBatchBuilder.addFile(originalNetworkAddress)
+                            newBatchBuilder.downloadFrom(originalNetworkAddress)
                                     .apply();
                         } else {
-                            newBatchBuilder.addFile(originalNetworkAddress)
+                            newBatchBuilder.downloadFrom(originalNetworkAddress)
                                     .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                                     .apply();
                         }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -95,7 +95,7 @@ class MigrationExtractor {
                                     .apply();
                         } else {
                             newBatchBuilder.downloadFrom(originalNetworkAddress)
-                                    .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
+                                    .withIdentifier(DownloadFileIdCreator.createFrom(originalFileId))
                                     .apply();
                         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -69,10 +69,10 @@ class PartialDownloadMigrationExtractor {
                 }
 
                 if (originalFileId == null) {
-                    newBatchBuilder.addFile(uri)
+                    newBatchBuilder.downloadFrom(uri)
                             .apply();
                 } else {
-                    newBatchBuilder.addFile(uri)
+                    newBatchBuilder.downloadFrom(uri)
                             .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
                             .apply();
                 }

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -73,7 +73,7 @@ class PartialDownloadMigrationExtractor {
                             .apply();
                 } else {
                     newBatchBuilder.downloadFrom(uri)
-                            .withDownloadFileId(DownloadFileIdCreator.createFrom(originalFileId))
+                            .withIdentifier(DownloadFileIdCreator.createFrom(originalFileId))
                             .apply();
                 }
 

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -11,7 +11,6 @@ public class BatchBuilderTest {
     private static final DownloadBatchId DOWNLOAD_BATCH_ID = DownloadBatchIdCreator.createFrom("download_batch_id");
     private static final String DOWNLOAD_BATCH_TITLE = "download_batch_title";
     private static final DownloadFileId DOWNLOAD_FILE_ID = new LiteDownloadFileId("download_file_id");
-    private static final String RELATIVE_PATH = "/foo/bar/5MB.zip";
 
     @Test
     public void returnsBatch_whenOptionalParametersAreNotSupplied() {
@@ -28,10 +27,10 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH, "5mb.zip").apply()
+                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo("/foo/bar/", "5MB.zip").apply()
                 .build();
 
-        BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of(RELATIVE_PATH));
+        BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of("/foo/bar/5MB.zip"));
         Batch expectedBatch = new Batch(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE, Collections.singletonList(expectedBatchFile));
 
         assertThat(batch).isEqualTo(expectedBatch);

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -28,7 +28,7 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH).apply()
+                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH).apply()
                 .build();
 
         BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of(RELATIVE_PATH));
@@ -40,8 +40,8 @@ public class BatchBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void throwsException_whenDuplicatedFileIDsAreSupplied() {
         Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
-                .downloadFrom("another_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
+                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).apply()
+                .downloadFrom("another_address").withIdentifier(DOWNLOAD_FILE_ID).apply()
                 .build();
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -16,7 +16,7 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreNotSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .addFile("net_address").apply()
+                .downloadFrom("net_address").apply()
                 .build();
 
         BatchFile expectedBatchFile = new BatchFile("net_address", Optional.absent(), Optional.absent());
@@ -28,7 +28,7 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .addFile("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).withRelativePath(RELATIVE_PATH).apply()
+                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).withRelativePath(RELATIVE_PATH).apply()
                 .build();
 
         BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of(RELATIVE_PATH));
@@ -40,16 +40,16 @@ public class BatchBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void throwsException_whenDuplicatedFileIDsAreSupplied() {
         Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .addFile("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
-                .addFile("another_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
+                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
+                .downloadFrom("another_address").withDownloadFileId(DOWNLOAD_FILE_ID).apply()
                 .build();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void throwsException_whenDuplicatedNetworkAddressWithoutFileIDsAreSupplied() {
         Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .addFile("net_address").apply()
-                .addFile("net_address").apply()
+                .downloadFrom("net_address").apply()
+                .downloadFrom("net_address").apply()
                 .build();
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -28,7 +28,7 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).withRelativePath(RELATIVE_PATH).apply()
+                .downloadFrom("net_address").withDownloadFileId(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH).apply()
                 .build();
 
         BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of(RELATIVE_PATH));

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -28,7 +28,7 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH).apply()
+                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo(RELATIVE_PATH, "5mb.zip").apply()
                 .build();
 
         BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of(RELATIVE_PATH));

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -77,8 +77,8 @@ public class MigrationExtractorTest {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
         Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_1".hashCode())), "title_1")
-                .downloadFrom(firstUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_1")).apply()
-                .downloadFrom(secondUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_2")).apply()
+                .downloadFrom(firstUri).withIdentifier(DownloadFileIdCreator.createFrom("file_1")).apply()
+                .downloadFrom(secondUri).withIdentifier(DownloadFileIdCreator.createFrom("file_2")).apply()
                 .build();
 
         List<Migration.FileMetadata> firstFileMetadata = new ArrayList<>();
@@ -88,8 +88,8 @@ public class MigrationExtractorTest {
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
         Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_3".hashCode())), "title_2")
-                .downloadFrom(thirdUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_3")).apply()
-                .downloadFrom(fourthUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_4")).apply()
+                .downloadFrom(thirdUri).withIdentifier(DownloadFileIdCreator.createFrom("file_3")).apply()
+                .downloadFrom(fourthUri).withIdentifier(DownloadFileIdCreator.createFrom("file_4")).apply()
                 .build();
 
         List<Migration.FileMetadata> secondFileMetadata = new ArrayList<>();

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -77,8 +77,8 @@ public class MigrationExtractorTest {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
         Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_1".hashCode())), "title_1")
-                .addFile(firstUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_1")).apply()
-                .addFile(secondUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_2")).apply()
+                .downloadFrom(firstUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_1")).apply()
+                .downloadFrom(secondUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_2")).apply()
                 .build();
 
         List<Migration.FileMetadata> firstFileMetadata = new ArrayList<>();
@@ -88,8 +88,8 @@ public class MigrationExtractorTest {
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
         Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_3".hashCode())), "title_2")
-                .addFile(thirdUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_3")).apply()
-                .addFile(fourthUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_4")).apply()
+                .downloadFrom(thirdUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_3")).apply()
+                .downloadFrom(fourthUri).withDownloadFileId(DownloadFileIdCreator.createFrom("file_4")).apply()
                 .build();
 
         List<Migration.FileMetadata> secondFileMetadata = new ArrayList<>();


### PR DESCRIPTION
## Problem
Some of the methods on the `Batch.Builder` are easily misinterpreted 😬 

## Solution
- Rename `addFile(networkAddress` to `downloadFrom(networkAddress)`
- Rename `withRelativePath(path)` to `saveTo(path)`
- Rename `withDownloadFileId(downloadFileId)` to `withIdentifier(downloadFileId)`, this could probably be more explicit but I couldn't think of a good name.

- `saveTo` has two implementations, one that takes just a path and another that takes a path and a file name.

## Next PR
Will make the `Optional<String> path` no longer `Optional`, moving the manipulation of the path from the `DownloadBatchFactory` to the `Batch.Builder` instead.