### PR TITLE
CallbackThrottle & delete on error

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
@@ -33,7 +33,7 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
 
     private boolean statusHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
         DownloadBatchStatus.Status newStatus = currentDownloadBatchStatus.status();
-        return currentStatus != newStatus;
+        return !currentStatus.equals(newStatus);
     }
 
     private boolean progressHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
@@ -43,7 +43,7 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
 
     private boolean errorHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
         DownloadError newDownloadError = currentDownloadBatchStatus.downloadError();
-        return currentDownloadError != newDownloadError;
+        return !currentDownloadError.equals(newDownloadError);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
@@ -33,7 +33,7 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
 
     private boolean statusHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
         DownloadBatchStatus.Status newStatus = currentDownloadBatchStatus.status();
-        return !currentStatus.equals(newStatus);
+        return newStatus != null && !newStatus.equals(currentStatus);
     }
 
     private boolean progressHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
@@ -43,7 +43,7 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
 
     private boolean errorHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
         DownloadError newDownloadError = currentDownloadBatchStatus.downloadError();
-        return !currentDownloadError.equals(newDownloadError);
+        return newDownloadError != null && !newDownloadError.equals(currentDownloadError);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -6,14 +6,7 @@ import android.support.annotation.WorkerThread;
 import java.util.List;
 import java.util.Map;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.QUEUED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
 
 // This model knows how to interact with low level components.
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity"})
@@ -318,7 +311,7 @@ class DownloadBatch {
             downloadFile.delete();
         }
 
-        if (status == PAUSED || status == DOWNLOADED || status == WAITING_FOR_NETWORK) {
+        if (status == PAUSED || status == DOWNLOADED || status == WAITING_FOR_NETWORK || status == ERROR) {
             Logger.v("delete async paused or downloaded batch " + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadsBatchPersistence.deleteAsync(downloadBatchStatus, downloadBatchId -> {
                 Logger.v("delete paused or downloaded mark as deleted: " + downloadBatchId.rawId());

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -6,7 +6,14 @@ import android.support.annotation.WorkerThread;
 import java.util.List;
 import java.util.Map;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.QUEUED;
 
 // This model knows how to interact with low level components.
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity"})

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -42,6 +42,7 @@ public final class DownloadManagerBuilder {
 
     private final Context applicationContext;
     private final Handler callbackHandler;
+    private final StorageRequirementRules storageRequirementRules;
 
     private FilePersistenceCreator filePersistenceCreator;
     private FileSizeRequester fileSizeRequester;
@@ -58,7 +59,6 @@ public final class DownloadManagerBuilder {
     private TimeUnit timeUnit;
     private long frequency;
     private Optional<LogHandle> logHandle;
-    private StorageRequirementRules storageRequirementRules;
 
     public static DownloadManagerBuilder newInstance(Context context, Handler callbackHandler, @DrawableRes final int notificationIcon) {
         Context applicationContext = context.getApplicationContext();

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
@@ -66,19 +66,14 @@ public class CallbackThrottleByProgressIncreaseTest {
         then(downloadBatchCallback).should(never()).onUpdate(any(DownloadBatchStatus.class));
     }
 
-    @Test(expected = NullPointerException.class)
-    public void throwsException_whenStoppingUpdatesWithoutCallback() {
-        callbackThrottleByProgressIncrease.stopUpdates();
-    }
-
     @Test
     public void emitsLastStatus_whenStoppingUpdates() {
         callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        givenPreviousUpdate(percentageIncreasedStatus);
-
         callbackThrottleByProgressIncrease.stopUpdates();
 
-        then(downloadBatchCallback).should().onUpdate(percentageIncreasedStatus);
+        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+
+        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
     }
 
     private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
@@ -1,9 +1,9 @@
 package com.novoda.downloadmanager;
 
-import org.junit.Before;
 import org.junit.Test;
 
-import static org.mockito.BDDMockito.given;
+import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 public class CallbackThrottleByProgressIncreaseTest {
@@ -11,13 +11,59 @@ public class CallbackThrottleByProgressIncreaseTest {
     private static final int DOWNLOAD_PERCENTAGE = 75;
 
     private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
-    private final DownloadBatchStatus downloadBatchStatus = mock(DownloadBatchStatus.class);
+    private final DownloadBatchStatus percentageIncreasedStatus = anInternalDownloadsBatchStatus()
+            .withPercentageDownloaded(DOWNLOAD_PERCENTAGE)
+            .build();
+    private final DownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
+            .withDownloadError(DownloadErrorFactory.createNetworkError("first"))
+            .build();
+    private final DownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
+            .withDownloadError(DownloadErrorFactory.createNetworkError("second"))
+            .build();
 
-    private CallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease;
+    private final CallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new CallbackThrottleByProgressIncrease();
 
-    @Before
-    public void setUp() {
-        callbackThrottleByProgressIncrease = new CallbackThrottleByProgressIncrease();
+    @Test
+    public void doesNothing_whenCallbackUnset() {
+        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+
+        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
+    }
+
+    @Test
+    public void doesNothing_whenDownloadBatchStatusIsUnchanged() {
+        givenPreviousUpdate(percentageIncreasedStatus);
+
+        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
+    }
+
+    @Test
+    public void emitsError_whenNotMatchingPrevious() {
+        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
+        givenPreviousUpdate(firstErrorStatus);
+
+        callbackThrottleByProgressIncrease.update(secondErrorStatus);
+        then(downloadBatchCallback).should().onUpdate(secondErrorStatus);
+    }
+
+    @Test
+    public void doesNotEmit_whenErrorIsUnchanged() {
+        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
+        givenPreviousUpdate(firstErrorStatus);
+
+        callbackThrottleByProgressIncrease.update(firstErrorStatus);
+        then(downloadBatchCallback).should(never()).onUpdate(firstErrorStatus);
+    }
+
+    @Test
+    public void doesNotEmit_whenPercentageIsUnchanged() {
+        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
+        givenPreviousUpdate(percentageIncreasedStatus);
+
+        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+
+        then(downloadBatchCallback).should(never()).onUpdate(any(DownloadBatchStatus.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -26,27 +72,16 @@ public class CallbackThrottleByProgressIncreaseTest {
     }
 
     @Test
-    public void doesNotEmit_whenPercentageIsUnchanged() {
-        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        givenPreviousUpdate(downloadBatchStatus);
-
-        callbackThrottleByProgressIncrease.update(downloadBatchStatus);
-
-        verifyZeroInteractions(downloadBatchCallback);
-    }
-
-    @Test
     public void emitsLastStatus_whenStoppingUpdates() {
         callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        givenPreviousUpdate(downloadBatchStatus);
+        givenPreviousUpdate(percentageIncreasedStatus);
 
         callbackThrottleByProgressIncrease.stopUpdates();
 
-        verify(downloadBatchCallback).onUpdate(downloadBatchStatus);
+        then(downloadBatchCallback).should().onUpdate(percentageIncreasedStatus);
     }
 
     private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {
-        given(downloadBatchStatus.percentageDownloaded()).willReturn(DOWNLOAD_PERCENTAGE);
         callbackThrottleByProgressIncrease.update(downloadBatchStatus);
         reset(downloadBatchCallback);
     }


### PR DESCRIPTION
## Problem
- The `CallbackThrottleByProgressIncrease` emits `DownloadBatchStatus` updates on progress change updates. It would also emit two instances of `ERROR` 😬 because we do not check for status changes or `DownloadError.type`.

- If receiving an error such as `insufficient storage` then it is impossible to delete that batch 😱 it seems that the `delete` is dependent on the batch still running in some way 😬 

## Solution
- Make the `CallbackThrottleByProgressIncrease` emit `DownloadBatchStatus` for only unique values.

- When performing a delete and the batch is in an `ERROR` state, immediately delete the asset, rather than waiting for the next tick of the `download-manager`.