### PR TITLE
Move path manipulation to Batch / File Builder

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -40,8 +40,8 @@ public class MainActivity extends AppCompatActivity {
     @SuppressLint("SdCardPath")
     private static final String V1_BASE_PATH = "/data/data/com.novoda.downloadmanager.demo.simple/files/Pictures/";
 
-    private static final DownloadBatchId BATCH_ID_1 = DownloadBatchIdCreator.createFrom("batch_id_1");
-    private static final DownloadBatchId BATCH_ID_2 = DownloadBatchIdCreator.createFrom("batch_id_2");
+    private static final DownloadBatchId BATCH_ID_1 = DownloadBatchIdCreator.createSanitizedFrom("batch_id_1");
+    private static final DownloadBatchId BATCH_ID_2 = DownloadBatchIdCreator.createSanitizedFrom("batch_id_2");
     private static final DownloadFileId FILE_ID_1 = DownloadFileIdCreator.createFrom("file_id_1");
     private static final String FIVE_MB_FILE_URL = "http://ipv4.download.thinkbroadband.com/5MB.zip";
     private static final String TEN_MB_FILE_URL = "http://ipv4.download.thinkbroadband.com/10MB.zip";

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -101,7 +101,7 @@ public class Batch {
 
         @Override
         public BatchFile.Builder downloadFrom(String networkAddress) {
-            this.fileBuilder = BatchFile.downloadFrom(networkAddress).withParentBuilder(this);
+            this.fileBuilder = BatchFile.from(downloadBatchId, networkAddress).withParentBuilder(this);
             return this.fileBuilder;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -1,6 +1,5 @@
 package com.novoda.downloadmanager;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -37,7 +36,7 @@ final class DownloadBatchFactory {
             FilePersistence filePersistence = fileOperations.filePersistenceCreator().create();
 
             String basePath = filePersistence.basePath().path();
-            FilePath filePath = FilePathCreator.create(basePath, prependBatchIdTo(relativePathFrom(batchFile), downloadBatchId));
+            FilePath filePath = FilePathCreator.create(basePath, batchFile.path());
 
             DownloadFileId downloadFileId = FallbackDownloadFileIdProvider.downloadFileIdFor(batch.downloadBatchId(), batchFile);
             InternalDownloadFileStatus downloadFileStatus = new LiteDownloadFileStatus(
@@ -85,19 +84,6 @@ final class DownloadBatchFactory {
                 callbackThrottle,
                 connectionChecker
         );
-    }
-
-    private static String prependBatchIdTo(String filePath, DownloadBatchId downloadBatchId) {
-        return sanitizeBatchIdPath(downloadBatchId.rawId()) + File.separatorChar + filePath;
-    }
-
-    private static String sanitizeBatchIdPath(String batchIdPath) {
-        return batchIdPath.replaceAll("[:\\\\/*?|<>]", "_");
-    }
-
-    private static String relativePathFrom(BatchFile batchFile) {
-        String fileNameFromNetworkAddress = FileNameExtractor.extractFrom(batchFile.networkAddress());
-        return batchFile.path().or(fileNameFromNetworkAddress);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchIdCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchIdCreator.java
@@ -6,7 +6,12 @@ public final class DownloadBatchIdCreator {
         // non-instantiable class
     }
 
-    public static DownloadBatchId createFrom(String rawId) {
-        return new LiteDownloadBatchId(rawId);
+    public static DownloadBatchId createSanitizedFrom(String rawId) {
+        String sanitizedBatchId = sanitizeBatchId(rawId);
+        return new LiteDownloadBatchId(sanitizedBatchId);
+    }
+
+    private static String sanitizeBatchId(String batchIdPath) {
+        return batchIdPath.replaceAll("[:\\\\/*?|<>]", "_");
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationExtractor.java
@@ -131,10 +131,10 @@ class MigrationExtractor {
     private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {
         if (originalFileId == null || originalFileId.isEmpty()) {
             String hashedString = String.valueOf(batchId.hashCode());
-            return DownloadBatchIdCreator.createFrom(hashedString);
+            return DownloadBatchIdCreator.createSanitizedFrom(hashedString);
         }
         String hashedString = String.valueOf(originalFileId.hashCode());
-        return DownloadBatchIdCreator.createFrom(hashedString);
+        return DownloadBatchIdCreator.createSanitizedFrom(hashedString);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -100,9 +100,9 @@ class PartialDownloadMigrationExtractor {
     private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {
         if (originalFileId == null || originalFileId.isEmpty()) {
             String hashedString = String.valueOf(batchId.hashCode());
-            return DownloadBatchIdCreator.createFrom(hashedString);
+            return DownloadBatchIdCreator.createSanitizedFrom(hashedString);
         }
         String hashedString = String.valueOf(originalFileId.hashCode());
-        return DownloadBatchIdCreator.createFrom(hashedString);
+        return DownloadBatchIdCreator.createSanitizedFrom(hashedString);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -53,7 +53,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         for (RoomBatch roomBatch : roomBatches) {
             DownloadsBatchPersisted batchPersisted = new LiteDownloadsBatchPersisted(
                     DownloadBatchTitleCreator.createFrom(roomBatch.title),
-                    DownloadBatchIdCreator.createFrom(roomBatch.id),
+                    DownloadBatchIdCreator.createSanitizedFrom(roomBatch.id),
                     DownloadBatchStatus.Status.from(roomBatch.status),
                     roomBatch.downloadedDateTimeInMillis,
                     roomBatch.notificationSeen
@@ -93,7 +93,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         List<DownloadsFilePersisted> filePersistedList = new ArrayList<>(roomFiles.size());
         for (RoomFile roomFile : roomFiles) {
             DownloadsFilePersisted filePersisted = new LiteDownloadsFilePersisted(
-                    DownloadBatchIdCreator.createFrom(roomFile.batchId),
+                    DownloadBatchIdCreator.createSanitizedFrom(roomFile.batchId),
                     DownloadFileIdCreator.createFrom(roomFile.fileId),
                     new LiteFilePath(roomFile.path),
                     roomFile.totalSize,

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -8,7 +8,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class BatchBuilderTest {
 
-    private static final DownloadBatchId DOWNLOAD_BATCH_ID = DownloadBatchIdCreator.createFrom("download_batch_id");
+    private static final DownloadBatchId DOWNLOAD_BATCH_ID = DownloadBatchIdCreator.createSanitizedFrom("download_batch_id");
     private static final String DOWNLOAD_BATCH_TITLE = "download_batch_title";
     private static final DownloadFileId DOWNLOAD_FILE_ID = new LiteDownloadFileId("download_file_id");
     private static final String RELATIVE_PATH = "/foo/bar/5MB.zip";

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -15,10 +15,10 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreNotSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").apply()
+                .downloadFrom("http://example.com/5mb.zip").apply()
                 .build();
 
-        BatchFile expectedBatchFile = new BatchFile("net_address", Optional.absent(), Optional.absent());
+        BatchFile expectedBatchFile = new BatchFile("http://example.com/5mb.zip", Optional.absent(), "download_batch_id/5mb.zip");
         Batch expectedBatch = new Batch(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE, Collections.singletonList(expectedBatchFile));
 
         assertThat(batch).isEqualTo(expectedBatch);
@@ -27,10 +27,10 @@ public class BatchBuilderTest {
     @Test
     public void returnsBatch_whenOptionalParametersAreSupplied() {
         Batch batch = Batch.with(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
-                .downloadFrom("net_address").withIdentifier(DOWNLOAD_FILE_ID).saveTo("/foo/bar/", "5MB.zip").apply()
+                .downloadFrom("http://example.com/5mb.zip").withIdentifier(DOWNLOAD_FILE_ID).saveTo("foo/bar/", "5mb.zip").apply()
                 .build();
 
-        BatchFile expectedBatchFile = new BatchFile("net_address", Optional.of(DOWNLOAD_FILE_ID), Optional.of("/foo/bar/5MB.zip"));
+        BatchFile expectedBatchFile = new BatchFile("http://example.com/5mb.zip", Optional.of(DOWNLOAD_FILE_ID), "download_batch_id/foo/bar/5mb.zip");
         Batch expectedBatch = new Batch(DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE, Collections.singletonList(expectedBatchFile));
 
         assertThat(batch).isEqualTo(expectedBatch);

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadFileStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadFileStatusFixtures.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager;
 
 class DownloadFileStatusFixtures {
 
-    private DownloadBatchId downloadBatchId = DownloadBatchIdCreator.createFrom("batch_01");
+    private DownloadBatchId downloadBatchId = DownloadBatchIdCreator.createSanitizedFrom("batch_01");
     private DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom("01");
     private InternalDownloadFileStatus.Status status = InternalDownloadFileStatus.Status.QUEUED;
     private FileSize fileSize = InternalFileSizeFixtures.aFileSize().build();

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationExtractorTest.java
@@ -76,7 +76,7 @@ public class MigrationExtractorTest {
     private List<Migration> expectedMigrations() {
         String firstUri = "uri_1";
         String secondUri = "uri_2";
-        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_1".hashCode())), "title_1")
+        Batch firstBatch = Batch.with(DownloadBatchIdCreator.createSanitizedFrom(String.valueOf("file_1".hashCode())), "title_1")
                 .downloadFrom(firstUri).withIdentifier(DownloadFileIdCreator.createFrom("file_1")).apply()
                 .downloadFrom(secondUri).withIdentifier(DownloadFileIdCreator.createFrom("file_2")).apply()
                 .build();
@@ -87,7 +87,7 @@ public class MigrationExtractorTest {
 
         String thirdUri = "uri_3";
         String fourthUri = "uri_4";
-        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createFrom(String.valueOf("file_3".hashCode())), "title_2")
+        Batch secondBatch = Batch.with(DownloadBatchIdCreator.createSanitizedFrom(String.valueOf("file_3".hashCode())), "title_2")
                 .downloadFrom(thirdUri).withIdentifier(DownloadFileIdCreator.createFrom("file_3")).apply()
                 .downloadFrom(fourthUri).withIdentifier(DownloadFileIdCreator.createFrom("file_4")).apply()
                 .build();

--- a/library/src/test/java/com/novoda/downloadmanager/MigrationPathExtractorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/MigrationPathExtractorTest.java
@@ -7,7 +7,7 @@ import static com.google.common.truth.Truth.assertThat;
 public class MigrationPathExtractorTest {
 
     private static final String BASE_PATH = "/data/data/com.novoda.downloadmanager.demo.simple/files/Pictures/";
-    private static final DownloadBatchId DOWNLOAD_BATCH_ID = DownloadBatchIdCreator.createFrom("batch_01");
+    private static final DownloadBatchId DOWNLOAD_BATCH_ID = DownloadBatchIdCreator.createSanitizedFrom("batch_01");
 
     @Test
     public void returnsAbsolutePathAndFileName_whenAssetPathConsistsOfFileNameOnly() {


### PR DESCRIPTION
## Problem 
Currently in the `DownloadBatchFactory` create a path from the `relativePath` or the `network` address based on the parameters that are specified in the `Batch.Builder`. Additionally we sanitise and prepend the `DownloadBatchId` to the this path. All of this is hidden in the factory and essentially means that the `Batch` we create from the `Builder` is passing partially invalid data. Ideally when we reach the factory we already want the `Batch` to contain only valid data.

## Solution
- Move the sanitisation of the `DownloadBatchId` to the `DownloadBatchIdCreator` and make it explicit in the naming, to avoid confusion for clients.

- Move the manipulation of the `path` to the `BatchFileBuilder`, making `BatchFile.path` mandatory.
