### PR TITLE
Migration binder casting

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -57,7 +57,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'download-manager'
-    publishVersion = 'SNAPSHOT-2.0.44'
+    publishVersion = 'SNAPSHOT-2.0.45'
     desc = 'Download Manager capable of batching, auto-resume, internal and external storage and highly customizable.'
     website = 'https://github.com/novoda/download-manager'
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -239,20 +239,19 @@ public final class DownloadManagerBuilder {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder service) {
-                if (!(service instanceof LiteDownloadService.DownloadServiceBinder)) {
-                    return;
-                }
-                LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
-                downloadService = binder.getService();
-                downloadManager.submitAllStoredDownloads(() -> {
-                    downloadManager.initialise(downloadService);
+                if (service instanceof LiteDownloadService.DownloadServiceBinder) {
+                    LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
+                    downloadService = binder.getService();
+                    downloadManager.submitAllStoredDownloads(() -> {
+                        downloadManager.initialise(downloadService);
 
-                    if (allowNetworkRecovery) {
-                        DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, downloadManager, connectionTypeAllowed);
-                    } else {
-                        DownloadsNetworkRecoveryCreator.createDisabled();
-                    }
-                });
+                        if (allowNetworkRecovery) {
+                            DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, downloadManager, connectionTypeAllowed);
+                        } else {
+                            DownloadsNetworkRecoveryCreator.createDisabled();
+                        }
+                    });
+                }
             }
 
             @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -93,6 +93,9 @@ public final class DownloadMigratorBuilder {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder binder) {
+                if (!(binder instanceof LiteDownloadMigrationService.MigrationDownloadServiceBinder)) {
+                    return;
+                }
                 DownloadMigrationService migrationService = ((LiteDownloadMigrationService.MigrationDownloadServiceBinder) binder).getService();
                 downloadMigrator.initialise(migrationService);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadMigratorBuilder.java
@@ -93,11 +93,10 @@ public final class DownloadMigratorBuilder {
         ServiceConnection serviceConnection = new ServiceConnection() {
             @Override
             public void onServiceConnected(ComponentName name, IBinder binder) {
-                if (!(binder instanceof LiteDownloadMigrationService.MigrationDownloadServiceBinder)) {
-                    return;
+                if (binder instanceof LiteDownloadMigrationService.MigrationDownloadServiceBinder) {
+                    DownloadMigrationService migrationService = ((LiteDownloadMigrationService.MigrationDownloadServiceBinder) binder).getService();
+                    downloadMigrator.initialise(migrationService);
                 }
-                DownloadMigrationService migrationService = ((LiteDownloadMigrationService.MigrationDownloadServiceBinder) binder).getService();
-                downloadMigrator.initialise(migrationService);
             }
 
             @Override


### PR DESCRIPTION
## Problem
We introduced a guard against casting an invalid binder in #398 but we forgot the migration one 😱 

## Solution
Add guard against an invalid binder in the migration service connection. 