### PR TITLE
GZIP response content length

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
@@ -46,7 +46,7 @@ class NetworkFileSizeRequester implements FileSizeRequester {
     }
 
     private long requestFileSizeThroughHeaderRequest(String url) throws IOException {
-        NetworkRequest fileSizeRequest = requestCreator.createFileSizeRequest(url);
+        NetworkRequest fileSizeRequest = requestCreator.createFileSizeHeadRequest(url);
         HttpClient.NetworkResponse response = httpClient.execute(fileSizeRequest);
         long fileSize = ZERO_FILE_SIZE;
         if (response.isSuccessful()) {
@@ -57,7 +57,7 @@ class NetworkFileSizeRequester implements FileSizeRequester {
     }
 
     private long requestFileSizeThroughBodyRequest(String url) throws IOException {
-        NetworkRequest downloadRequest = requestCreator.createDownloadRequest(url);
+        NetworkRequest downloadRequest = requestCreator.createFileSizeBodyRequest(url);
         HttpClient.NetworkResponse response = httpClient.execute(downloadRequest);
         long fileSize = ZERO_FILE_SIZE;
         if (response.isSuccessful()) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
@@ -34,7 +34,7 @@ class NetworkFileSizeRequester implements FileSizeRequester {
 
     private long executeRequestFileSize(String url) throws IOException {
         long fileSize = requestFileSizeThroughHeaderRequest(url);
-        if (fileSize == 0) {
+        if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
             Logger.w("filesize request through header returned zero, we'll try again " + url);
             fileSize = requestFileSizeThroughBodyRequest(url);
             if (fileSize == 0) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
@@ -20,7 +20,7 @@ class NetworkFileSizeRequester implements FileSizeRequester {
     public FileSize requestFileSize(String url) {
         try {
             long fileSize = executeRequestFileSize(url);
-            if (fileSize == 0) {
+            if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
                 return FileSizeCreator.unknownFileSize();
             } else {
                 return FileSizeCreator.createFromTotalSize(fileSize);
@@ -35,10 +35,10 @@ class NetworkFileSizeRequester implements FileSizeRequester {
     private long executeRequestFileSize(String url) throws IOException {
         long fileSize = requestFileSizeThroughHeaderRequest(url);
         if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
-            Logger.w("filesize request through header returned zero, we'll try again " + url);
+            Logger.w(String.format("file size header request '%s' returned %s, we'll try with a body request", url, fileSize));
             fileSize = requestFileSizeThroughBodyRequest(url);
-            if (fileSize == 0) {
-                Logger.w("filesize request through body returned zero");
+            if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
+                Logger.w(String.format("file size body request '%s' returned %s", url, fileSize));
             }
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
@@ -6,17 +6,18 @@ import java.util.Map;
 class NetworkRequestCreator {
 
     private static final String DOWNLOADED_BYTES_VALUE_FORMAT = "bytes=%s-%s";
+    private static final Map<String, String> DISABLE_COMPRESSION_HEADERS = new HashMap<>(1);
+
+    static {
+        DISABLE_COMPRESSION_HEADERS.put("Accept-Encoding", "identity");
+    }
 
     NetworkRequest createFileSizeHeadRequest(String url) {
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("Accept-Encoding", "identity");
-        return new NetworkRequest(headers, url, NetworkRequest.Method.HEAD);
+        return new NetworkRequest(DISABLE_COMPRESSION_HEADERS, url, NetworkRequest.Method.HEAD);
     }
 
     NetworkRequest createFileSizeBodyRequest(String url) {
-        HashMap<String, String> headers = new HashMap<>();
-        headers.put("Accept-Encoding", "identity");
-        return new NetworkRequest(headers, url, NetworkRequest.Method.GET);
+        return new NetworkRequest(DISABLE_COMPRESSION_HEADERS, url, NetworkRequest.Method.GET);
     }
 
     NetworkRequest createDownloadRequest(String url) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
@@ -8,7 +8,7 @@ class NetworkRequestCreator {
     private static final String DOWNLOADED_BYTES_VALUE_FORMAT = "bytes=%s-%s";
 
     NetworkRequest createFileSizeRequest(String url) {
-        return new NetworkRequest(new HashMap<>(), url, NetworkRequest.Method.HEAD);
+        return new NetworkRequest(new HashMap<>(), url, NetworkRequest.Method.GET);
     }
 
     NetworkRequest createDownloadRequest(String url) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
@@ -8,7 +8,7 @@ class NetworkRequestCreator {
     private static final String DOWNLOADED_BYTES_VALUE_FORMAT = "bytes=%s-%s";
 
     NetworkRequest createFileSizeRequest(String url) {
-        return new NetworkRequest(new HashMap<>(), url, NetworkRequest.Method.GET);
+        return new NetworkRequest(new HashMap<>(), url, NetworkRequest.Method.HEAD);
     }
 
     NetworkRequest createDownloadRequest(String url) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
@@ -7,8 +7,16 @@ class NetworkRequestCreator {
 
     private static final String DOWNLOADED_BYTES_VALUE_FORMAT = "bytes=%s-%s";
 
-    NetworkRequest createFileSizeRequest(String url) {
-        return new NetworkRequest(new HashMap<>(), url, NetworkRequest.Method.HEAD);
+    NetworkRequest createFileSizeHeadRequest(String url) {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Accept-Encoding", "identity");
+        return new NetworkRequest(headers, url, NetworkRequest.Method.HEAD);
+    }
+
+    NetworkRequest createFileSizeBodyRequest(String url) {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Accept-Encoding", "identity");
+        return new NetworkRequest(headers, url, NetworkRequest.Method.GET);
     }
 
     NetworkRequest createDownloadRequest(String url) {

--- a/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
+++ b/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
@@ -24,6 +24,7 @@ class WrappedOkHttpClient implements HttpClient {
             requestBuilder = requestBuilder.head();
         }
 
+        requestBuilder.addHeader("Accept-Encoding", "identity");
         for (Map.Entry<String, String> entry : request.headers().entrySet()) {
             requestBuilder.addHeader(entry.getKey(), entry.getValue());
         }

--- a/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
+++ b/library/src/main/java/com/novoda/downloadmanager/WrappedOkHttpClient.java
@@ -24,7 +24,6 @@ class WrappedOkHttpClient implements HttpClient {
             requestBuilder = requestBuilder.head();
         }
 
-        requestBuilder.addHeader("Accept-Encoding", "identity");
         for (Map.Entry<String, String> entry : request.headers().entrySet()) {
             requestBuilder.addHeader(entry.getKey(), entry.getValue());
         }

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
@@ -1,9 +1,9 @@
 package com.novoda.downloadmanager;
 
+import java.io.IOException;
+
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.NetworkResponseFixtures.aNetworkResponse;
@@ -29,7 +29,7 @@ public class NetworkFileSizeRequesterTest {
 
     @Test
     public void returnsUnknownSize_whenHttpClientErrors() throws IOException {
-        given(httpClient.execute(requestCreator.createFileSizeRequest(ANY_RAW_URL))).willThrow(IOException.class);
+        given(httpClient.execute(requestCreator.createFileSizeHeadRequest(ANY_RAW_URL))).willThrow(IOException.class);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 
@@ -38,8 +38,8 @@ public class NetworkFileSizeRequesterTest {
 
     @Test
     public void returnsUnknownSize_whenResponseIsUnsuccessful() throws IOException {
-        given(httpClient.execute(requestCreator.createFileSizeRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
-        given(httpClient.execute(requestCreator.createDownloadRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
+        given(httpClient.execute(requestCreator.createFileSizeHeadRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
+        given(httpClient.execute(requestCreator.createFileSizeBodyRequest(ANY_RAW_URL))).willReturn(UNSUCCESSFUL_RESPONSE);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 
@@ -48,7 +48,7 @@ public class NetworkFileSizeRequesterTest {
 
     @Test
     public void returnsFileSize_whenResponseSuccessful() throws IOException {
-        given(httpClient.execute(requestCreator.createFileSizeRequest(ANY_RAW_URL))).willReturn(SUCCESSFUL_RESPONSE);
+        given(httpClient.execute(requestCreator.createFileSizeHeadRequest(ANY_RAW_URL))).willReturn(SUCCESSFUL_RESPONSE);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 


### PR DESCRIPTION
## Problem
`OkHttp` automatically adds the `Accept-Encoding` header to any request that we make. In the case of `GZIP` okhttp will automatically decompress the file when downloading, this means that the `Content-Length` (compressed size) does not match the actual size when it is decompressed automatically. 

## Solution
Add the header `Accept-Encoding: Identity` -> Indicates the identity function (i.e. no compression, nor modification). This will give the correct `Content-Length` for our file size request.

## Screen Capture

Before | After
--- | --- 
![gzip_before mp4](https://user-images.githubusercontent.com/3380092/39474114-4b641398-4d4a-11e8-9084-7ac642608aa1.gif) | ![gzip_after mp4](https://user-images.githubusercontent.com/3380092/39474115-4b7bce2a-4d4a-11e8-9638-359036ef158b.gif)
