### PR TITLE
Callback throttle rename

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFileCallbackThrottle.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFileCallbackThrottle.java
@@ -2,14 +2,14 @@ package com.novoda.downloadmanager.demo;
 
 import android.util.Log;
 
-import com.novoda.downloadmanager.CallbackThrottle;
+import com.novoda.downloadmanager.FileCallbackThrottle;
 import com.novoda.downloadmanager.DownloadBatchStatus;
 import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 
 // Must be public
-public class CustomCallbackThrottle implements CallbackThrottle {
+public class CustomFileCallbackThrottle implements FileCallbackThrottle {
 
-    private static final String TAG = CustomCallbackThrottle.class.getSimpleName();
+    private static final String TAG = CustomFileCallbackThrottle.class.getSimpleName();
     private DownloadBatchStatusCallback callback;
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/CallbackThrottleCreator.java
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit;
 
 final class CallbackThrottleCreator {
 
-    private static final Class<? extends CallbackThrottle> NO_CUSTOM_CALLBACK_THROTTLE = null;
+    private static final Class<? extends FileCallbackThrottle> NO_CUSTOM_CALLBACK_THROTTLE = null;
     private static final TimeUnit UNUSED_TIME_UNIT = TimeUnit.SECONDS;
     private static final int UNUSED_FREQUENCY = 0;
 
@@ -17,7 +17,7 @@ final class CallbackThrottleCreator {
     private final Type type;
     private final TimeUnit timeUnit;
     private final long frequency;
-    private final Class<? extends CallbackThrottle> customCallbackThrottle;
+    private final Class<? extends FileCallbackThrottle> customCallbackThrottle;
 
     static CallbackThrottleCreator byTime(TimeUnit timeUnit, long quantity) {
         return new CallbackThrottleCreator(Type.THROTTLE_BY_TIME, timeUnit, quantity, NO_CUSTOM_CALLBACK_THROTTLE);
@@ -27,24 +27,24 @@ final class CallbackThrottleCreator {
         return new CallbackThrottleCreator(Type.THROTTLE_BY_PROGRESS_INCREASE, UNUSED_TIME_UNIT, UNUSED_FREQUENCY, NO_CUSTOM_CALLBACK_THROTTLE);
     }
 
-    static CallbackThrottleCreator byCustomThrottle(Class<? extends CallbackThrottle> customCallbackThrottle) {
+    static CallbackThrottleCreator byCustomThrottle(Class<? extends FileCallbackThrottle> customCallbackThrottle) {
         return new CallbackThrottleCreator(Type.CUSTOM, UNUSED_TIME_UNIT, UNUSED_FREQUENCY, customCallbackThrottle);
     }
 
-    private CallbackThrottleCreator(Type type, TimeUnit timeUnit, long frequency, Class<? extends CallbackThrottle> customCallbackThrottle) {
+    private CallbackThrottleCreator(Type type, TimeUnit timeUnit, long frequency, Class<? extends FileCallbackThrottle> customCallbackThrottle) {
         this.type = type;
         this.timeUnit = timeUnit;
         this.frequency = frequency;
         this.customCallbackThrottle = customCallbackThrottle;
     }
 
-    CallbackThrottle create() {
+    FileCallbackThrottle create() {
         switch (type) {
             case THROTTLE_BY_TIME:
                 ActionScheduler actionScheduler = SchedulerFactory.createFixedRateTimerScheduler(timeUnit.toMillis(frequency));
-                return new CallbackThrottleByTime(actionScheduler);
+                return new FileCallbackThrottleByTime(actionScheduler);
             case THROTTLE_BY_PROGRESS_INCREASE:
-                return new CallbackThrottleByProgressIncrease();
+                return new FileCallbackThrottleByProgressIncrease();
             case CUSTOM:
                 return createCallbackThrottle();
             default:
@@ -52,7 +52,7 @@ final class CallbackThrottleCreator {
         }
     }
 
-    private CallbackThrottle createCallbackThrottle() {
+    private FileCallbackThrottle createCallbackThrottle() {
         if (customCallbackThrottle == null) {
             throw new CustomCallbackThrottleException("CustomCallbackThrottle class cannot be accessed, is it public?");
         }
@@ -60,7 +60,7 @@ final class CallbackThrottleCreator {
         try {
             ClassLoader systemClassLoader = getClass().getClassLoader();
             Class<?> customCallbackThrottleClass = systemClassLoader.loadClass(customCallbackThrottle.getCanonicalName());
-            return (CallbackThrottle) customCallbackThrottleClass.newInstance();
+            return (FileCallbackThrottle) customCallbackThrottleClass.newInstance();
         } catch (IllegalAccessException e) {
             throw new CustomCallbackThrottleException(customCallbackThrottle, "Class cannot be accessed, is it public?", e);
         } catch (ClassNotFoundException e) {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -26,7 +26,7 @@ class DownloadBatch {
     private final InternalDownloadBatchStatus downloadBatchStatus;
     private final List<DownloadFile> downloadFiles;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
-    private final CallbackThrottle callbackThrottle;
+    private final FileCallbackThrottle fileCallbackThrottle;
     private final ConnectionChecker connectionChecker;
 
     private long totalBatchSizeBytes;
@@ -36,19 +36,19 @@ class DownloadBatch {
                   List<DownloadFile> downloadFiles,
                   Map<DownloadFileId, Long> fileBytesDownloadedMap,
                   DownloadsBatchPersistence downloadsBatchPersistence,
-                  CallbackThrottle callbackThrottle,
+                  FileCallbackThrottle fileCallbackThrottle,
                   ConnectionChecker connectionChecker) {
         this.downloadFiles = downloadFiles;
         this.fileBytesDownloadedMap = fileBytesDownloadedMap;
         this.downloadBatchStatus = internalDownloadBatchStatus;
         this.downloadsBatchPersistence = downloadsBatchPersistence;
-        this.callbackThrottle = callbackThrottle;
+        this.fileCallbackThrottle = fileCallbackThrottle;
         this.connectionChecker = connectionChecker;
     }
 
     void setCallback(DownloadBatchStatusCallback callback) {
         this.callback = callback;
-        callbackThrottle.setCallback(callback);
+        fileCallbackThrottle.setCallback(callback);
     }
 
     void download() {
@@ -86,7 +86,7 @@ class DownloadBatch {
 
         deleteBatchIfNeeded(downloadBatchStatus, downloadsBatchPersistence, callback);
         notifyCallback(callback, downloadBatchStatus);
-        callbackThrottle.stopUpdates();
+        fileCallbackThrottle.stopUpdates();
         Logger.v("end sync download " + rawBatchId);
     }
 
@@ -227,7 +227,7 @@ class DownloadBatch {
             if (currentBytesDownloaded > totalBatchSizeBytes) {
                 DownloadError downloadError = DownloadErrorFactory.createSizeMismatchError(downloadFileStatus);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
-                callbackThrottle.update(downloadBatchStatus);
+                fileCallbackThrottle.update(downloadBatchStatus);
                 return;
             }
 
@@ -243,7 +243,7 @@ class DownloadBatch {
                 downloadBatchStatus.markAsWaitingForNetwork(downloadsBatchPersistence);
             }
 
-            callbackThrottle.update(downloadBatchStatus);
+            fileCallbackThrottle.update(downloadBatchStatus);
         }
     };
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -19,7 +19,7 @@ final class DownloadBatchFactory {
                                      FileOperations fileOperations,
                                      DownloadsBatchPersistence downloadsBatchPersistence,
                                      DownloadsFilePersistence downloadsFilePersistence,
-                                     CallbackThrottle callbackThrottle,
+                                     FileCallbackThrottle fileCallbackThrottle,
                                      ConnectionChecker connectionChecker) {
         DownloadBatchTitle downloadBatchTitle = DownloadBatchTitleCreator.createFrom(batch);
         DownloadBatchId downloadBatchId = batch.downloadBatchId();
@@ -80,7 +80,7 @@ final class DownloadBatchFactory {
                 downloadFiles,
                 new HashMap<>(),
                 downloadsBatchPersistence,
-                callbackThrottle,
+                fileCallbackThrottle,
                 connectionChecker
         );
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -53,7 +53,7 @@ public final class DownloadManagerBuilder {
     private NotificationChannelProvider notificationChannelProvider;
     private ConnectionType connectionTypeAllowed;
     private boolean allowNetworkRecovery;
-    private Class<? extends CallbackThrottle> customCallbackThrottle;
+    private Class<? extends FileCallbackThrottle> customCallbackThrottle;
     private DownloadsPersistence downloadsPersistence;
     private CallbackThrottleCreator.Type callbackThrottleCreatorType;
     private TimeUnit timeUnit;
@@ -198,7 +198,7 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    public DownloadManagerBuilder withCallbackThrottleCustom(Class<? extends CallbackThrottle> customCallbackThrottle) {
+    public DownloadManagerBuilder withCallbackThrottleCustom(Class<? extends FileCallbackThrottle> customCallbackThrottle) {
         this.callbackThrottleCreatorType = CallbackThrottleCreator.Type.CUSTOM;
         this.customCallbackThrottle = customCallbackThrottle;
         return this;
@@ -328,7 +328,7 @@ public final class DownloadManagerBuilder {
     private CallbackThrottleCreator getCallbackThrottleCreator(CallbackThrottleCreator.Type callbackThrottleType,
                                                                TimeUnit timeUnit,
                                                                long frequency,
-                                                               Class<? extends CallbackThrottle> customCallbackThrottle) {
+                                                               Class<? extends FileCallbackThrottle> customCallbackThrottle) {
         switch (callbackThrottleType) {
             case THROTTLE_BY_TIME:
                 return CallbackThrottleCreator.byTime(timeUnit, frequency);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -133,14 +133,14 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                 NO_DOWNLOAD_ERROR
         );
 
-        CallbackThrottle callbackThrottle = callbackThrottleCreator.create();
+        FileCallbackThrottle fileCallbackThrottle = callbackThrottleCreator.create();
 
         return new DownloadBatch(
                 liteDownloadBatchStatus,
                 downloadFiles,
                 downloadedFileSizeMap,
                 DownloadsBatchPersistence.this,
-                callbackThrottle,
+                fileCallbackThrottle,
                 connectionChecker
         );
     }

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-public interface CallbackThrottle {
+public interface FileCallbackThrottle {
 
     void setCallback(DownloadBatchStatusCallback callback);
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
@@ -1,10 +1,30 @@
 package com.novoda.downloadmanager;
 
+/**
+ * Controls the rate at which a {@link DownloadFile} calls back to
+ * a {@link DownloadBatch}. Essentially controls the rate of notifications
+ * during a download of a file.
+ */
 public interface FileCallbackThrottle {
 
+    /**
+     * Set the callback that should be notified of {@link DownloadBatchStatus}
+     * changes.
+     *
+     * @param callback to notify.
+     */
     void setCallback(DownloadBatchStatusCallback callback);
 
+    /**
+     * The throttle logic that will forward events to the {@link DownloadBatchStatusCallback}.
+     *
+     * @param downloadBatchStatus the latest status to emit.
+     */
     void update(DownloadBatchStatus downloadBatchStatus);
 
+    /**
+     * Disable the callback or the throttling logic to
+     * prevent further emissions of {@link DownloadBatchStatus}.
+     */
     void stopUpdates();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottle.java
@@ -4,6 +4,8 @@ package com.novoda.downloadmanager;
  * Controls the rate at which a {@link DownloadFile} calls back to
  * a {@link DownloadBatch}. Essentially controls the rate of notifications
  * during a download of a file.
+ * <p>
+ * Note: This does not control the overall emissions of {@link DownloadBatchStatus} between the client and this library.
  */
 public interface FileCallbackThrottle {
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-class CallbackThrottleByProgressIncrease implements CallbackThrottle {
+class FileCallbackThrottleByProgressIncrease implements FileCallbackThrottle {
 
     private DownloadBatchStatusCallback callback;
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
@@ -1,13 +1,13 @@
 package com.novoda.downloadmanager;
 
-class CallbackThrottleByTime implements CallbackThrottle {
+class FileCallbackThrottleByTime implements FileCallbackThrottle {
 
     private final ActionScheduler actionScheduler;
 
     private DownloadBatchStatus downloadBatchStatus;
     private DownloadBatchStatusCallback callback;
 
-    CallbackThrottleByTime(ActionScheduler actionScheduler) {
+    FileCallbackThrottleByTime(ActionScheduler actionScheduler) {
         this.actionScheduler = actionScheduler;
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
@@ -6,7 +6,7 @@ import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anI
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
-public class CallbackThrottleByProgressIncreaseTest {
+public class FileCallbackThrottleByProgressIncreaseTest {
 
     private static final int DOWNLOAD_PERCENTAGE = 75;
 
@@ -15,7 +15,7 @@ public class CallbackThrottleByProgressIncreaseTest {
             .withPercentageDownloaded(DOWNLOAD_PERCENTAGE)
             .build();
 
-    private final CallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new CallbackThrottleByProgressIncrease();
+    private final FileCallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new FileCallbackThrottleByProgressIncrease();
 
     @Test
     public void doesNothing_whenCallbackUnset() {

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
@@ -10,17 +10,17 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.*;
 
-public class CallbackThrottleByTimeTest {
+public class FileCallbackThrottleByTimeTest {
 
     private final ActionScheduler actionScheduler = mock(ActionScheduler.class);
     private final DownloadBatchStatusCallback callback = mock(DownloadBatchStatusCallback.class);
     private final DownloadBatchStatus downloadBatchStatus = mock(DownloadBatchStatus.class);
 
-    private CallbackThrottleByTime callbackThrottleByTime;
+    private FileCallbackThrottleByTime callbackThrottleByTime;
 
     @Before
     public void setUp() {
-        callbackThrottleByTime = new CallbackThrottleByTime(actionScheduler);
+        callbackThrottleByTime = new FileCallbackThrottleByTime(actionScheduler);
 
         final ArgumentCaptor<ActionScheduler.Action> argumentCaptor = ArgumentCaptor.forClass(ActionScheduler.Action.class);
         willAnswer(new Answer<Void>() {

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleCreatorTest.java
@@ -6,22 +6,22 @@ import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-public class CallbackThrottleCreatorTest {
+public class FileCallbackThrottleCreatorTest {
 
     @Test
     public void createsTimeThrottle() {
-        CallbackThrottle callbackThrottle = CallbackThrottleCreator.byTime(TimeUnit.SECONDS, 1)
+        FileCallbackThrottle fileCallbackThrottle = CallbackThrottleCreator.byTime(TimeUnit.SECONDS, 1)
                 .create();
 
-        assertThat(callbackThrottle).isInstanceOf(CallbackThrottleByTime.class);
+        assertThat(fileCallbackThrottle).isInstanceOf(FileCallbackThrottleByTime.class);
     }
 
     @Test
     public void createsProgressThrottle() {
-        CallbackThrottle callbackThrottle = CallbackThrottleCreator.byProgressIncrease()
+        FileCallbackThrottle fileCallbackThrottle = CallbackThrottleCreator.byProgressIncrease()
                 .create();
 
-        assertThat(callbackThrottle).isInstanceOf(CallbackThrottleByProgressIncrease.class);
+        assertThat(fileCallbackThrottle).isInstanceOf(FileCallbackThrottleByProgressIncrease.class);
     }
 
     @Test(expected = RuntimeException.class)
@@ -50,17 +50,17 @@ public class CallbackThrottleCreatorTest {
 
     @Test
     public void createsCustomThrottle() {
-        CallbackThrottle callbackThrottle = CallbackThrottleCreator.byCustomThrottle(TestValidCustomThrottle.class)
+        FileCallbackThrottle fileCallbackThrottle = CallbackThrottleCreator.byCustomThrottle(TestValidCustomThrottle.class)
                 .create();
 
-        assertThat(callbackThrottle).isInstanceOf(TestValidCustomThrottle.class);
+        assertThat(fileCallbackThrottle).isInstanceOf(TestValidCustomThrottle.class);
     }
 
     /**
      * Used to test the {@link CallbackThrottleCreator} to ensure that a
      * {@link ClassNotFoundException} is thrown for the custom throttle.
      */
-    private static class TestNotFoundCustomThrottle implements CallbackThrottle {
+    private static class TestNotFoundCustomThrottle implements FileCallbackThrottle {
         @Override
         public void setCallback(DownloadBatchStatusCallback callback) {
 

--- a/library/src/test/java/com/novoda/downloadmanager/TestNonInstantiableCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestNonInstantiableCustomThrottle.java
@@ -4,7 +4,7 @@ package com.novoda.downloadmanager;
  * Used to test the {@link CallbackThrottleCreator} to ensure that a
  * {@link InstantiationException} is thrown for the custom throttle.
  */
-abstract class TestNonInstantiableCustomThrottle implements CallbackThrottle {
+abstract class TestNonInstantiableCustomThrottle implements FileCallbackThrottle {
 
     @Override
     public void setCallback(DownloadBatchStatusCallback callback) {

--- a/library/src/test/java/com/novoda/downloadmanager/TestNonPublicCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestNonPublicCustomThrottle.java
@@ -4,7 +4,7 @@ package com.novoda.downloadmanager;
  * Used to test the {@link CallbackThrottleCreator} to ensure that a
  * {@link IllegalAccessException} is thrown for the custom throttle.
  */
-class TestNonPublicCustomThrottle implements CallbackThrottle {
+class TestNonPublicCustomThrottle implements FileCallbackThrottle {
 
     private TestNonPublicCustomThrottle() {
     }

--- a/library/src/test/java/com/novoda/downloadmanager/TestValidCustomThrottle.java
+++ b/library/src/test/java/com/novoda/downloadmanager/TestValidCustomThrottle.java
@@ -2,9 +2,9 @@ package com.novoda.downloadmanager;
 
 /**
  * Used to test the {@link CallbackThrottleCreator} to ensure that a
- * valid {@link CallbackThrottle} is returned.
+ * valid {@link FileCallbackThrottle} is returned.
  */
-public class TestValidCustomThrottle implements CallbackThrottle {
+public class TestValidCustomThrottle implements FileCallbackThrottle {
 
     @Override
     public void setCallback(DownloadBatchStatusCallback callback) {


### PR DESCRIPTION
## Problem
When working on #415 I found the `CallbackThrottle` a little misleading. From a clients point of view it implies, to me, that it throttles all of the callbacks in the library that are emitted to the client but this is not the case. This `CallbackThrottle` handles the emissions from the `DownloadFile` to the `DownloadBatch`, essentially the emissions that tick when a file is downloading.

## Solution
Rename the interface to show that it is explicitly for the file and not for anything else. Add a javadoc to the interface 😄 