### PR TITLE
Multiple events

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncrease.java
@@ -5,8 +5,6 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
     private DownloadBatchStatusCallback callback;
 
     private int currentProgress;
-    private DownloadBatchStatus.Status currentStatus;
-    private DownloadError currentDownloadError;
 
     @Override
     public void setCallback(DownloadBatchStatusCallback callback) {
@@ -19,31 +17,15 @@ class CallbackThrottleByProgressIncrease implements CallbackThrottle {
             return;
         }
 
-        if (statusHasChanged(currentDownloadBatchStatus)
-                || progressHasChanged(currentDownloadBatchStatus)
-                || errorHasChanged(currentDownloadBatchStatus)) {
-
-            currentStatus = currentDownloadBatchStatus.status();
+        if (progressHasChanged(currentDownloadBatchStatus)) {
             currentProgress = currentDownloadBatchStatus.percentageDownloaded();
-            currentDownloadError = currentDownloadBatchStatus.downloadError();
-
             callback.onUpdate(currentDownloadBatchStatus);
         }
-    }
-
-    private boolean statusHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
-        DownloadBatchStatus.Status newStatus = currentDownloadBatchStatus.status();
-        return newStatus != null && !newStatus.equals(currentStatus);
     }
 
     private boolean progressHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
         int newProgress = currentDownloadBatchStatus.percentageDownloaded();
         return currentProgress != newProgress;
-    }
-
-    private boolean errorHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
-        DownloadError newDownloadError = currentDownloadBatchStatus.downloadError();
-        return newDownloadError != null && !newDownloadError.equals(currentDownloadError);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
@@ -2,40 +2,19 @@ package com.novoda.downloadmanager;
 
 class DownloadBatchStatusFilter {
 
-    private int currentProgress;
-    private DownloadBatchStatus.Status currentStatus;
-    private DownloadError currentDownloadError;
+    private InternalDownloadBatchStatus currentStatus;
 
     boolean shouldFilterOut(DownloadBatchStatus currentDownloadBatchStatus) {
-        if (currentDownloadBatchStatus == null) {
+        if (!(currentDownloadBatchStatus instanceof InternalDownloadBatchStatus)) {
             return true;
         }
 
-        if (statusHasChanged(currentDownloadBatchStatus)
-                || progressHasChanged(currentDownloadBatchStatus)
-                || errorHasChanged(currentDownloadBatchStatus)) {
-
-            currentStatus = currentDownloadBatchStatus.status();
-            currentProgress = currentDownloadBatchStatus.percentageDownloaded();
-            currentDownloadError = currentDownloadBatchStatus.downloadError();
-
-            return false;
+        InternalDownloadBatchStatus copiedStatus = ((InternalDownloadBatchStatus) currentDownloadBatchStatus).copy();
+        if (copiedStatus.equals(currentStatus)) {
+            return true;
         }
-        return true;
-    }
 
-    private boolean statusHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
-        DownloadBatchStatus.Status newStatus = currentDownloadBatchStatus.status();
-        return newStatus != null && !newStatus.equals(currentStatus);
-    }
-
-    private boolean progressHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
-        int newProgress = currentDownloadBatchStatus.percentageDownloaded();
-        return currentProgress != newProgress;
-    }
-
-    private boolean errorHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
-        DownloadError newDownloadError = currentDownloadBatchStatus.downloadError();
-        return newDownloadError != null && !newDownloadError.equals(currentDownloadError);
+        currentStatus = copiedStatus;
+        return false;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
@@ -1,0 +1,41 @@
+package com.novoda.downloadmanager;
+
+class DownloadBatchStatusFilter {
+
+    private int currentProgress;
+    private DownloadBatchStatus.Status currentStatus;
+    private DownloadError currentDownloadError;
+
+    boolean shouldFilter(DownloadBatchStatus currentDownloadBatchStatus) {
+        if (currentDownloadBatchStatus == null) {
+            return true;
+        }
+
+        if (statusHasChanged(currentDownloadBatchStatus)
+                || progressHasChanged(currentDownloadBatchStatus)
+                || errorHasChanged(currentDownloadBatchStatus)) {
+
+            currentStatus = currentDownloadBatchStatus.status();
+            currentProgress = currentDownloadBatchStatus.percentageDownloaded();
+            currentDownloadError = currentDownloadBatchStatus.downloadError();
+
+            return false;
+        }
+        return true;
+    }
+
+    private boolean statusHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
+        DownloadBatchStatus.Status newStatus = currentDownloadBatchStatus.status();
+        return newStatus != null && !newStatus.equals(currentStatus);
+    }
+
+    private boolean progressHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
+        int newProgress = currentDownloadBatchStatus.percentageDownloaded();
+        return currentProgress != newProgress;
+    }
+
+    private boolean errorHasChanged(DownloadBatchStatus currentDownloadBatchStatus) {
+        DownloadError newDownloadError = currentDownloadBatchStatus.downloadError();
+        return newDownloadError != null && !newDownloadError.equals(currentDownloadError);
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
@@ -6,7 +6,7 @@ class DownloadBatchStatusFilter {
     private DownloadBatchStatus.Status currentStatus;
     private DownloadError currentDownloadError;
 
-    boolean shouldFilter(DownloadBatchStatus currentDownloadBatchStatus) {
+    boolean shouldFilterOut(DownloadBatchStatus currentDownloadBatchStatus) {
         if (currentDownloadBatchStatus == null) {
             return true;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusFilter.java
@@ -6,14 +6,24 @@ class DownloadBatchStatusFilter {
 
     boolean shouldFilterOut(DownloadBatchStatus currentDownloadBatchStatus) {
         if (!(currentDownloadBatchStatus instanceof InternalDownloadBatchStatus)) {
+            Logger.w(currentDownloadBatchStatus.getClass() + " is not an instance of " + InternalDownloadBatchStatus.class);
             return true;
         }
 
         InternalDownloadBatchStatus copiedStatus = ((InternalDownloadBatchStatus) currentDownloadBatchStatus).copy();
         if (copiedStatus.equals(currentStatus)) {
+            Logger.v("Failed filter. "
+                             + "ID: " + currentDownloadBatchStatus.getDownloadBatchId().rawId()
+                             + " Status: " + currentDownloadBatchStatus.status().toRawValue()
+            );
             return true;
         }
 
+        Logger.v(
+                "Passes filter. "
+                        + "ID: " + currentDownloadBatchStatus.getDownloadBatchId().rawId()
+                        + " Status: " + currentDownloadBatchStatus.status().toRawValue()
+        );
         currentStatus = copiedStatus;
         return false;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadError.java
@@ -31,4 +31,36 @@ public class DownloadError {
     public String message() {
         return message;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DownloadError that = (DownloadError) o;
+
+        if (type != that.type) {
+            return false;
+        }
+        return message != null ? message.equals(that.message) : that.message == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type != null ? type.hashCode() : 0;
+        result = 31 * result + (message != null ? message.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "DownloadError{"
+                + "type=" + type
+                + ", message='" + message + '\''
+                + '}';
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -27,11 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
 
 @SuppressWarnings("PMD.ExcessiveImports")
 public final class DownloadManagerBuilder {
@@ -292,6 +288,8 @@ public final class DownloadManagerBuilder {
                 new HashSet<>()
         );
 
+        DownloadBatchStatusFilter downloadBatchStatusFilter = new DownloadBatchStatusFilter();
+
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 SERVICE_LOCK,
                 CALLBACK_LOCK,
@@ -303,7 +301,8 @@ public final class DownloadManagerBuilder {
                 batchStatusNotificationDispatcher,
                 connectionChecker,
                 callbacks,
-                callbackThrottleCreator
+                callbackThrottleCreator,
+                downloadBatchStatusFilter
         );
 
         downloadManager = new DownloadManager(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -27,7 +27,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
 @SuppressWarnings("PMD.ExcessiveImports")
 public final class DownloadManagerBuilder {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -97,7 +97,7 @@ class LiteDownloadManagerDownloader {
 
     private DownloadBatchStatusCallback downloadBatchCallback(Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         return downloadBatchStatus -> {
-            if (downloadBatchStatus == null || downloadBatchStatusFilter.shouldFilter(downloadBatchStatus)) {
+            if (downloadBatchStatus == null || downloadBatchStatusFilter.shouldFilterOut(downloadBatchStatus)) {
                 return;
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -6,7 +6,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.*;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 
 class LiteDownloadManagerDownloader {
 

--- a/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/CallbackThrottleByProgressIncreaseTest.java
@@ -14,12 +14,6 @@ public class CallbackThrottleByProgressIncreaseTest {
     private final DownloadBatchStatus percentageIncreasedStatus = anInternalDownloadsBatchStatus()
             .withPercentageDownloaded(DOWNLOAD_PERCENTAGE)
             .build();
-    private final DownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
-            .withDownloadError(DownloadErrorFactory.createNetworkError("first"))
-            .build();
-    private final DownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
-            .withDownloadError(DownloadErrorFactory.createNetworkError("second"))
-            .build();
 
     private final CallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new CallbackThrottleByProgressIncrease();
 
@@ -39,24 +33,6 @@ public class CallbackThrottleByProgressIncreaseTest {
     }
 
     @Test
-    public void emitsError_whenNotMatchingPrevious() {
-        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        givenPreviousUpdate(firstErrorStatus);
-
-        callbackThrottleByProgressIncrease.update(secondErrorStatus);
-        then(downloadBatchCallback).should().onUpdate(secondErrorStatus);
-    }
-
-    @Test
-    public void doesNotEmit_whenErrorIsUnchanged() {
-        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        givenPreviousUpdate(firstErrorStatus);
-
-        callbackThrottleByProgressIncrease.update(firstErrorStatus);
-        then(downloadBatchCallback).should(never()).onUpdate(firstErrorStatus);
-    }
-
-    @Test
     public void doesNotEmit_whenPercentageIsUnchanged() {
         callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
         givenPreviousUpdate(percentageIncreasedStatus);
@@ -67,7 +43,7 @@ public class CallbackThrottleByProgressIncreaseTest {
     }
 
     @Test
-    public void emitsLastStatus_whenStoppingUpdates() {
+    public void doesNotEmitsStatus_whenStoppingUpdates() {
         callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
         callbackThrottleByProgressIncrease.stopUpdates();
 

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
@@ -4,27 +4,24 @@ import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 
 public class DownloadBatchStatusFilterTest {
 
-    private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
-    private final DownloadBatchStatus firstPercentageStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus firstPercentageStatus = anInternalDownloadsBatchStatus()
             .withPercentageDownloaded(75)
             .build();
-    private final DownloadBatchStatus secondPercentageStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus secondPercentageStatus = anInternalDownloadsBatchStatus()
             .withPercentageDownloaded(80)
             .build();
-    private final DownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
             .withDownloadError(DownloadErrorFactory.createNetworkError("first"))
             .build();
-    private final DownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
             .withDownloadError(DownloadErrorFactory.createNetworkError("second"))
             .build();
-    private final DownloadBatchStatus firstStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus firstStatus = anInternalDownloadsBatchStatus()
             .build();
-    private final DownloadBatchStatus secondStatus = anInternalDownloadsBatchStatus()
+    private final InternalDownloadBatchStatus secondStatus = anInternalDownloadsBatchStatus()
             .withStatus(DownloadBatchStatus.Status.DOWNLOADED)
             .build();
 
@@ -84,8 +81,7 @@ public class DownloadBatchStatusFilterTest {
         assertThat(shouldFilterOut).isTrue();
     }
 
-    private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {
+    private void givenPreviousUpdate(InternalDownloadBatchStatus downloadBatchStatus) {
         downloadBatchStatusFilter.shouldFilterOut(downloadBatchStatus);
-        reset(downloadBatchCallback);
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
@@ -1,0 +1,91 @@
+package com.novoda.downloadmanager;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+
+public class DownloadBatchStatusFilterTest {
+
+    private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
+    private final DownloadBatchStatus firstPercentageStatus = anInternalDownloadsBatchStatus()
+            .withPercentageDownloaded(75)
+            .build();
+    private final DownloadBatchStatus secondPercentageStatus = anInternalDownloadsBatchStatus()
+            .withPercentageDownloaded(80)
+            .build();
+    private final DownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
+            .withDownloadError(DownloadErrorFactory.createNetworkError("first"))
+            .build();
+    private final DownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
+            .withDownloadError(DownloadErrorFactory.createNetworkError("second"))
+            .build();
+    private final DownloadBatchStatus firstStatus = anInternalDownloadsBatchStatus()
+            .build();
+    private final DownloadBatchStatus secondStatus = anInternalDownloadsBatchStatus()
+            .withStatus(DownloadBatchStatus.Status.DOWNLOADED)
+            .build();
+
+    private final DownloadBatchStatusFilter downloadBatchStatusFilter = new DownloadBatchStatusFilter();
+
+    @Test
+    public void returnsFalse_whenPercentageDoesNotMatchPrevious() {
+        givenPreviousUpdate(firstPercentageStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(secondPercentageStatus);
+
+        assertThat(shouldFilterOut).isFalse();
+    }
+
+    @Test
+    public void returnsTrue_whenPercentageIsUnchanged() {
+        givenPreviousUpdate(firstPercentageStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(firstPercentageStatus);
+
+        assertThat(shouldFilterOut).isTrue();
+    }
+
+    @Test
+    public void returnsFalse_whenErrorDoesNotMatchPrevious() {
+        givenPreviousUpdate(firstErrorStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(secondErrorStatus);
+
+        assertThat(shouldFilterOut).isFalse();
+    }
+
+    @Test
+    public void returnsTrue_whenErrorIsUnchanged() {
+        givenPreviousUpdate(firstErrorStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(firstErrorStatus);
+
+        assertThat(shouldFilterOut).isTrue();
+    }
+
+    @Test
+    public void returnsFalse_whenStatusDoesNotMatchPrevious() {
+        givenPreviousUpdate(firstStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(secondStatus);
+
+        assertThat(shouldFilterOut).isFalse();
+    }
+
+    @Test
+    public void returnsTrue_whenStatusIsUnchanged() {
+        givenPreviousUpdate(firstStatus);
+
+        boolean shouldFilterOut = downloadBatchStatusFilter.shouldFilterOut(firstStatus);
+
+        assertThat(shouldFilterOut).isTrue();
+    }
+
+    private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {
+        downloadBatchStatusFilter.shouldFilterOut(downloadBatchStatus);
+        reset(downloadBatchCallback);
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -62,114 +62,15 @@ class InternalDownloadBatchStatusFixtures {
     }
 
     InternalDownloadBatchStatus build() {
-        return new InternalDownloadBatchStatus() {
-
-            @Override
-            public DownloadBatchTitle getDownloadBatchTitle() {
-                return downloadBatchTitle;
-            }
-
-            @Override
-            public int percentageDownloaded() {
-                return percentageDownloaded;
-            }
-
-            @Override
-            public long bytesDownloaded() {
-                return bytesDownloaded;
-            }
-
-            @Override
-            public long bytesTotalSize() {
-                return bytesTotalSize;
-            }
-
-            @Override
-            public DownloadBatchId getDownloadBatchId() {
-                return downloadBatchId;
-            }
-
-            @Override
-            public Status status() {
-                return status;
-            }
-
-            @Override
-            public long downloadedDateTimeInMillis() {
-                return downloadedDateTimeInMillis;
-            }
-
-            @Override
-            public DownloadError downloadError() {
-                return downloadError;
-            }
-
-            @Override
-            public void updateTotalSize(long totalBatchSizeBytes) {
-                // do nothing.
-            }
-
-            @Override
-            public void updateDownloaded(long currentBytesDownloaded) {
-                // do nothing.
-            }
-
-            @Override
-            public void markAsDownloading(DownloadsBatchStatusPersistence persistence) {
-                status = Status.DOWNLOADING;
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public void markAsPaused(DownloadsBatchStatusPersistence persistence) {
-                status = Status.PAUSED;
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public void markAsQueued(DownloadsBatchStatusPersistence persistence) {
-                status = Status.QUEUED;
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public void markAsDeleting() {
-                status = Status.DELETING;
-            }
-
-            @Override
-            public void markAsDeleted() {
-                status = Status.DELETED;
-            }
-
-            @Override
-            public void markAsError(Optional<DownloadError> downloadError, DownloadsBatchStatusPersistence persistence) {
-                status = Status.ERROR;
-                InternalDownloadBatchStatusFixtures.this.downloadError = downloadError.get();
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public void markAsDownloaded(DownloadsBatchStatusPersistence persistence) {
-                status = Status.DOWNLOADED;
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
-                status = Status.WAITING_FOR_NETWORK;
-                persistence.updateStatusAsync(downloadBatchId, status);
-            }
-
-            @Override
-            public InternalDownloadBatchStatus copy() {
-                return build();
-            }
-
-            @Override
-            public boolean notificationSeen() {
-                return notificationSeen;
-            }
-        };
+        return new LiteDownloadBatchStatus(
+                downloadBatchId,
+                downloadBatchTitle,
+                downloadedDateTimeInMillis,
+                bytesDownloaded,
+                bytesTotalSize,
+                status,
+                notificationSeen,
+                Optional.fromNullable(downloadError)
+        );
     }
 }


### PR DESCRIPTION
## Problem
After some discussion with @zegnus we would rather not mess with the callback flow that currently exists on the `DownloadBatch`.

## Solution
- We've opted with introducing a variation of the filter that was used on the `CallbackThrottleByProgressIncrease` for `DownloadBatchStatus` to the `LiteDownloadManagerDownloader`. When the `LiteDownloadManagerDownloader` receives a `DownloadBatchStatus` change, it will only allow it to be emitted to the clients if it wasn't previously emitted. 

- The `CallbackThrottleByProgressIncrease` has been reverted to its previous state and now only handles `progress increases` again.