### PR TITLE
DownloadError message

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -221,6 +221,8 @@ class DownloadBatch {
             if (currentBytesDownloaded > totalBatchSizeBytes) {
                 DownloadError downloadError = DownloadErrorFactory.createSizeMismatchError(downloadFileStatus);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
+                callbackThrottle.update(downloadBatchStatus);
+                return;
             }
 
             if (currentBytesDownloaded == totalBatchSizeBytes && totalBatchSizeBytes != ZERO_BYTES) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -219,7 +219,13 @@ class DownloadBatch {
             downloadBatchStatus.updateDownloaded(currentBytesDownloaded);
 
             if (currentBytesDownloaded > totalBatchSizeBytes) {
-                DownloadError downloadError = new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH);
+                String sizeMismatchMessage = String.format(
+                        "Download File with ID: %s has a greater current size: %s than the total size: ",
+                        downloadFileStatus.downloadBatchId().rawId(),
+                        downloadFileStatus.bytesDownloaded(),
+                        downloadFileStatus.totalBytes()
+                );
+                DownloadError downloadError = new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH, sizeMismatchMessage);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -219,7 +219,7 @@ class DownloadBatch {
             downloadBatchStatus.updateDownloaded(currentBytesDownloaded);
 
             if (currentBytesDownloaded > totalBatchSizeBytes) {
-                DownloadError downloadError = new DownloadError(DownloadError.Error.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH);
+                DownloadError downloadError = new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
             }
 
@@ -256,8 +256,8 @@ class DownloadBatch {
         if (status == WAITING_FOR_NETWORK) {
             return true;
         } else if (status == ERROR) {
-            DownloadError.Error downloadErrorType = downloadBatchStatus.getDownloadErrorType();
-            if (downloadErrorType == DownloadError.Error.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE) {
+            DownloadError.Type downloadErrorType = downloadBatchStatus.getDownloadErrorType();
+            if (downloadErrorType == DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE) {
                 return true;
             }
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -219,13 +219,7 @@ class DownloadBatch {
             downloadBatchStatus.updateDownloaded(currentBytesDownloaded);
 
             if (currentBytesDownloaded > totalBatchSizeBytes) {
-                String sizeMismatchMessage = String.format(
-                        "Download File with ID: %s has a greater current size: %s than the total size: ",
-                        downloadFileStatus.downloadBatchId().rawId(),
-                        downloadFileStatus.bytesDownloaded(),
-                        downloadFileStatus.totalBytes()
-                );
-                DownloadError downloadError = new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH, sizeMismatchMessage);
+                DownloadError downloadError = DownloadErrorFactory.createSizeMismatchError(downloadFileStatus);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -218,6 +218,11 @@ class DownloadBatch {
             long currentBytesDownloaded = getBytesDownloadedFrom(fileBytesDownloadedMap);
             downloadBatchStatus.updateDownloaded(currentBytesDownloaded);
 
+            if (currentBytesDownloaded > totalBatchSizeBytes) {
+                DownloadError downloadError = new DownloadError(DownloadError.Error.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH);
+                downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
+            }
+
             if (currentBytesDownloaded == totalBatchSizeBytes && totalBatchSizeBytes != ZERO_BYTES) {
                 downloadBatchStatus.markAsDownloaded(downloadsBatchPersistence);
             }
@@ -372,9 +377,9 @@ class DownloadBatch {
     void updateTotalSize() {
         if (totalBatchSizeBytes == 0) {
             totalBatchSizeBytes = DownloadBatchSizeCalculator.getTotalSize(
-                downloadFiles,
-                downloadBatchStatus.status(),
-                downloadBatchStatus.getDownloadBatchId()
+                    downloadFiles,
+                    downloadBatchStatus.status(),
+                    downloadBatchStatus.getDownloadBatchId()
             );
         }
         downloadBatchStatus.updateTotalSize(totalBatchSizeBytes);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -51,7 +51,7 @@ public interface DownloadBatchStatus {
      * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
      */
     @Nullable
-    DownloadError.Error getDownloadErrorType();
+    DownloadError.Type getDownloadErrorType();
 
     boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -2,7 +2,7 @@ package com.novoda.downloadmanager;
 
 public class DownloadError {
 
-    public enum Error {
+    public enum Type {
         FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH,
         FILE_TOTAL_SIZE_REQUEST_FAILED,
         FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE,
@@ -12,13 +12,13 @@ public class DownloadError {
         UNKNOWN
     }
 
-    private final Error error;
+    private final Type type;
 
-    DownloadError(Error error) {
-        this.error = error;
+    DownloadError(Type type) {
+        this.type = type;
     }
 
-    Error error() {
-        return error;
+    Type error() {
+        return type;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -13,12 +13,23 @@ public class DownloadError {
     }
 
     private final Type type;
+    private final String message;
+
+    DownloadError(Type type, String message) {
+        this.type = type;
+        this.message = message;
+    }
 
     DownloadError(Type type) {
         this.type = type;
+        this.message = "";
     }
 
     Type error() {
         return type;
+    }
+
+    public String message() {
+        return message;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 public class DownloadError {
 
     public enum Error {
+        FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH,
         FILE_TOTAL_SIZE_REQUEST_FAILED,
         FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE,
         FILE_CANNOT_BE_WRITTEN,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -25,7 +25,7 @@ public class DownloadError {
         this.message = "";
     }
 
-    Type error() {
+    Type type() {
         return type;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -1,0 +1,19 @@
+package com.novoda.downloadmanager;
+
+class DownloadErrorFactory {
+
+    private DownloadErrorFactory() {
+        // Uses static factory methods.
+    }
+
+    static DownloadError createSizeMismatchError(DownloadFileStatus downloadFileStatus) {
+        String sizeMismatchMessage = String.format(
+                "Download File with ID: %s has a greater current size: %s than the total size: ",
+                downloadFileStatus.downloadBatchId().rawId(),
+                downloadFileStatus.bytesDownloaded(),
+                downloadFileStatus.totalBytes()
+        );
+        return new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH, sizeMismatchMessage);
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -51,8 +51,8 @@ final class DownloadErrorFactory {
         return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }
 
-    static DownloadError createUnknownError() {
-        String unknownErrorMessage = "Unknown download error, additional information unavailable.";
+    static DownloadError createUnknownErrorFor(FilePersistenceResult status) {
+        String unknownErrorMessage = "Unhandled error for FilePersistenceResult: " + status.name();
         return new DownloadError(DownloadError.Type.UNKNOWN, unknownErrorMessage);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -7,54 +7,47 @@ final class DownloadErrorFactory {
     }
 
     static DownloadError createSizeMismatchError(DownloadFileStatus downloadFileStatus) {
-        String sizeMismatchMessage = String.format(
-                "Download File with ID: %s has a greater current size: %s than the total size: %s",
-                downloadFileStatus.downloadBatchId().rawId(),
-                downloadFileStatus.bytesDownloaded(),
-                downloadFileStatus.totalBytes()
-        );
+        String sizeMismatchMessage = "Download File with ID: "
+                + downloadFileStatus.downloadBatchId().rawId()
+                + " has a greater current size: "
+                + downloadFileStatus.bytesDownloaded()
+                + " than the total size: "
+                + downloadFileStatus.totalBytes();
+
         return new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH, sizeMismatchMessage);
     }
 
     static DownloadError createTotalSizeRequestFailedError(DownloadFileId downloadFileId, String url) {
-        String totalSizeRequestFailedMessage = String.format(
-                "Total size request failed for File with ID: %s and Request: %s",
-                downloadFileId.rawId(),
-                url
-        );
+        String totalSizeRequestFailedMessage = "Total size request failed for File with ID: "
+                + downloadFileId.rawId()
+                + " and Request: "
+                + url;
+
         return new DownloadError(DownloadError.Type.FILE_TOTAL_SIZE_REQUEST_FAILED, totalSizeRequestFailedMessage);
     }
 
     static DownloadError createInsufficientFreeSpaceError(DownloadFileStatus downloadFileStatus) {
-        String insufficientFreeSpaceMessage = String.format(
-                "Insufficient free space to create file with ID: %s Bytes Required: %s",
-                downloadFileStatus.downloadFileId().rawId(),
-                downloadFileStatus.totalBytes()
-        );
+        String insufficientFreeSpaceMessage =
+                "Insufficient free space to create file with ID: "
+                        + downloadFileStatus.downloadFileId().rawId()
+                        + " Bytes Required: "
+                        + downloadFileStatus.totalBytes();
+
         return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE, insufficientFreeSpaceMessage);
     }
 
     static DownloadError createCannotWriteToFileError(DownloadFileStatus downloadFileStatus) {
-        String cannotWriteToFileMessage = String.format(
-                "Cannot write to file with Id: %s",
-                downloadFileStatus.downloadFileId().rawId()
-        );
+        String cannotWriteToFileMessage = "Cannot write to file with Id: " + downloadFileStatus.downloadFileId().rawId();
         return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_WRITTEN, cannotWriteToFileMessage);
     }
 
     static DownloadError createStorageNotAvailableError(FilePersistence filePersistence) {
-        String storageUnavailableMessage = String.format(
-                "Storage with base path: %s is not available",
-                filePersistence.basePath()
-        );
+        String storageUnavailableMessage = "Storage with base path: " + filePersistence.basePath() + " is not available";
         return new DownloadError(DownloadError.Type.STORAGE_UNAVAILABLE, storageUnavailableMessage);
     }
 
     static DownloadError createNetworkError(String networkErrorCause) {
-        String networkErrorMessage = String.format(
-                "Network error, cannot download file. Cause: %s",
-                networkErrorCause
-        );
+        String networkErrorMessage = "Network error, cannot download file. Cause: " + networkErrorCause;
         return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }
 
@@ -62,5 +55,4 @@ final class DownloadErrorFactory {
         String unknownErrorMessage = "Unknown download error, additional information unavailable.";
         return new DownloadError(DownloadError.Type.UNKNOWN, unknownErrorMessage);
     }
-
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-class DownloadErrorFactory {
+final class DownloadErrorFactory {
 
     private DownloadErrorFactory() {
         // Uses static factory methods.

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -2,18 +2,67 @@ package com.novoda.downloadmanager;
 
 class DownloadErrorFactory {
 
+    private static final String NO_MESSAGE = "";
+
     private DownloadErrorFactory() {
         // Uses static factory methods.
     }
 
     static DownloadError createSizeMismatchError(DownloadFileStatus downloadFileStatus) {
         String sizeMismatchMessage = String.format(
-                "Download File with ID: %s has a greater current size: %s than the total size: ",
+                "Download File with ID: %s has a greater current size: %s than the total size: %s",
                 downloadFileStatus.downloadBatchId().rawId(),
                 downloadFileStatus.bytesDownloaded(),
                 downloadFileStatus.totalBytes()
         );
         return new DownloadError(DownloadError.Type.FILE_CURRENT_AND_TOTAL_SIZE_MISMATCH, sizeMismatchMessage);
+    }
+
+    static DownloadError createTotalSizeRequestFailedError(DownloadFileId downloadFileId, String url) {
+        String totalSizeRequestFailedMessage = String.format(
+                "Total size request failed for File with ID: %s and Request: %s",
+                downloadFileId.rawId(),
+                url
+        );
+        return new DownloadError(DownloadError.Type.FILE_TOTAL_SIZE_REQUEST_FAILED, totalSizeRequestFailedMessage);
+    }
+
+    static DownloadError createInsufficientFreeSpaceError(DownloadFileStatus downloadFileStatus) {
+        String insufficientFreeSpaceMessage = String.format(
+                "Insufficient free space to create file with ID: %s Bytes Required: %s",
+                downloadFileStatus.downloadFileId().rawId(),
+                downloadFileStatus.totalBytes()
+        );
+        return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE, insufficientFreeSpaceMessage);
+    }
+
+    static DownloadError createCannotWriteToFileError(DownloadFileStatus downloadFileStatus) {
+        String cannotWriteToFileMessage = String.format(
+                "Cannot write to file with Id: %s",
+                downloadFileStatus.downloadFileId().rawId()
+        );
+        return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_WRITTEN, cannotWriteToFileMessage);
+    }
+
+    static DownloadError createStorageNotAvailableError(FilePersistence filePersistence) {
+        String storageUnavailableMessage = String.format(
+                "Storage with base path: %s is not available",
+                filePersistence.basePath()
+        );
+        return new DownloadError(DownloadError.Type.STORAGE_UNAVAILABLE, storageUnavailableMessage);
+    }
+
+    static DownloadError createNetworkError(String networkErrorCause) {
+        String networkErrorMessage = String.format(
+                "Network error, cannot download file. Cause: %s",
+                networkErrorCause
+        );
+        return new DownloadError(DownloadError.Type.STORAGE_UNAVAILABLE, networkErrorMessage);
+    }
+
+    static DownloadError createUnknownError() {
+        String unknownErrorMessage = "Unknown download error, additional information unavailable.";
+        return new DownloadError(DownloadError.Type.UNKNOWN, unknownErrorMessage);
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -55,7 +55,7 @@ class DownloadErrorFactory {
                 "Network error, cannot download file. Cause: %s",
                 networkErrorCause
         );
-        return new DownloadError(DownloadError.Type.STORAGE_UNAVAILABLE, networkErrorMessage);
+        return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }
 
     static DownloadError createUnknownError() {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 class DownloadErrorFactory {
 
-    private static final String NO_MESSAGE = "";
-
     private DownloadErrorFactory() {
         // Uses static factory methods.
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -2,8 +2,6 @@ package com.novoda.downloadmanager;
 
 import android.support.annotation.WorkerThread;
 
-import com.novoda.downloadmanager.DownloadError.Type;
-
 // This model knows how to interact with low level components.
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity"})
 class DownloadFile {
@@ -52,7 +50,8 @@ class DownloadFile {
         fileSize = requestTotalFileSizeIfNecessary(fileSize);
 
         if (fileSize.isTotalSizeUnknown()) {
-            updateAndFeedbackWithStatus(Type.FILE_TOTAL_SIZE_REQUEST_FAILED, callback);
+            DownloadError downloadError = DownloadErrorFactory.createTotalSizeRequestFailedError(downloadFileId, url);
+            updateAndFeedbackWithStatus(downloadError, callback);
             return;
         }
 
@@ -76,8 +75,8 @@ class DownloadFile {
 
         FilePersistenceResult result = filePersistence.create(filePath, fileSize);
         if (result != FilePersistenceResult.SUCCESS) {
-            Type type = convertError(result);
-            updateAndFeedbackWithStatus(type, callback);
+            DownloadError downloadError = convertError(result);
+            updateAndFeedbackWithStatus(downloadError, callback);
             return;
         }
 
@@ -86,7 +85,8 @@ class DownloadFile {
             public void onBytesRead(byte[] buffer, int bytesRead) {
                 boolean success = filePersistence.write(buffer, 0, bytesRead);
                 if (!success) {
-                    updateAndFeedbackWithStatus(Type.FILE_CANNOT_BE_WRITTEN, callback);
+                    DownloadError downloadError = DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
+                    updateAndFeedbackWithStatus(downloadError, callback);
                 }
 
                 if (downloadFileStatus.isMarkedAsDownloading()) {
@@ -97,8 +97,9 @@ class DownloadFile {
             }
 
             @Override
-            public void onError() {
-                updateAndFeedbackWithStatus(Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, callback);
+            public void onError(String cause) {
+                DownloadError downloadError = DownloadErrorFactory.createNetworkError(cause);
+                updateAndFeedbackWithStatus(downloadError, callback);
             }
 
             @Override
@@ -114,26 +115,22 @@ class DownloadFile {
         });
     }
 
-    private Type convertError(FilePersistenceResult status) {
+    private DownloadError convertError(FilePersistenceResult status) {
         switch (status) {
-            case SUCCESS:
-                Logger.e("Cannot convert success status to any DownloadError type");
-                break;
             case ERROR_UNKNOWN_TOTAL_FILE_SIZE:
-                return Type.FILE_TOTAL_SIZE_REQUEST_FAILED;
+                return DownloadErrorFactory.createTotalSizeRequestFailedError(downloadFileId, url);
             case ERROR_INSUFFICIENT_SPACE:
-                return Type.FILE_CANNOT_BE_CREATED_LOCALLY_INSUFFICIENT_FREE_SPACE;
+                return DownloadErrorFactory.createInsufficientFreeSpaceError(downloadFileStatus);
             case ERROR_EXTERNAL_STORAGE_NON_WRITABLE:
-                return Type.STORAGE_UNAVAILABLE;
+                return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
             case ERROR_OPENING_FILE:
-                return Type.FILE_CANNOT_BE_WRITTEN;
+                return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
             default:
                 Logger.e("Status " + status + " missing to be processed");
                 break;
 
         }
-
-        return Type.UNKNOWN;
+        return DownloadErrorFactory.createUnknownError();
     }
 
     private InternalFileSize requestTotalFileSizeIfNecessary(InternalFileSize fileSize) {
@@ -149,8 +146,8 @@ class DownloadFile {
         return updatedFileSize;
     }
 
-    private void updateAndFeedbackWithStatus(Type type, Callback callback) {
-        downloadFileStatus.markAsError(type);
+    private void updateAndFeedbackWithStatus(DownloadError downloadError, Callback callback) {
+        downloadFileStatus.markAsError(downloadError);
         callback.onUpdate(downloadFileStatus);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -127,7 +127,7 @@ class DownloadFile {
                 return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
             default:
                 Logger.e("Status " + status + " missing to be processed");
-                return DownloadErrorFactory.createUnknownError();
+                return DownloadErrorFactory.createUnknownErrorFor(status);
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -122,7 +122,7 @@ class DownloadFile {
             case ERROR_INSUFFICIENT_SPACE:
                 return DownloadErrorFactory.createInsufficientFreeSpaceError(downloadFileStatus);
             case ERROR_EXTERNAL_STORAGE_NON_WRITABLE:
-                return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
+                return DownloadErrorFactory.createStorageNotAvailableError(filePersistence);
             case ERROR_OPENING_FILE:
                 return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
             default:

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -127,10 +127,8 @@ class DownloadFile {
                 return DownloadErrorFactory.createCannotWriteToFileError(downloadFileStatus);
             default:
                 Logger.e("Status " + status + " missing to be processed");
-                break;
-
+                return DownloadErrorFactory.createUnknownError();
         }
-        return DownloadErrorFactory.createUnknownError();
     }
 
     private InternalFileSize requestTotalFileSizeIfNecessary(InternalFileSize fileSize) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -393,7 +393,7 @@ public final class DownloadManagerBuilder {
                     .build();
         }
 
-        private Notification createErrorNotification(NotificationCompat.Builder builder, DownloadError.Error errorType) {
+        private Notification createErrorNotification(NotificationCompat.Builder builder, DownloadError.Type errorType) {
             String content = resources.getString(R.string.download_notification_content_error, errorType);
             return builder
                     .setContentText(content)

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -10,7 +10,7 @@ public interface FileDownloader {
 
         void onBytesRead(byte[] buffer, int bytesRead);
 
-        void onError();
+        void onError(String cause);
 
         void onDownloadFinished();
     }

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
@@ -20,7 +20,7 @@ interface InternalDownloadFileStatus extends DownloadFileStatus {
 
     void markAsDeleted();
 
-    void markAsError(DownloadError.Error error);
+    void markAsError(DownloadError.Type type);
 
     boolean isMarkedAsWaitingForNetwork();
 

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadFileStatus.java
@@ -20,7 +20,7 @@ interface InternalDownloadFileStatus extends DownloadFileStatus {
 
     void markAsDeleted();
 
-    void markAsError(DownloadError.Type type);
+    void markAsError(DownloadError downloadError);
 
     boolean isMarkedAsWaitingForNetwork();
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -161,7 +161,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     @Nullable
     @Override
-    public DownloadError.Error getDownloadErrorType() {
+    public DownloadError.Type getDownloadErrorType() {
         if (downloadError.isPresent()) {
             return downloadError.get().error();
         } else {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -163,7 +163,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public DownloadError.Type getDownloadErrorType() {
         if (downloadError.isPresent()) {
-            return downloadError.get().error();
+            return downloadError.get().type();
         } else {
             return null;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
@@ -98,9 +98,9 @@ class LiteDownloadFileStatus implements InternalDownloadFileStatus {
     }
 
     @Override
-    public void markAsError(DownloadError.Type type) {
+    public void markAsError(DownloadError downloadError) {
         status = Status.ERROR;
-        downloadError = Optional.of(new DownloadError(type));
+        this.downloadError = Optional.of(downloadError);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadFileStatus.java
@@ -98,9 +98,9 @@ class LiteDownloadFileStatus implements InternalDownloadFileStatus {
     }
 
     @Override
-    public void markAsError(DownloadError.Error error) {
+    public void markAsError(DownloadError.Type type) {
         status = Status.ERROR;
-        downloadError = Optional.of(new DownloadError(error));
+        downloadError = Optional.of(new DownloadError(type));
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -27,10 +27,10 @@ class NetworkFileDownloader implements FileDownloader {
         try {
             response = httpClient.execute(request);
             int responseCode = response.code();
-            processResponse(callback, response, responseCode);
+            processResponse(callback, response, responseCode, url);
         } catch (IOException e) {
             Logger.e(e, "Exception with http request");
-            callback.onError();
+            callback.onError(e.getMessage());
         } finally {
             try {
                 if (response != null) {
@@ -44,7 +44,7 @@ class NetworkFileDownloader implements FileDownloader {
         callback.onDownloadFinished();
     }
 
-    private void processResponse(Callback callback, HttpClient.NetworkResponse response, int responseCode) throws IOException {
+    private void processResponse(Callback callback, HttpClient.NetworkResponse response, int responseCode, String url) throws IOException {
         if (isValid(responseCode)) {
             byte[] buffer = new byte[BUFFER_SIZE];
             int readLast = 0;
@@ -59,7 +59,12 @@ class NetworkFileDownloader implements FileDownloader {
             }
         } else {
             Logger.e("Network response code is not ok, responseCode: " + responseCode);
-            callback.onError();
+            String networkErrorMessage = String.format(
+                    "Request: %s with response code: %s failed.",
+                    url,
+                    responseCode
+            );
+            callback.onError(networkErrorMessage);
         }
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -145,7 +145,7 @@ class InternalDownloadBatchStatusFixtures {
             @Override
             public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
                 status = Status.ERROR;
-                downloadErrorType = downloadError.get().error();
+                downloadErrorType = downloadError.get().type();
                 persistence.updateStatusAsync(downloadBatchId, status);
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -8,7 +8,7 @@ class InternalDownloadBatchStatusFixtures {
     private long bytesTotalSize = 1000;
     private DownloadBatchId downloadBatchId = DownloadBatchIdFixtures.aDownloadBatchId().build();
     private DownloadBatchStatus.Status status = DownloadBatchStatus.Status.QUEUED;
-    private DownloadError.Error downloadErrorType = null;
+    private DownloadError.Type downloadErrorType = null;
     private long downloadedDateTimeInMillis = 123456789L;
     private boolean notificationSeen = false;
 
@@ -51,7 +51,7 @@ class InternalDownloadBatchStatusFixtures {
         return this;
     }
 
-    InternalDownloadBatchStatusFixtures withDownloadErrorType(DownloadError.Error downloadErrorType) {
+    InternalDownloadBatchStatusFixtures withDownloadErrorType(DownloadError.Type downloadErrorType) {
         this.downloadErrorType = downloadErrorType;
         return this;
     }
@@ -100,7 +100,7 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
-            public DownloadError.Error getDownloadErrorType() {
+            public DownloadError.Type getDownloadErrorType() {
                 return downloadErrorType;
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
@@ -67,11 +67,7 @@ public class NetworkFileDownloaderTest {
 
         networkFileDownloader.startDownloading(ANY_RAW_URL, UNKNOWN_FILE_SIZE, callback);
 
-        String expectedCause = String.format(
-                "Request: %s with response code: %s failed.",
-                ANY_RAW_URL,
-                418
-        );
+        String expectedCause = "Request: http://example.com with response code: 418 failed.";
         verify(callback).onError(expectedCause);
     }
 


### PR DESCRIPTION
## Problem
The information provided by the `DownloadError` is a little sparse and as such it is super difficult to debug potential problems in the `download-manager`, when used in a production application. 

## Solution
Provide additional information in the form of a `message` that can be supplied to each of the `DownloadErrors` exposed in the download manager. This message should include information that can help us to diagnose issues.