### PR TITLE
Check for the type of connected service

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -239,6 +239,9 @@ public final class DownloadManagerBuilder {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder service) {
+                if (!(service instanceof LiteDownloadService.DownloadServiceBinder)) {
+                    return;
+                }
                 LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
                 downloadService = binder.getService();
                 downloadManager.submitAllStoredDownloads(() -> {


### PR DESCRIPTION
### Problem

When using Leakcanary in a client app, it happens that there is a crash when the Leakcanary connects, similar to what described in https://github.com/square/leakcanary/issues/91

### Solution

Check for the type of connected service in the `onServiceConnected` callback.