### PR TITLE
Concurrent modification exception

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -7,6 +7,7 @@ import android.support.annotation.WorkerThread;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 class DownloadManager implements LiteDownloadManagerCommands {
@@ -16,7 +17,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
     private final ExecutorService executor;
     private final Handler callbackHandler;
     private final Map<DownloadBatchId, DownloadBatch> downloadBatchMap;
-    private final List<DownloadBatchStatusCallback> callbacks;
+    private final Set<DownloadBatchStatusCallback> callbacks;
     private final FileOperations fileOperations;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final LiteDownloadManagerDownloader downloader;
@@ -31,7 +32,7 @@ class DownloadManager implements LiteDownloadManagerCommands {
                     ExecutorService executor,
                     Handler callbackHandler,
                     Map<DownloadBatchId, DownloadBatch> downloadBatchMap,
-                    List<DownloadBatchStatusCallback> callbacks,
+                    Set<DownloadBatchStatusCallback> callbacks,
                     FileOperations fileOperations,
                     DownloadsBatchPersistence downloadsBatchPersistence,
                     LiteDownloadManagerDownloader downloader,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -18,10 +18,10 @@ import android.support.v4.app.NotificationManagerCompat;
 
 import com.novoda.merlin.MerlinsBeard;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -112,7 +112,8 @@ public final class DownloadManagerBuilder {
         );
     }
 
-    @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})     // Can't group anymore these are customisable options.
+    @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
+    // Can't group anymore these are customisable options.
     private DownloadManagerBuilder(Context applicationContext,
                                    Handler callbackHandler,
                                    StorageRequirementRules storageRequirementRules,
@@ -254,7 +255,7 @@ public final class DownloadManagerBuilder {
 
         filePersistenceCreator.withStorageRequirementRules(storageRequirementRules);
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloaderCreator);
-        List<DownloadBatchStatusCallback> callbacks = new ArrayList<>();
+        Set<DownloadBatchStatusCallback> callbacks = new CopyOnWriteArraySet<>();
 
         CallbackThrottleCreator callbackThrottleCreator = getCallbackThrottleCreator(
                 callbackThrottleCreatorType,

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -2,8 +2,8 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
@@ -21,7 +21,7 @@ class LiteDownloadManagerDownloader {
     private final DownloadsBatchPersistence downloadsBatchPersistence;
     private final DownloadsFilePersistence downloadsFilePersistence;
     private final DownloadBatchStatusNotificationDispatcher notificationDispatcher;
-    private final List<DownloadBatchStatusCallback> callbacks;
+    private final Set<DownloadBatchStatusCallback> callbacks;
     private final ConnectionChecker connectionChecker;
 
     private final CallbackThrottleCreator callbackThrottleCreator;
@@ -39,7 +39,7 @@ class LiteDownloadManagerDownloader {
                                   DownloadsFilePersistence downloadsFilePersistence,
                                   DownloadBatchStatusNotificationDispatcher notificationDispatcher,
                                   ConnectionChecker connectionChecker,
-                                  List<DownloadBatchStatusCallback> callbacks,
+                                  Set<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator) {
         this.waitForDownloadService = waitForDownloadService;
         this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
@@ -56,12 +56,12 @@ class LiteDownloadManagerDownloader {
 
     void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         DownloadBatch downloadBatch = DownloadBatchFactory.newInstance(
-            batch,
-            fileOperations,
-            downloadsBatchPersistence,
-            downloadsFilePersistence,
-            callbackThrottleCreator.create(),
-            connectionChecker
+                batch,
+                fileOperations,
+                downloadsBatchPersistence,
+                downloadsFilePersistence,
+                callbackThrottleCreator.create(),
+                connectionChecker
         );
 
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
@@ -77,7 +77,7 @@ class LiteDownloadManagerDownloader {
         }
 
         executor.submit(() -> Wait.<Void>waitFor(downloadService, waitForDownloadService)
-            .thenPerform(executeDownload(downloadBatch, downloadBatchMap)));
+                .thenPerform(executeDownload(downloadBatch, downloadBatchMap)));
     }
 
     private Wait.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadManagerTest.java
@@ -2,18 +2,20 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.InOrder;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.InOrder;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.DownloadBatchIdFixtures.aDownloadBatchId;
@@ -62,7 +64,7 @@ public class DownloadManagerTest {
     private DownloadManager downloadManager;
     private Map<DownloadBatchId, DownloadBatch> downloadingBatches = new HashMap<>();
     private List<DownloadBatchStatus> downloadBatchStatuses = new ArrayList<>();
-    private List<DownloadBatchStatusCallback> downloadBatchCallbacks = new ArrayList<>();
+    private Set<DownloadBatchStatusCallback> downloadBatchCallbacks = new CopyOnWriteArraySet<>();
     private DownloadFileStatus downloadFileStatus = null;
 
     @Before


### PR DESCRIPTION
**Problem**

A client has reported `concurrent modification exceptions` on the `.add` and `.remove` callbacks

**Solution**

Change the data structure of the callbacks from the current `ArrayList` to `https://developer.android.com/reference/java/util/concurrent/CopyOnWriteArraySet` as the latter is thread-safe and fail-safe

Official documentation: https://developer.android.com/reference/java/util/concurrent/CopyOnWriteArraySet