### PR TITLE
Alternative migration partials

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -140,8 +140,22 @@ public class MainActivity extends AppCompatActivity {
 
         for (VersionOnePartialDownloadBatch partialDownloadBatch : partialDownloadBatches) {
             liteDownloadManagerCommands.download(partialDownloadBatch.batch());
+            deleteVersionOneFiles(partialDownloadBatch);
         }
     };
+
+    private void deleteVersionOneFiles(VersionOnePartialDownloadBatch partialDownloadBatch) {
+        for (String originalFileLocation : partialDownloadBatch.originalFileLocations()) {
+            if (originalFileLocation != null && !originalFileLocation.isEmpty()) {
+                File file = new File(originalFileLocation);
+                boolean deleted = file.delete();
+                if (!deleted) {
+                    String message = String.format("Could not delete File or Directory: %s", file.getPath());
+                    Log.e(getClass().getSimpleName(), message);
+                }
+            }
+        }
+    }
 
     private final CompoundButton.OnCheckedChangeListener wifiOnlyOnCheckedChange = (buttonView, isChecked) -> {
         LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -27,7 +27,7 @@ import com.novoda.downloadmanager.DownloadMigratorBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
 import com.novoda.downloadmanager.MigrationCallback;
 import com.novoda.downloadmanager.MigrationStatus;
-import com.novoda.downloadmanager.PartialDownloadMigrationExtractor;
+import com.novoda.downloadmanager.VersionOnePartialDownloadBatchesExtractor;
 import com.novoda.downloadmanager.SqlDatabaseWrapper;
 import com.novoda.downloadmanager.VersionOnePartialDownloadBatch;
 
@@ -134,7 +134,7 @@ public class MainActivity extends AppCompatActivity {
 
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
-        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
+        VersionOnePartialDownloadBatchesExtractor partialDownloadMigrationExtractor = new VersionOnePartialDownloadBatchesExtractor(database);
 
         List<VersionOnePartialDownloadBatch> partialDownloadBatches = partialDownloadMigrationExtractor.extractMigrations();
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -29,6 +29,7 @@ import com.novoda.downloadmanager.MigrationCallback;
 import com.novoda.downloadmanager.MigrationStatus;
 import com.novoda.downloadmanager.PartialDownloadMigrationExtractor;
 import com.novoda.downloadmanager.SqlDatabaseWrapper;
+import com.novoda.downloadmanager.VersionOnePartialDownloadBatch;
 
 import java.io.File;
 import java.util.List;
@@ -135,10 +136,10 @@ public class MainActivity extends AppCompatActivity {
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
 
-        List<Batch> partialDownloads = partialDownloadMigrationExtractor.extractMigrations();
+        List<VersionOnePartialDownloadBatch> partialDownloadBatches = partialDownloadMigrationExtractor.extractMigrations();
 
-        for (Batch partialDownload : partialDownloads) {
-            liteDownloadManagerCommands.download(partialDownload);
+        for (VersionOnePartialDownloadBatch partialDownloadBatch : partialDownloadBatches) {
+            liteDownloadManagerCommands.download(partialDownloadBatch.batch());
         }
     };
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -25,7 +25,6 @@ import com.novoda.downloadmanager.DownloadFileIdCreator;
 import com.novoda.downloadmanager.DownloadMigrator;
 import com.novoda.downloadmanager.DownloadMigratorBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
-import com.novoda.downloadmanager.Migration;
 import com.novoda.downloadmanager.MigrationCallback;
 import com.novoda.downloadmanager.MigrationStatus;
 import com.novoda.downloadmanager.PartialDownloadMigrationExtractor;
@@ -134,12 +133,12 @@ public class MainActivity extends AppCompatActivity {
 
         SQLiteDatabase sqLiteDatabase = SQLiteDatabase.openDatabase(databasePath.getAbsolutePath(), null, 0);
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
-        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database, V1_BASE_PATH);
+        PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database);
 
-        List<Migration> migrations = partialDownloadMigrationExtractor.extractMigrations();
+        List<Batch> partialDownloads = partialDownloadMigrationExtractor.extractMigrations();
 
-        for (Migration migration : migrations) {
-            liteDownloadManagerCommands.download(migration.batch());
+        for (Batch partialDownload : partialDownloads) {
+            liteDownloadManagerCommands.download(partialDownload);
         }
     };
 

--- a/library/src/main/java/com/novoda/downloadmanager/Migration.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Migration.java
@@ -3,9 +3,9 @@ package com.novoda.downloadmanager;
 import java.util.Collections;
 import java.util.List;
 
-class Migration {
+public class Migration {
 
-    enum Type {
+    public enum Type {
         COMPLETE,
         PARTIAL
     }
@@ -15,18 +15,18 @@ class Migration {
     private final long downloadedDateTimeInMillis;
     private final Type type;
 
-    Migration(Batch batch, List<FileMetadata> fileMetadata, long downloadedDateTimeInMillis, Type type) {
+    public Migration(Batch batch, List<FileMetadata> fileMetadata, long downloadedDateTimeInMillis, Type type) {
         this.batch = batch;
         this.fileMetadata = Collections.unmodifiableList(fileMetadata);
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.type = type;
     }
 
-    Batch batch() {
+    public Batch batch() {
         return batch;
     }
 
-    List<FileMetadata> getFileMetadata() {
+    public List<FileMetadata> getFileMetadata() {
         return fileMetadata;
     }
 
@@ -34,7 +34,7 @@ class Migration {
         return downloadedDateTimeInMillis;
     }
 
-    Type type() {
+    public Type type() {
         return type;
     }
 
@@ -80,7 +80,7 @@ class Migration {
                 + '}';
     }
 
-    static class FileMetadata {
+    public static class FileMetadata {
 
         private final String fileId;
         private final FilePath originalFileLocation;
@@ -88,7 +88,7 @@ class Migration {
         private final FileSize fileSize;
         private final String originalNetworkAddress;
 
-        FileMetadata(String fileId, FilePath originalFileLocation, FilePath newFileLocation, FileSize fileSize, String originalNetworkAddress) {
+        public FileMetadata(String fileId, FilePath originalFileLocation, FilePath newFileLocation, FileSize fileSize, String originalNetworkAddress) {
             this.fileId = fileId;
             this.originalFileLocation = originalFileLocation;
             this.newFileLocation = newFileLocation;
@@ -96,23 +96,23 @@ class Migration {
             this.originalNetworkAddress = originalNetworkAddress;
         }
 
-        String fileId() {
+        public String fileId() {
             return fileId;
         }
 
-        FilePath originalFileLocation() {
+        public FilePath originalFileLocation() {
             return originalFileLocation;
         }
 
-        FilePath newFileLocation() {
+        public FilePath newFileLocation() {
             return newFileLocation;
         }
 
-        FileSize fileSize() {
+        public FileSize fileSize() {
             return fileSize;
         }
 
-        String originalNetworkAddress() {
+        public String originalNetworkAddress() {
             return originalNetworkAddress;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 public class PartialDownloadMigrationExtractor {
 
-    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title, batches.last_modified_timestamp "
+    private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title "
             + "FROM batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
             + "WHERE DownloadsByBatch.batch_total_bytes != DownloadsByBatch.batch_current_bytes "
             + "OR DownloadsByBatch._data IS NULL "
@@ -17,7 +17,6 @@ public class PartialDownloadMigrationExtractor {
 
     private static final int BATCH_ID_COLUMN = 0;
     private static final int TITLE_COLUMN = 1;
-    private static final int MODIFIED_TIMESTAMP_COLUMN = 2;
 
     private static final String DOWNLOADS_QUERY = "SELECT uri, notificationextras, hint FROM Downloads WHERE batch_id = ?";
     private static final int URI_COLUMN = 0;
@@ -25,36 +24,29 @@ public class PartialDownloadMigrationExtractor {
     private static final int FILE_LOCATION_COLUMN = 2;
 
     private final SqlDatabaseWrapper database;
-    private final String basePath;
 
-    public PartialDownloadMigrationExtractor(SqlDatabaseWrapper database, String basePath) {
+    public PartialDownloadMigrationExtractor(SqlDatabaseWrapper database) {
         this.database = database;
-        this.basePath = basePath;
     }
 
-    public List<Migration> extractMigrations() {
+    public List<Batch> extractMigrations() {
         Cursor batchesCursor = database.rawQuery(BATCHES_QUERY);
 
-        List<Migration> migrations = new ArrayList<>();
+        List<Batch> batches = new ArrayList<>();
         while (batchesCursor.moveToNext()) {
 
             String batchId = batchesCursor.getString(BATCH_ID_COLUMN);
             String batchTitle = batchesCursor.getString(TITLE_COLUMN);
-            long downloadedDateTimeInMillis = batchesCursor.getLong(MODIFIED_TIMESTAMP_COLUMN);
 
             Cursor downloadsCursor = database.rawQuery(DOWNLOADS_QUERY, batchId);
             BatchBuilder newBatchBuilder = null;
-            List<Migration.FileMetadata> fileMetadataList = new ArrayList<>();
             Set<String> uris = new HashSet<>();
             Set<String> fileIds = new HashSet<>();
 
-            DownloadBatchId downloadBatchId = null;
+            DownloadBatchId downloadBatchId;
             while (downloadsCursor.moveToNext()) {
                 String originalFileId = downloadsCursor.getString(FILE_ID_COLUMN);
                 String uri = downloadsCursor.getString(URI_COLUMN);
-                String originalFileLocation = downloadsCursor.getString(FILE_LOCATION_COLUMN);
-                String sanitizedOriginalFileLocation = MigrationStoragePathSanitizer.sanitize(originalFileLocation);
-                FilePath originalFilePath = new LiteFilePath(sanitizedOriginalFileLocation);
 
                 if (downloadsCursor.isFirst()) {
                     downloadBatchId = createDownloadBatchIdFrom(originalFileId, batchId);
@@ -76,25 +68,14 @@ public class PartialDownloadMigrationExtractor {
                             .withIdentifier(DownloadFileIdCreator.createFrom(originalFileId))
                             .apply();
                 }
-
-                FilePath newFilePath = MigrationPathExtractor.extractMigrationPath(basePath, originalFilePath.path(), downloadBatchId);
-
-                Migration.FileMetadata fileMetadata = new Migration.FileMetadata(
-                        originalFileId,
-                        originalFilePath,
-                        newFilePath,
-                        FileSizeCreator.unknownFileSize(),
-                        uri
-                );
-                fileMetadataList.add(fileMetadata);
             }
             downloadsCursor.close();
 
             Batch batch = newBatchBuilder.build();
-            migrations.add(new Migration(batch, fileMetadataList, downloadedDateTimeInMillis, Migration.Type.PARTIAL));
+            batches.add(batch);
         }
         batchesCursor.close();
-        return migrations;
+        return batches;
     }
 
     private DownloadBatchId createDownloadBatchIdFrom(String originalFileId, String batchId) {

--- a/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PartialDownloadMigrationExtractor.java
@@ -7,7 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-class PartialDownloadMigrationExtractor {
+public class PartialDownloadMigrationExtractor {
 
     private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title, batches.last_modified_timestamp "
             + "FROM batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
@@ -27,12 +27,12 @@ class PartialDownloadMigrationExtractor {
     private final SqlDatabaseWrapper database;
     private final String basePath;
 
-    PartialDownloadMigrationExtractor(SqlDatabaseWrapper database, String basePath) {
+    public PartialDownloadMigrationExtractor(SqlDatabaseWrapper database, String basePath) {
         this.database = database;
         this.basePath = basePath;
     }
 
-    List<Migration> extractMigrations() {
+    public List<Migration> extractMigrations() {
         Cursor batchesCursor = database.rawQuery(BATCHES_QUERY);
 
         List<Migration> migrations = new ArrayList<>();

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOnePartialDownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOnePartialDownloadBatch.java
@@ -1,0 +1,54 @@
+package com.novoda.downloadmanager;
+
+import java.util.List;
+
+public class VersionOnePartialDownloadBatch {
+
+    private final Batch batch;
+    private final List<String> originalFileLocations;
+
+    VersionOnePartialDownloadBatch(Batch batch, List<String> originalFileLocations) {
+        this.batch = batch;
+        this.originalFileLocations = originalFileLocations;
+    }
+
+    public Batch batch() {
+        return batch;
+    }
+
+    public List<String> originalFileLocations() {
+        return originalFileLocations;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        VersionOnePartialDownloadBatch that = (VersionOnePartialDownloadBatch) o;
+
+        if (batch != null ? !batch.equals(that.batch) : that.batch != null) {
+            return false;
+        }
+        return originalFileLocations != null ? originalFileLocations.equals(that.originalFileLocations) : that.originalFileLocations == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = batch != null ? batch.hashCode() : 0;
+        result = 31 * result + (originalFileLocations != null ? originalFileLocations.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "VersionOnePartialDownloadBatch{"
+                + "batch=" + batch
+                + ", originalFileLocations=" + originalFileLocations
+                + '}';
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/VersionOnePartialDownloadBatchesExtractor.java
+++ b/library/src/main/java/com/novoda/downloadmanager/VersionOnePartialDownloadBatchesExtractor.java
@@ -7,7 +7,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-public class PartialDownloadMigrationExtractor {
+public class VersionOnePartialDownloadBatchesExtractor {
 
     private static final String BATCHES_QUERY = "SELECT batches._id, batches.batch_title "
             + "FROM batches INNER JOIN DownloadsByBatch ON DownloadsByBatch.batch_id = batches._id "
@@ -25,7 +25,7 @@ public class PartialDownloadMigrationExtractor {
 
     private final SqlDatabaseWrapper database;
 
-    public PartialDownloadMigrationExtractor(SqlDatabaseWrapper database) {
+    public VersionOnePartialDownloadBatchesExtractor(SqlDatabaseWrapper database) {
         this.database = database;
     }
 


### PR DESCRIPTION
## Problem
We want to be able to expose a mechanism for migrating data from version one to version two of the `download-manager`. At the moment the implementation is heavily constructed around one usecase and buried within a migration job that cannot be customised by clients of the library. 

## Solution
Avoid doing all of the heavy lifting in the library. The idea now is to only go through the `LiteDownloadManagerCommands` interface. This means we will trigger `download` for partials, we won't perform the extraction or any notifications from within the library itself, this will be down to the client. 

This PR publicly exposes the `PartialDownloadMigrationExtractor` (will be moved to demo module later), and shows how the `partial` downloads can be extracted and queued on the new `download-manager`.

## Follow-up
Do the same for the complete downloads from version one. Remove the migration job and wrap everything in something that can be executed off of the main thread.