### PR TITLE
storage requirement

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFilePersistence.java
@@ -9,7 +9,7 @@ import com.novoda.downloadmanager.FilePersistence;
 import com.novoda.downloadmanager.FilePersistenceResult;
 import com.novoda.downloadmanager.FilePersistenceType;
 import com.novoda.downloadmanager.FileSize;
-import com.novoda.downloadmanager.StorageRequirementsRule;
+import com.novoda.downloadmanager.StorageRequirementRule;
 
 // Must be public
 public class CustomFilePersistence implements FilePersistence {
@@ -19,7 +19,7 @@ public class CustomFilePersistence implements FilePersistence {
     private int currentSize;
 
     @Override
-    public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
+    public void initialiseWith(Context context, StorageRequirementRule storageRequirementRule) {
         Log.v(TAG, "initialise");
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -5,12 +5,13 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.facebook.stetho.Stetho;
+import com.novoda.downloadmanager.ByteBasedStorageRequirementRule;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
-import com.novoda.downloadmanager.PercentageBasedStorageRequirementRule;
 
 public class DemoApplication extends Application {
 
+    private static final int TWO_HUNDRED_MB_IN_BYTES = 200000000;
     private volatile LiteDownloadManagerCommands liteDownloadManagerCommands;
 
     @Override
@@ -26,7 +27,7 @@ public class DemoApplication extends Application {
         liteDownloadManagerCommands = DownloadManagerBuilder
                 .newInstance(this, handler, R.mipmap.ic_launcher_round)
                 .withLogHandle(new DemoLogHandle())
-                .withStorageRequirementRules(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(0.2f))
+                .withStorageRequirementRules(ByteBasedStorageRequirementRule.withBytesOfStorageRemaining(TWO_HUNDRED_MB_IN_BYTES))
                 .build();
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -7,6 +7,7 @@ import android.os.Looper;
 import com.facebook.stetho.Stetho;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
+import com.novoda.downloadmanager.PercentageBasedStorageRequirementRule;
 
 public class DemoApplication extends Application {
 
@@ -25,6 +26,7 @@ public class DemoApplication extends Application {
         liteDownloadManagerCommands = DownloadManagerBuilder
                 .newInstance(this, handler, R.mipmap.ic_launcher_round)
                 .withLogHandle(new DemoLogHandle())
+                .withStorageRequirementRules(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(0.2f))
                 .build();
     }
 

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -11,7 +11,7 @@ import com.novoda.downloadmanager.StorageRequirementRuleFactory;
 
 public class DemoApplication extends Application {
 
-    private static final int TWO_HUNDRED_MB_IN_BYTES = 200000000;
+    private static final int TWO_HUNDRED_MB_IN_BYTES = 209715200;
     private volatile LiteDownloadManagerCommands liteDownloadManagerCommands;
 
     @Override

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -5,9 +5,9 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.facebook.stetho.Stetho;
-import com.novoda.downloadmanager.ByteBasedStorageRequirementRule;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
 import com.novoda.downloadmanager.LiteDownloadManagerCommands;
+import com.novoda.downloadmanager.StorageRequirementRuleFactory;
 
 public class DemoApplication extends Application {
 
@@ -27,7 +27,7 @@ public class DemoApplication extends Application {
         liteDownloadManagerCommands = DownloadManagerBuilder
                 .newInstance(this, handler, R.mipmap.ic_launcher_round)
                 .withLogHandle(new DemoLogHandle())
-                .withStorageRequirementRules(ByteBasedStorageRequirementRule.withBytesOfStorageRemaining(TWO_HUNDRED_MB_IN_BYTES))
+                .withStorageRequirementRules(StorageRequirementRuleFactory.createByteBasedRule(TWO_HUNDRED_MB_IN_BYTES))
                 .build();
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
@@ -2,14 +2,10 @@ package com.novoda.downloadmanager;
 
 import java.io.File;
 
-public final class ByteBasedStorageRequirementRule implements StorageRequirementRule {
+class ByteBasedStorageRequirementRule implements StorageRequirementRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final long bytesRemainingAfterDownload;
-
-    public static ByteBasedStorageRequirementRule withBytesOfStorageRemaining(long bytesRemainingAfterDownload) {
-        return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
-    }
 
     ByteBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
         this.storageCapacityReader = storageCapacityReader;

--- a/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
@@ -1,0 +1,35 @@
+package com.novoda.downloadmanager;
+
+import android.os.StatFs;
+
+import java.io.File;
+
+public final class ByteBasedStorageRequirementRule implements StorageRequirementRule {
+
+    private final StorageCapacityReader storageCapacityReader;
+    private final long bytesRemainingAfterDownload;
+
+    public static ByteBasedStorageRequirementRule withPercentageOfStorageRemaining(long bytesRemainingAfterDownload) {
+        return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
+    }
+
+    private ByteBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
+        this.storageCapacityReader = storageCapacityReader;
+        this.bytesRemainingAfterDownload = bytesRemainingAfterDownload;
+    }
+
+    @Override
+    public boolean hasViolatedRule(File storageDirectory,
+                                   FileSize downloadFileSize) {
+        StatFs statFs = new StatFs(storageDirectory.getPath());
+        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(statFs);
+        long usableStorageInBytes = storageDirectory.getUsableSpace();
+        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
+
+        Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
+        Logger.v("Usable storage in bytes: ", usableStorageInBytes);
+        Logger.v("Minimum required storage in bytes: ", bytesRemainingAfterDownload);
+        return remainingStorageAfterDownloadInBytes < bytesRemainingAfterDownload;
+    }
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
@@ -11,7 +11,7 @@ public final class ByteBasedStorageRequirementRule implements StorageRequirement
         return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
     }
 
-    private ByteBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
+    ByteBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
         this.storageCapacityReader = storageCapacityReader;
         this.bytesRemainingAfterDownload = bytesRemainingAfterDownload;
     }
@@ -21,7 +21,7 @@ public final class ByteBasedStorageRequirementRule implements StorageRequirement
                                    FileSize downloadFileSize) {
         long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(storageDirectory.getPath());
         long usableStorageInBytes = storageDirectory.getUsableSpace();
-        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
+        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.remainingSize();
 
         Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
         Logger.v("Usable storage in bytes: ", usableStorageInBytes);

--- a/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRule.java
@@ -1,7 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.os.StatFs;
-
 import java.io.File;
 
 public final class ByteBasedStorageRequirementRule implements StorageRequirementRule {
@@ -9,7 +7,7 @@ public final class ByteBasedStorageRequirementRule implements StorageRequirement
     private final StorageCapacityReader storageCapacityReader;
     private final long bytesRemainingAfterDownload;
 
-    public static ByteBasedStorageRequirementRule withPercentageOfStorageRemaining(long bytesRemainingAfterDownload) {
+    public static ByteBasedStorageRequirementRule withBytesOfStorageRemaining(long bytesRemainingAfterDownload) {
         return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
     }
 
@@ -21,8 +19,7 @@ public final class ByteBasedStorageRequirementRule implements StorageRequirement
     @Override
     public boolean hasViolatedRule(File storageDirectory,
                                    FileSize downloadFileSize) {
-        StatFs statFs = new StatFs(storageDirectory.getPath());
-        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(statFs);
+        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(storageDirectory.getPath());
         long usableStorageInBytes = storageDirectory.getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -60,12 +60,12 @@ public final class DownloadManagerBuilder {
     private TimeUnit timeUnit;
     private long frequency;
     private Optional<LogHandle> logHandle;
-    private StorageRequirementRule storageRequirementRule;
+    private StorageRequirementRules storageRequirementRules;
 
     public static DownloadManagerBuilder newInstance(Context context, Handler callbackHandler, @DrawableRes final int notificationIcon) {
         Context applicationContext = context.getApplicationContext();
 
-        StorageRequirementRule storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(TEN_PERCENT);
+        StorageRequirementRules storageRequirementRule = StorageRequirementRules.newInstance();
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(applicationContext);
         FileDownloaderCreator fileDownloaderCreator = FileDownloaderCreator.newNetworkFileDownloaderCreator();
 
@@ -117,7 +117,7 @@ public final class DownloadManagerBuilder {
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})     // Can't group anymore these are customisable options.
     private DownloadManagerBuilder(Context applicationContext,
                                    Handler callbackHandler,
-                                   StorageRequirementRule storageRequirementRule,
+                                   StorageRequirementRules storageRequirementRules,
                                    FilePersistenceCreator filePersistenceCreator,
                                    DownloadsPersistence downloadsPersistence,
                                    FileSizeRequester fileSizeRequester,
@@ -130,7 +130,7 @@ public final class DownloadManagerBuilder {
                                    Optional<LogHandle> logHandle) {
         this.applicationContext = applicationContext;
         this.callbackHandler = callbackHandler;
-        this.storageRequirementRule = storageRequirementRule;
+        this.storageRequirementRules = storageRequirementRules;
         this.filePersistenceCreator = filePersistenceCreator;
         this.downloadsPersistence = downloadsPersistence;
         this.fileSizeRequester = fileSizeRequester;
@@ -166,7 +166,7 @@ public final class DownloadManagerBuilder {
     }
 
     public DownloadManagerBuilder withRequiredFreeStorageAfterDownload(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        this.storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining);
+        storageRequirementRules.addRule(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining));
         return this;
     }
 
@@ -262,7 +262,7 @@ public final class DownloadManagerBuilder {
 
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
-        filePersistenceCreator.withStorageRequirementsRule(storageRequirementRule);
+        filePersistenceCreator.withStorageRequirementRules(storageRequirementRules);
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloaderCreator);
         List<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -12,7 +12,6 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.support.annotation.DrawableRes;
-import android.support.annotation.FloatRange;
 import android.support.annotation.RequiresApi;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
@@ -168,11 +167,6 @@ public final class DownloadManagerBuilder {
         for (StorageRequirementRule storageRequirementRule : storageRequirementRules) {
             this.storageRequirementRules.addRule(storageRequirementRule);
         }
-        return this;
-    }
-
-    public DownloadManagerBuilder withRequiredFreeStorageAfterDownload(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        this.storageRequirementRules.addRule(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining));
         return this;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -60,12 +60,12 @@ public final class DownloadManagerBuilder {
     private TimeUnit timeUnit;
     private long frequency;
     private Optional<LogHandle> logHandle;
-    private StorageRequirementsRule storageRequirementsRule;
+    private StorageRequirementRule storageRequirementRule;
 
     public static DownloadManagerBuilder newInstance(Context context, Handler callbackHandler, @DrawableRes final int notificationIcon) {
         Context applicationContext = context.getApplicationContext();
 
-        StorageRequirementsRule storageRequirementsRule = StorageRequirementsRule.withPercentageOfStorageRemaining(TEN_PERCENT);
+        StorageRequirementRule storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(TEN_PERCENT);
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(applicationContext);
         FileDownloaderCreator fileDownloaderCreator = FileDownloaderCreator.newNetworkFileDownloaderCreator();
 
@@ -100,7 +100,7 @@ public final class DownloadManagerBuilder {
         return new DownloadManagerBuilder(
                 applicationContext,
                 callbackHandler,
-                storageRequirementsRule,
+                storageRequirementRule,
                 filePersistenceCreator,
                 downloadsPersistence,
                 fileSizeRequester,
@@ -117,7 +117,7 @@ public final class DownloadManagerBuilder {
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})     // Can't group anymore these are customisable options.
     private DownloadManagerBuilder(Context applicationContext,
                                    Handler callbackHandler,
-                                   StorageRequirementsRule storageRequirementsRule,
+                                   StorageRequirementRule storageRequirementRule,
                                    FilePersistenceCreator filePersistenceCreator,
                                    DownloadsPersistence downloadsPersistence,
                                    FileSizeRequester fileSizeRequester,
@@ -130,7 +130,7 @@ public final class DownloadManagerBuilder {
                                    Optional<LogHandle> logHandle) {
         this.applicationContext = applicationContext;
         this.callbackHandler = callbackHandler;
-        this.storageRequirementsRule = storageRequirementsRule;
+        this.storageRequirementRule = storageRequirementRule;
         this.filePersistenceCreator = filePersistenceCreator;
         this.downloadsPersistence = downloadsPersistence;
         this.fileSizeRequester = fileSizeRequester;
@@ -166,7 +166,7 @@ public final class DownloadManagerBuilder {
     }
 
     public DownloadManagerBuilder withRequiredFreeStorageAfterDownload(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        this.storageRequirementsRule = StorageRequirementsRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining);
+        this.storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining);
         return this;
     }
 
@@ -262,7 +262,7 @@ public final class DownloadManagerBuilder {
 
         applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
 
-        filePersistenceCreator.withStorageRequirementsRule(storageRequirementsRule);
+        filePersistenceCreator.withStorageRequirementsRule(storageRequirementRule);
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloaderCreator);
         List<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -40,7 +40,6 @@ public final class DownloadManagerBuilder {
     private static final Object SERVICE_LOCK = new Object();
     private static final Object CALLBACK_LOCK = new Object();
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
-    private static final float TEN_PERCENT = 0.1f;
 
     private final Context applicationContext;
     private final Handler callbackHandler;
@@ -165,8 +164,15 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
+    public DownloadManagerBuilder withStorageRequirementRules(StorageRequirementRule... storageRequirementRules) {
+        for (StorageRequirementRule storageRequirementRule : storageRequirementRules) {
+            this.storageRequirementRules.addRule(storageRequirementRule);
+        }
+        return this;
+    }
+
     public DownloadManagerBuilder withRequiredFreeStorageAfterDownload(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        storageRequirementRules.addRule(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining));
+        this.storageRequirementRules.addRule(PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(percentageOfStorageRemaining));
         return this;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ExternalFilePersistence.java
@@ -17,15 +17,15 @@ class ExternalFilePersistence implements FilePersistence {
     private static final boolean APPEND = true;
 
     private Context context;
-    private StorageRequirementsRule storageRequirementsRule;
+    private StorageRequirementRule storageRequirementRule;
 
     @Nullable
     private FileOutputStream fileOutputStream;
 
     @Override
-    public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
+    public void initialiseWith(Context context, StorageRequirementRule storageRequirementRule) {
         this.context = context.getApplicationContext();
-        this.storageRequirementsRule = storageRequirementsRule;
+        this.storageRequirementRule = storageRequirementRule;
     }
 
     @Override
@@ -45,7 +45,7 @@ class ExternalFilePersistence implements FilePersistence {
 
         File externalFileDir = getExternalFileDirWithBiggerAvailableSpace();
 
-        if (storageRequirementsRule.hasViolatedRule(externalFileDir, fileSize)) {
+        if (storageRequirementRule.hasViolatedRule(externalFileDir, fileSize)) {
             return FilePersistenceResult.ERROR_INSUFFICIENT_SPACE;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistence.java
@@ -4,7 +4,7 @@ import android.content.Context;
 
 public interface FilePersistence {
 
-    void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule);
+    void initialiseWith(Context context, StorageRequirementRule storageRequirementRule);
 
     FilePath basePath();
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
@@ -30,7 +30,7 @@ class FilePersistenceCreator {
         this.customClass = customClass;
     }
 
-    void withStorageRequirementsRule(StorageRequirementRule storageRequirementRule) {
+    void withStorageRequirementRules(StorageRequirementRule storageRequirementRule) {
         this.storageRequirementRule = storageRequirementRule;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilePersistenceCreator.java
@@ -10,7 +10,7 @@ class FilePersistenceCreator {
     @Nullable
     private final Class<? extends FilePersistence> customClass;
 
-    private StorageRequirementsRule storageRequirementsRule;
+    private StorageRequirementRule storageRequirementRule;
 
     static FilePersistenceCreator newInternalFilePersistenceCreator(Context context) {
         return new FilePersistenceCreator(context, FilePersistenceType.INTERNAL, null);
@@ -30,8 +30,8 @@ class FilePersistenceCreator {
         this.customClass = customClass;
     }
 
-    void withStorageRequirementsRule(StorageRequirementsRule storageRequirementsRule) {
-        this.storageRequirementsRule = storageRequirementsRule;
+    void withStorageRequirementsRule(StorageRequirementRule storageRequirementRule) {
+        this.storageRequirementRule = storageRequirementRule;
     }
 
     FilePersistence create() {
@@ -55,7 +55,7 @@ class FilePersistenceCreator {
                 throw new IllegalStateException("Persistence of type " + type + " is not supported");
         }
 
-        filePersistence.initialiseWith(context, storageRequirementsRule);
+        filePersistence.initialiseWith(context, storageRequirementRule);
         return filePersistence;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileSize.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileSize.java
@@ -6,6 +6,8 @@ public interface FileSize {
 
     long totalSize();
 
+    long remainingSize();
+
     boolean isTotalSizeKnown();
 
     boolean isTotalSizeUnknown();

--- a/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalFilePersistence.java
@@ -13,15 +13,15 @@ class InternalFilePersistence implements FilePersistence {
     private static final String DOWNLOADS_DIR = "/downloads/";
 
     private Context context;
-    private StorageRequirementsRule storageRequirementsRule;
+    private StorageRequirementRule storageRequirementRule;
 
     @Nullable
     private FileOutputStream fileOutputStream;
 
     @Override
-    public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
+    public void initialiseWith(Context context, StorageRequirementRule storageRequirementRule) {
         this.context = context.getApplicationContext();
-        this.storageRequirementsRule = storageRequirementsRule;
+        this.storageRequirementRule = storageRequirementRule;
     }
 
     @Override
@@ -35,7 +35,7 @@ class InternalFilePersistence implements FilePersistence {
             return FilePersistenceResult.ERROR_UNKNOWN_TOTAL_FILE_SIZE;
         }
 
-        if (storageRequirementsRule.hasViolatedRule(context.getFilesDir(), fileSize)) {
+        if (storageRequirementRule.hasViolatedRule(context.getFilesDir(), fileSize)) {
             return FilePersistenceResult.ERROR_INSUFFICIENT_SPACE;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteFileSize.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteFileSize.java
@@ -38,6 +38,11 @@ class LiteFileSize implements InternalFileSize {
     }
 
     @Override
+    public long remainingSize() {
+        return totalSize - currentSize;
+    }
+
+    @Override
     public void addToCurrentSize(long newBytes) {
         currentSize += newBytes;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -54,8 +54,8 @@ class MigrationJob implements Runnable {
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
-        StorageRequirementsRule storageRequirementsRule = StorageRequirementsRule.withPercentageOfStorageRemaining(TEN_PERCENT);
-        filePersistenceCreator.withStorageRequirementsRule(storageRequirementsRule);
+        StorageRequirementRule storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(TEN_PERCENT);
+        filePersistenceCreator.withStorageRequirementsRule(storageRequirementRule);
         FilePersistence filePersistence = filePersistenceCreator.create();
 
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database, basePath);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -54,7 +54,7 @@ class MigrationJob implements Runnable {
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
-        StorageRequirementRule storageRequirementRule = StorageRequirementRuleFactory.createPercetageBasedRule(TEN_PERCENT);
+        StorageRequirementRule storageRequirementRule = StorageRequirementRuleFactory.createPercentageBasedRule(TEN_PERCENT);
         filePersistenceCreator.withStorageRequirementRules(storageRequirementRule);
         FilePersistence filePersistence = filePersistenceCreator.create();
 

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -55,7 +55,7 @@ class MigrationJob implements Runnable {
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
         StorageRequirementRule storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(TEN_PERCENT);
-        filePersistenceCreator.withStorageRequirementsRule(storageRequirementRule);
+        filePersistenceCreator.withStorageRequirementRules(storageRequirementRule);
         FilePersistence filePersistence = filePersistenceCreator.create();
 
         PartialDownloadMigrationExtractor partialDownloadMigrationExtractor = new PartialDownloadMigrationExtractor(database, basePath);

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -54,7 +54,7 @@ class MigrationJob implements Runnable {
         SqlDatabaseWrapper database = new SqlDatabaseWrapper(sqLiteDatabase);
 
         FilePersistenceCreator filePersistenceCreator = FilePersistenceCreator.newInternalFilePersistenceCreator(context);
-        StorageRequirementRule storageRequirementRule = PercentageBasedStorageRequirementRule.withPercentageOfStorageRemaining(TEN_PERCENT);
+        StorageRequirementRule storageRequirementRule = StorageRequirementRuleFactory.createPercetageBasedRule(TEN_PERCENT);
         filePersistenceCreator.withStorageRequirementRules(storageRequirementRule);
         FilePersistence filePersistence = filePersistenceCreator.create();
 

--- a/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
@@ -5,23 +5,24 @@ import android.support.annotation.FloatRange;
 
 import java.io.File;
 
-public final class StorageRequirementsRule {
+public final class PercentageBasedStorageRequirementRule implements StorageRequirementRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final float percentageOfStorageRemaining;
 
-    public static StorageRequirementsRule withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        return new StorageRequirementsRule(new StorageCapacityReader(), percentageOfStorageRemaining);
+    public static PercentageBasedStorageRequirementRule withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+        return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
     }
 
-    private StorageRequirementsRule(StorageCapacityReader storageCapacityReader,
-                                    @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+    private PercentageBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader,
+                                                  @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         this.storageCapacityReader = storageCapacityReader;
         this.percentageOfStorageRemaining = percentageOfStorageRemaining;
     }
 
-    boolean hasViolatedRule(File storageDirectory,
-                            FileSize downloadFileSize) {
+    @Override
+    public boolean hasViolatedRule(File storageDirectory,
+                                   FileSize downloadFileSize) {
         StatFs statFs = new StatFs(storageDirectory.getPath());
         long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(statFs);
         long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageOfStorageRemaining);

--- a/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
@@ -1,6 +1,5 @@
 package com.novoda.downloadmanager;
 
-import android.os.StatFs;
 import android.support.annotation.FloatRange;
 
 import java.io.File;
@@ -23,8 +22,7 @@ public final class PercentageBasedStorageRequirementRule implements StorageRequi
     @Override
     public boolean hasViolatedRule(File storageDirectory,
                                    FileSize downloadFileSize) {
-        StatFs statFs = new StatFs(storageDirectory.getPath());
-        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(statFs);
+        long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(storageDirectory.getPath());
         long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageOfStorageRemaining);
         long usableStorageInBytes = storageDirectory.getUsableSpace();
         long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();

--- a/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
@@ -13,8 +13,8 @@ public final class PercentageBasedStorageRequirementRule implements StorageRequi
         return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
     }
 
-    private PercentageBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader,
-                                                  @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+    PercentageBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader,
+                                          @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         this.storageCapacityReader = storageCapacityReader;
         this.percentageOfStorageRemaining = percentageOfStorageRemaining;
     }
@@ -25,7 +25,7 @@ public final class PercentageBasedStorageRequirementRule implements StorageRequi
         long storageCapacityInBytes = storageCapacityReader.storageCapacityInBytes(storageDirectory.getPath());
         long minimumStorageRequiredInBytes = (long) (storageCapacityInBytes * percentageOfStorageRemaining);
         long usableStorageInBytes = storageDirectory.getUsableSpace();
-        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.totalSize();
+        long remainingStorageAfterDownloadInBytes = usableStorageInBytes - downloadFileSize.remainingSize();
 
         Logger.v("Storage capacity in bytes: ", storageCapacityInBytes);
         Logger.v("Usable storage in bytes: ", usableStorageInBytes);

--- a/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRule.java
@@ -4,14 +4,10 @@ import android.support.annotation.FloatRange;
 
 import java.io.File;
 
-public final class PercentageBasedStorageRequirementRule implements StorageRequirementRule {
+class PercentageBasedStorageRequirementRule implements StorageRequirementRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final float percentageOfStorageRemaining;
-
-    public static PercentageBasedStorageRequirementRule withPercentageOfStorageRemaining(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
-    }
 
     PercentageBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader,
                                           @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {

--- a/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageCapacityReader.java
@@ -5,7 +5,8 @@ import android.os.StatFs;
 
 class StorageCapacityReader {
 
-    long storageCapacityInBytes(StatFs statFs) {
+    long storageCapacityInBytes(String path) {
+        StatFs statFs = new StatFs(path);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             return statFs.getTotalBytes();
         } else {

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRule.java
@@ -1,0 +1,9 @@
+package com.novoda.downloadmanager;
+
+import java.io.File;
+
+public interface StorageRequirementRule {
+
+    boolean hasViolatedRule(File storageDirectory, FileSize downloadFileSize);
+
+}

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -1,0 +1,18 @@
+package com.novoda.downloadmanager;
+
+import android.support.annotation.FloatRange;
+
+public final class StorageRequirementRuleFactory {
+
+    private StorageRequirementRuleFactory() {
+        // Uses static factory methods.
+    }
+
+    public static StorageRequirementRule createByteBasedRule(long bytesRemainingAfterDownload) {
+        return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
+    }
+
+    public static StorageRequirementRule createPercetageBasedRule(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+        return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -12,7 +12,7 @@ public final class StorageRequirementRuleFactory {
         return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
     }
 
-    public static StorageRequirementRule createPercetageBasedRule(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+    public static StorageRequirementRule createPercentageBasedRule(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
@@ -1,0 +1,28 @@
+package com.novoda.downloadmanager;
+
+import java.io.File;
+import java.util.List;
+
+class StorageRequirementRules implements StorageRequirementRule {
+
+    private List<StorageRequirementRule> storageRequirementRules;
+
+    public StorageRequirementRules(List<StorageRequirementRule> storageRequirementRules) {
+        this.storageRequirementRules = storageRequirementRules;
+    }
+
+    public void addRule(StorageRequirementRule storageRequirementRule) {
+        storageRequirementRules.add(storageRequirementRule);
+    }
+
+    @Override
+    public boolean hasViolatedRule(File storageDirectory, FileSize downloadFileSize) {
+        for (StorageRequirementRule requirementRule : storageRequirementRules) {
+            if (requirementRule.hasViolatedRule(storageDirectory, downloadFileSize)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 final class StorageRequirementRules implements StorageRequirementRule {
 
-    private List<StorageRequirementRule> rules;
+    private final List<StorageRequirementRule> rules;
 
     static StorageRequirementRules newInstance() {
         return new StorageRequirementRules(new ArrayList<>());

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
@@ -6,23 +6,23 @@ import java.util.List;
 
 final class StorageRequirementRules implements StorageRequirementRule {
 
-    private List<StorageRequirementRule> storageRequirementRules;
+    private List<StorageRequirementRule> rules;
 
     static StorageRequirementRules newInstance() {
         return new StorageRequirementRules(new ArrayList<>());
     }
 
-    private StorageRequirementRules(List<StorageRequirementRule> storageRequirementRules) {
-        this.storageRequirementRules = storageRequirementRules;
+    private StorageRequirementRules(List<StorageRequirementRule> rules) {
+        this.rules = rules;
     }
 
     void addRule(StorageRequirementRule storageRequirementRule) {
-        storageRequirementRules.add(storageRequirementRule);
+        rules.add(storageRequirementRule);
     }
 
     @Override
     public boolean hasViolatedRule(File storageDirectory, FileSize downloadFileSize) {
-        for (StorageRequirementRule requirementRule : storageRequirementRules) {
+        for (StorageRequirementRule requirementRule : rules) {
             if (requirementRule.hasViolatedRule(storageDirectory, downloadFileSize)) {
                 return true;
             }

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRules.java
@@ -1,17 +1,22 @@
 package com.novoda.downloadmanager;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 
-class StorageRequirementRules implements StorageRequirementRule {
+final class StorageRequirementRules implements StorageRequirementRule {
 
     private List<StorageRequirementRule> storageRequirementRules;
 
-    public StorageRequirementRules(List<StorageRequirementRule> storageRequirementRules) {
+    static StorageRequirementRules newInstance() {
+        return new StorageRequirementRules(new ArrayList<>());
+    }
+
+    private StorageRequirementRules(List<StorageRequirementRule> storageRequirementRules) {
         this.storageRequirementRules = storageRequirementRules;
     }
 
-    public void addRule(StorageRequirementRule storageRequirementRule) {
+    void addRule(StorageRequirementRule storageRequirementRule) {
         storageRequirementRules.add(storageRequirementRule);
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRuleTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ByteBasedStorageRequirementRuleTest.java
@@ -1,0 +1,93 @@
+package com.novoda.downloadmanager;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class ByteBasedStorageRequirementRuleTest {
+
+    private static final long CAPACITY_ONE_GB_IN_BYTES = 1000000000;
+    private static final long USABLE_THREE_HUNDRED_MB_IN_BYTES = 300000000;
+    private static final long REMAINING_OVER_ONE_HUNDRED_MB_IN_BYTES = 100000001;
+    private static final long REMAINING_ONE_HUNDRED_MB_IN_BYTES = 100000000;
+
+    private static final long TWO_HUNDRED_MB_IN_BYTES_REMAINING = 200000000;
+
+    private final File file = createFile();
+    private final StorageCapacityReader storageCapacityReader = createStorageCapacityReader();
+    private final ByteBasedStorageRequirementRule storageRequirementRule = new ByteBasedStorageRequirementRule(storageCapacityReader, TWO_HUNDRED_MB_IN_BYTES_REMAINING);
+
+    @Test
+    public void doesNotViolateRule_whenRemainingFileSizeIsLessThanRestriction() {
+        FileSize fileSize = new RemainingFileSize(REMAINING_ONE_HUNDRED_MB_IN_BYTES);
+
+        boolean hasViolatedRule = storageRequirementRule.hasViolatedRule(file, fileSize);
+
+        assertThat(hasViolatedRule).isFalse();
+    }
+
+    @Test
+    public void violatesRule_whenRemainingFileSizeIsGreaterThanRestriction() {
+        FileSize fileSize = new RemainingFileSize(REMAINING_OVER_ONE_HUNDRED_MB_IN_BYTES);
+
+        boolean hasViolatedRule = storageRequirementRule.hasViolatedRule(file, fileSize);
+
+        assertThat(hasViolatedRule).isTrue();
+    }
+
+    private static File createFile() {
+        File file = mock(File.class);
+        given(file.getUsableSpace()).willReturn(USABLE_THREE_HUNDRED_MB_IN_BYTES);
+        return file;
+    }
+
+    private static StorageCapacityReader createStorageCapacityReader() {
+        StorageCapacityReader storageCapacityReader = mock(StorageCapacityReader.class);
+        given(storageCapacityReader.storageCapacityInBytes(anyString())).willReturn(CAPACITY_ONE_GB_IN_BYTES);
+        return storageCapacityReader;
+    }
+
+    private class RemainingFileSize implements FileSize {
+
+        private final long remainingSizeInBytes;
+
+        RemainingFileSize(long remainingSizeInBytes) {
+            this.remainingSizeInBytes = remainingSizeInBytes;
+        }
+
+        @Override
+        public long currentSize() {
+            throw new IllegalStateException("not implemented");
+        }
+
+        @Override
+        public long totalSize() {
+            throw new IllegalStateException("not implemented");
+        }
+
+        @Override
+        public long remainingSize() {
+            return remainingSizeInBytes;
+        }
+
+        @Override
+        public boolean isTotalSizeKnown() {
+            throw new IllegalStateException("not implemented");
+        }
+
+        @Override
+        public boolean isTotalSizeUnknown() {
+            throw new IllegalStateException("not implemented");
+        }
+
+        @Override
+        public boolean areBytesDownloadedKnown() {
+            throw new IllegalStateException("not implemented");
+        }
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FilePersistenceFixtures.java
@@ -36,7 +36,7 @@ class FilePersistenceFixtures {
     FilePersistence build() {
         return new FilePersistence() {
             @Override
-            public void initialiseWith(Context context, StorageRequirementsRule storageRequirementsRule) {
+            public void initialiseWith(Context context, StorageRequirementRule storageRequirementRule) {
 
             }
 

--- a/library/src/test/java/com/novoda/downloadmanager/InternalFileSizeFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalFileSizeFixtures.java
@@ -76,6 +76,11 @@ class InternalFileSizeFixtures {
             }
 
             @Override
+            public long remainingSize() {
+                return totalSize - currentSize;
+            }
+
+            @Override
             public boolean isTotalSizeKnown() {
                 return isTotalSizeKnown;
             }

--- a/library/src/test/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRuleTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/PercentageBasedStorageRequirementRuleTest.java
@@ -9,19 +9,18 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class ByteBasedStorageRequirementRuleTest {
+public class PercentageBasedStorageRequirementRuleTest {
 
     private static final long CAPACITY_ONE_GB_IN_BYTES = 1000000000;
-    private static final long USABLE_THREE_HUNDRED_MB_IN_BYTES = 300000000;
+    private static final long USABLE_TWO_HUNDRED_MB_IN_BYTES = 200000000;
     private static final long REMAINING_OVER_ONE_HUNDRED_MB_IN_BYTES = 100000001;
     private static final long REMAINING_ONE_HUNDRED_MB_IN_BYTES = 100000000;
-
-    private static final long TWO_HUNDRED_MB_IN_BYTES_REMAINING = 200000000;
+    private static final float TEN_PERCENT = 0.1f;
 
     private final FileSize fileSize = mock(FileSize.class);
     private final File file = createFile();
     private final StorageCapacityReader storageCapacityReader = createStorageCapacityReader();
-    private final ByteBasedStorageRequirementRule storageRequirementRule = new ByteBasedStorageRequirementRule(storageCapacityReader, TWO_HUNDRED_MB_IN_BYTES_REMAINING);
+    private final PercentageBasedStorageRequirementRule storageRequirementRule = new PercentageBasedStorageRequirementRule(storageCapacityReader, TEN_PERCENT);
 
     @Test
     public void doesNotViolateRule_whenRemainingFileSizeIsLessThanRestriction() {
@@ -44,7 +43,7 @@ public class ByteBasedStorageRequirementRuleTest {
     private static File createFile() {
         File file = mock(File.class);
         given(file.getPath()).willReturn("any_path");
-        given(file.getUsableSpace()).willReturn(USABLE_THREE_HUNDRED_MB_IN_BYTES);
+        given(file.getUsableSpace()).willReturn(USABLE_TWO_HUNDRED_MB_IN_BYTES);
         return file;
     }
 
@@ -53,4 +52,5 @@ public class ByteBasedStorageRequirementRuleTest {
         given(storageCapacityReader.storageCapacityInBytes(anyString())).willReturn(CAPACITY_ONE_GB_IN_BYTES);
         return storageCapacityReader;
     }
+
 }


### PR DESCRIPTION
## Problem

Our percentage based storage requirement rule is a little excessive :joy: If a device has 32GB of memory then they cannot download a file when they have 3.2GB of space remaining on their device :grimacing:


## Solution
Implement an interface for `StorageRequirementRule` so that clients can specify their own rules for when a write / create of a file should fail. Create a wrapper `StorageRequirmentRules` that holds one or more rules to be checked. This is exposed through the `DownloadManagerBuilder..withStorageRequirementRules(StorageRequirementRule...)`. 

:warning: we do not add a rule by default :warning: