### PR TITLE
Use UUID in place of system.nanoTime.

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 final class RoomDownloadsPersistence implements DownloadsPersistence {
 
@@ -177,7 +178,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
 
     private String rawFileIdFrom(DownloadBatchTitle batch, CompletedDownloadBatch.CompletedDownloadFile completedDownloadFile) {
         if (completedDownloadFile.fileId() == null || completedDownloadFile.fileId().isEmpty()) {
-            return batch.asString() + System.nanoTime();
+            return batch.asString() + UUID.randomUUID();
         } else {
             return completedDownloadFile.fileId();
         }


### PR DESCRIPTION
## Problem
We currently use `System.nanoTime` when creating a `rawFileId` for a given batch. 😬 There is no guarantee that this time will be unique each time this method is called.

## Solution
Use a `UUID` instead. 