### PR TITLE
V2 alternative migration in memory map

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/CompletedDownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CompletedDownloadBatch.java
@@ -1,5 +1,6 @@
 package com.novoda.downloadmanager;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CompletedDownloadBatch {
@@ -33,6 +34,22 @@ public class CompletedDownloadBatch {
 
     public List<CompletedDownloadFile> completedDownloadFiles() {
         return completedDownloadFiles;
+    }
+
+    public Batch asBatch() {
+        return new Batch(
+                downloadBatchId,
+                downloadBatchTitle.asString(),
+                asBatchFiles()
+        );
+    }
+
+    private List<BatchFile> asBatchFiles() {
+        List<BatchFile> batchFiles = new ArrayList<>(completedDownloadFiles.size());
+        for (CompletedDownloadFile completedDownloadFile : completedDownloadFiles) {
+            batchFiles.add(completedDownloadFile.asBatchFile());
+        }
+        return batchFiles;
     }
 
     @Override
@@ -115,6 +132,15 @@ public class CompletedDownloadBatch {
 
         public String originalNetworkAddress() {
             return originalNetworkAddress;
+        }
+
+        public BatchFile asBatchFile() {
+            DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(fileId);
+            return new BatchFile(
+                    originalNetworkAddress,
+                    Optional.of(downloadFileId),
+                    newFileLocation
+            );
         }
 
         @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -224,14 +224,16 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     @Override
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
-        DownloadBatchId downloadBatchId = completedDownloadBatch.downloadBatchId();
-        DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
-        if (downloadBatch != null) {
-            throw new IllegalStateException("CompletedDownloadBatch with id: " + downloadBatchId + " already exists.");
+    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException {
+        if (alreadyContainsBatch(completedDownloadBatch)) {
+            throw new IllegalArgumentException("CompletedDownloadBatch with id: " + completedDownloadBatch.downloadBatchId() + " already exists.");
         }
 
-        downloader.addCompletedBatch(completedDownloadBatch);
+        downloader.addCompletedBatch(completedDownloadBatch, downloadBatchMap);
+    }
+
+    private boolean alreadyContainsBatch(CompletedDownloadBatch completedDownloadBatch) {
+        return downloadBatchMap.get(completedDownloadBatch.downloadBatchId()) != null;
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -225,6 +225,12 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
+        DownloadBatchId downloadBatchId = completedDownloadBatch.downloadBatchId();
+        DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
+        if (downloadBatch != null) {
+            throw new IllegalStateException("CompletedDownloadBatch with id: " + downloadBatchId + " already exists.");
+        }
+
         downloader.addCompletedBatch(completedDownloadBatch);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -233,7 +233,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     private boolean alreadyContainsBatch(CompletedDownloadBatch completedDownloadBatch) {
-        return downloadBatchMap.get(completedDownloadBatch.downloadBatchId()) != null;
+        return downloadBatchMap.containsKey(completedDownloadBatch.downloadBatchId());
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
@@ -37,5 +37,5 @@ public interface LiteDownloadManagerCommands {
 
     File getDownloadsDir();
 
-    void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch);
+    void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -124,7 +124,16 @@ class LiteDownloadManagerDownloader {
         notificationDispatcher.setDownloadService(downloadService);
     }
 
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
+    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
+        DownloadBatch downloadBatch = DownloadBatchFactory.newInstance(
+                completedDownloadBatch.asBatch(),
+                fileOperations,
+                downloadsBatchPersistence,
+                downloadsFilePersistence,
+                callbackThrottleCreator.create(),
+                connectionChecker
+        );
+        downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         downloadsBatchPersistence.persistCompletedBatch(completedDownloadBatch);
     }
 }


### PR DESCRIPTION
## Problem 
We added a completed batch to the download manager but a client cannot interact with these 😬 because they have not been added to the internal map on the download manager. 

In #395 "Alternative Migration Complete" we wanted to add a `throws` when attempting to add a duplicated completed batch. To do this we need to be able to add the completed batch to the internal map.

## Solution
Add to the internal map and add a throws on the download manager when attempting to add a duplicated completed download batch. 

## QUESTION❓❓ 
This `DownloadManager.addCompletedBatch` feels like it should be a synchronous process that the client should put inside their own threading mechanism. 

1. The `asBatch` could take sometime and ATM would occur on whatever thread  they call it on 😬 
2. It might be useful to return a status and have the client do something based on that status, like how we handle the other parts of the code. 