### PR TITLE
Return Error not Type

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -199,7 +199,7 @@ public class MainActivity extends AppCompatActivity {
     private String getStatusMessage(DownloadBatchStatus downloadBatchStatus) {
         if (downloadBatchStatus.status() == ERROR) {
             return "\nstatus: " + downloadBatchStatus.status()
-                    + " - " + downloadBatchStatus.getDownloadErrorType();
+                    + " - " + downloadBatchStatus.downloadError().type();
         } else {
             return "\nstatus: " + downloadBatchStatus.status();
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -258,8 +258,8 @@ class DownloadBatch {
         if (status == WAITING_FOR_NETWORK) {
             return true;
         } else if (status == ERROR) {
-            DownloadError.Type downloadErrorType = downloadBatchStatus.getDownloadErrorType();
-            if (downloadErrorType == DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE) {
+            DownloadError downloadError = downloadBatchStatus.downloadError();
+            if (downloadError != null && downloadError.type() == DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE) {
                 return true;
             }
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -259,9 +259,7 @@ class DownloadBatch {
             return true;
         } else if (status == ERROR) {
             DownloadError downloadError = downloadBatchStatus.downloadError();
-            if (downloadError != null && downloadError.type() == DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE) {
-                return true;
-            }
+            return downloadError != null && downloadError.type() == DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE;
         }
         return false;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -51,7 +51,7 @@ public interface DownloadBatchStatus {
      * @return null if {@link DownloadBatchStatus#status()} is not {@link Status#ERROR}.
      */
     @Nullable
-    DownloadError.Type getDownloadErrorType();
+    DownloadError downloadError();
 
     boolean notificationSeen();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -378,7 +378,7 @@ public final class DownloadManagerBuilder {
                 case DELETING:
                     return createDeletedNotification(builder);
                 case ERROR:
-                    return createErrorNotification(builder, payload.getDownloadErrorType());
+                    return createErrorNotification(builder, payload.downloadError());
                 case DOWNLOADED:
                     return createCompletedNotification(builder);
                 default:
@@ -393,8 +393,8 @@ public final class DownloadManagerBuilder {
                     .build();
         }
 
-        private Notification createErrorNotification(NotificationCompat.Builder builder, DownloadError.Type errorType) {
-            String content = resources.getString(R.string.download_notification_content_error, errorType);
+        private Notification createErrorNotification(NotificationCompat.Builder builder, DownloadError downloadError) {
+            String content = resources.getString(R.string.download_notification_content_error, downloadError.type().name());
             return builder
                     .setContentText(content)
                     .build();

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -161,9 +161,9 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     @Nullable
     @Override
-    public DownloadError.Type getDownloadErrorType() {
+    public DownloadError downloadError() {
         if (downloadError.isPresent()) {
-            return downloadError.get().type();
+            return downloadError.get();
         } else {
             return null;
         }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -100,7 +100,7 @@ class InternalDownloadBatchStatusFixtures {
             }
 
             @Override
-            public DownloadError.Type getDownloadErrorType() {
+            public DownloadError downloadError() {
                 return downloadErrorType;
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -8,7 +8,7 @@ class InternalDownloadBatchStatusFixtures {
     private long bytesTotalSize = 1000;
     private DownloadBatchId downloadBatchId = DownloadBatchIdFixtures.aDownloadBatchId().build();
     private DownloadBatchStatus.Status status = DownloadBatchStatus.Status.QUEUED;
-    private DownloadError.Type downloadErrorType = null;
+    private DownloadError downloadError = null;
     private long downloadedDateTimeInMillis = 123456789L;
     private boolean notificationSeen = false;
 
@@ -51,8 +51,8 @@ class InternalDownloadBatchStatusFixtures {
         return this;
     }
 
-    InternalDownloadBatchStatusFixtures withDownloadErrorType(DownloadError.Type downloadErrorType) {
-        this.downloadErrorType = downloadErrorType;
+    InternalDownloadBatchStatusFixtures withDownloadError(DownloadError downloadError) {
+        this.downloadError = downloadError;
         return this;
     }
 
@@ -101,7 +101,7 @@ class InternalDownloadBatchStatusFixtures {
 
             @Override
             public DownloadError downloadError() {
-                return downloadErrorType;
+                return downloadError;
             }
 
             @Override
@@ -145,7 +145,7 @@ class InternalDownloadBatchStatusFixtures {
             @Override
             public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
                 status = Status.ERROR;
-                downloadErrorType = downloadError.get().type();
+                InternalDownloadBatchStatusFixtures.this.downloadError = downloadError.get();
                 persistence.updateStatusAsync(downloadBatchId, status);
             }
 


### PR DESCRIPTION
## Problem
We are returning `DownloadError.Type` from `DownloadBatchStatus` instead of `DownloadError` 😬 

## Solution 
Update the interface and all references to use `DownloadError` in place of type.