### PR TITLE
V2 alternative migration (worker thread)

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/migration/MigrationJob.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/migration/MigrationJob.java
@@ -61,10 +61,10 @@ public class MigrationJob implements Runnable {
 
         onUpdate("Migrating Complete Downloads");
         for (CompletedDownloadBatch completeDownloadBatch : completeDownloadBatches) {
-            downloadManager.addCompletedBatch(completeDownloadBatch);
-
-            for (CompletedDownloadBatch.CompletedDownloadFile completedDownloadFile : completeDownloadBatch.completedDownloadFiles()) {
-                deleteVersionOneFile(completedDownloadFile.originalFileLocation());
+            if (downloadManager.addCompletedBatch(completeDownloadBatch)) {
+                for (CompletedDownloadBatch.CompletedDownloadFile completedDownloadFile : completeDownloadBatch.completedDownloadFiles()) {
+                    deleteVersionOneFile(completedDownloadFile.originalFileLocation());
+                }
             }
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/CompletedDownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CompletedDownloadBatch.java
@@ -1,5 +1,6 @@
 package com.novoda.downloadmanager;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class CompletedDownloadBatch {
@@ -33,6 +34,22 @@ public class CompletedDownloadBatch {
 
     public List<CompletedDownloadFile> completedDownloadFiles() {
         return completedDownloadFiles;
+    }
+
+    public Batch asBatch() {
+        return new Batch(
+                downloadBatchId,
+                downloadBatchTitle.asString(),
+                asBatchFiles()
+        );
+    }
+
+    private List<BatchFile> asBatchFiles() {
+        List<BatchFile> batchFiles = new ArrayList<>(completedDownloadFiles.size());
+        for (CompletedDownloadFile completedDownloadFile : completedDownloadFiles) {
+            batchFiles.add(completedDownloadFile.asBatchFile());
+        }
+        return batchFiles;
     }
 
     @Override
@@ -115,6 +132,15 @@ public class CompletedDownloadBatch {
 
         public String originalNetworkAddress() {
             return originalNetworkAddress;
+        }
+
+        public BatchFile asBatchFile() {
+            DownloadFileId downloadFileId = DownloadFileIdCreator.createFrom(fileId);
+            return new BatchFile(
+                    originalNetworkAddress,
+                    Optional.of(downloadFileId),
+                    newFileLocation
+            );
         }
 
         @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -223,13 +223,15 @@ class DownloadManager implements LiteDownloadManagerCommands {
         return new File(filePath.path());
     }
 
+    @WorkerThread
     @Override
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException {
+    public boolean addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException {
         if (alreadyContainsBatch(completedDownloadBatch)) {
-            throw new IllegalArgumentException("CompletedDownloadBatch with id: " + completedDownloadBatch.downloadBatchId() + " already exists.");
+            Logger.w("CompletedDownloadBatch with id: " + completedDownloadBatch.downloadBatchId() + " already exists.");
+            return false;
         }
 
-        downloader.addCompletedBatch(completedDownloadBatch, downloadBatchMap);
+        return downloader.addCompletedBatch(completedDownloadBatch, downloadBatchMap);
     }
 
     private boolean alreadyContainsBatch(CompletedDownloadBatch completedDownloadBatch) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -224,14 +224,16 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     @Override
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
-        DownloadBatchId downloadBatchId = completedDownloadBatch.downloadBatchId();
-        DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
-        if (downloadBatch != null) {
-            throw new IllegalStateException("CompletedDownloadBatch with id: " + downloadBatchId + " already exists.");
+    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException {
+        if (alreadyContainsBatch(completedDownloadBatch)) {
+            throw new IllegalArgumentException("CompletedDownloadBatch with id: " + completedDownloadBatch.downloadBatchId() + " already exists.");
         }
 
-        downloader.addCompletedBatch(completedDownloadBatch);
+        downloader.addCompletedBatch(completedDownloadBatch, downloadBatchMap);
+    }
+
+    private boolean alreadyContainsBatch(CompletedDownloadBatch completedDownloadBatch) {
+        return downloadBatchMap.get(completedDownloadBatch.downloadBatchId()) != null;
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -225,6 +225,12 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     @Override
     public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
+        DownloadBatchId downloadBatchId = completedDownloadBatch.downloadBatchId();
+        DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
+        if (downloadBatch != null) {
+            throw new IllegalStateException("CompletedDownloadBatch with id: " + downloadBatchId + " already exists.");
+        }
+
         downloader.addCompletedBatch(completedDownloadBatch);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -233,7 +233,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     }
 
     private boolean alreadyContainsBatch(CompletedDownloadBatch completedDownloadBatch) {
-        return downloadBatchMap.get(completedDownloadBatch.downloadBatchId()) != null;
+        return downloadBatchMap.containsKey(completedDownloadBatch.downloadBatchId());
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchStatusPersistence.java
@@ -1,8 +1,11 @@
 package com.novoda.downloadmanager;
 
+import android.support.annotation.WorkerThread;
+
 interface DownloadsBatchStatusPersistence {
 
     void updateStatusAsync(DownloadBatchId downloadBatchId, DownloadBatchStatus.Status status);
 
-    void persistCompletedBatch(CompletedDownloadBatch completedDownloadBatch);
+    @WorkerThread
+    boolean persistCompletedBatch(CompletedDownloadBatch completedDownloadBatch);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
@@ -37,5 +37,6 @@ public interface LiteDownloadManagerCommands {
 
     File getDownloadsDir();
 
-    void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException;
+    @WorkerThread
+    boolean addCompletedBatch(CompletedDownloadBatch completedDownloadBatch);
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerCommands.java
@@ -37,5 +37,5 @@ public interface LiteDownloadManagerCommands {
 
     File getDownloadsDir();
 
-    void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch);
+    void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) throws IllegalArgumentException;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -124,7 +124,7 @@ class LiteDownloadManagerDownloader {
         notificationDispatcher.setDownloadService(downloadService);
     }
 
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
+    public boolean addCompletedBatch(CompletedDownloadBatch completedDownloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         DownloadBatch downloadBatch = DownloadBatchFactory.newInstance(
                 completedDownloadBatch.asBatch(),
                 fileOperations,
@@ -134,6 +134,6 @@ class LiteDownloadManagerDownloader {
                 connectionChecker
         );
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
-        downloadsBatchPersistence.persistCompletedBatch(completedDownloadBatch);
+        return downloadsBatchPersistence.persistCompletedBatch(completedDownloadBatch);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -124,7 +124,16 @@ class LiteDownloadManagerDownloader {
         notificationDispatcher.setDownloadService(downloadService);
     }
 
-    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch) {
+    public void addCompletedBatch(CompletedDownloadBatch completedDownloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
+        DownloadBatch downloadBatch = DownloadBatchFactory.newInstance(
+                completedDownloadBatch.asBatch(),
+                fileOperations,
+                downloadsBatchPersistence,
+                downloadsFilePersistence,
+                callbackThrottleCreator.create(),
+                connectionChecker
+        );
+        downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         downloadsBatchPersistence.persistCompletedBatch(completedDownloadBatch);
     }
 }


### PR DESCRIPTION
## Problem
After completing the work on adding the completed download batch to the download manager and opening #402 I think we should be using a `WorkerThread` and returning a `boolean` to represent success. My reasoning was talked about in the other PR, here is a transcript.

>This implementation suffers in another regard. The client doesn't know if something was successfully added, it's fire and forget. Currently they would need to wait for it to complete, which is a guess because it executes against an executor. Then check each completed download manually to see if it was indeed added to the download manager 😬 This means if they wanted to delete from the old DB after adding the item they can't 😬 


## Solution
Add a `WorkerThread` implementation of the `addCompletedBatch`. 