### PR TITLE
v2 Update dependencies

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -39,17 +39,18 @@ android {
 }
 
 dependencies {
-    annotationProcessor 'android.arch.persistence.room:compiler:1.0.0'
+    annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
     implementation 'com.novoda:merlin:1.1.7'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'
-    implementation 'android.arch.persistence.room:runtime:1.0.0'
-    implementation('com.evernote:android-job:1.2.5') {
+    implementation('android.arch.persistence.room:runtime:1.1.1') {
         exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'android.arch.core', module: 'runtime'
     }
+    implementation 'com.evernote:android-job:1.2.6'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.16.0'
-    testImplementation 'com.google.truth:truth:0.39'
+    testImplementation 'org.mockito:mockito-core:2.19.0'
+    testImplementation 'com.google.truth:truth:0.41'
 }
 
 publish {


### PR DESCRIPTION
## Problem 
Trying to open #411 Path based persistence PR but I am getting blocked up dependency updates 😄 rather than make that PR any bigger I decided to do the updates here.

## Solution
`android.arch` components release notes: https://developer.android.com/jetpack/docs/release-notes

`android-job` https://github.com/evernote/android-job/releases they'll be a `minor` release soon that will use the new `WorkManager`.

`mockito` https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md

`truth` https://github.com/google/truth/releases