### PR TITLE
Add Storage Root to Batch

### DIFF
--- a/library/roomSchemas/com.novoda.downloadmanager.RoomAppDatabase/3.json
+++ b/library/roomSchemas/com.novoda.downloadmanager.RoomAppDatabase/3.json
@@ -1,0 +1,144 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "cea0758d42e212b6739e5db5ac2080f1",
+    "entities": [
+      {
+        "tableName": "RoomBatch",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`batch_id` TEXT NOT NULL, `batch_title` TEXT, `batch_status` TEXT, `batch_downloaded_date_time_in_millis` INTEGER NOT NULL, `notification_seen` INTEGER NOT NULL, `storage_root` TEXT, PRIMARY KEY(`batch_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "batch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "batch_title",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "batch_status",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedDateTimeInMillis",
+            "columnName": "batch_downloaded_date_time_in_millis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notificationSeen",
+            "columnName": "notification_seen",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "storageRoot",
+            "columnName": "storage_root",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "batch_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_RoomBatch_batch_id",
+            "unique": false,
+            "columnNames": [
+              "batch_id"
+            ],
+            "createSql": "CREATE  INDEX `index_RoomBatch_batch_id` ON `${TABLE_NAME}` (`batch_id`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "RoomFile",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`file_id` TEXT NOT NULL, `batch_id` TEXT NOT NULL, `file_path` TEXT, `total_size` INTEGER NOT NULL, `url` TEXT, `persistence_type` TEXT, PRIMARY KEY(`file_id`, `batch_id`), FOREIGN KEY(`batch_id`) REFERENCES `RoomBatch`(`batch_id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "fileId",
+            "columnName": "file_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "batchId",
+            "columnName": "batch_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "path",
+            "columnName": "file_path",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "totalSize",
+            "columnName": "total_size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "persistenceType",
+            "columnName": "persistence_type",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "file_id",
+            "batch_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_RoomFile_batch_id",
+            "unique": false,
+            "columnNames": [
+              "batch_id"
+            ],
+            "createSql": "CREATE  INDEX `index_RoomFile_batch_id` ON `${TABLE_NAME}` (`batch_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "RoomBatch",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "batch_id"
+            ],
+            "referencedColumns": [
+              "batch_id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"cea0758d42e212b6739e5db5ac2080f1\")"
+    ]
+  }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/Batch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Batch.java
@@ -25,6 +25,10 @@ public class Batch {
         return downloadBatchId;
     }
 
+    public StorageRoot storageRoot() {
+        return storageRoot;
+    }
+
     public String title() {
         return title;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -363,7 +363,8 @@ class DownloadBatch {
                 downloadBatchStatus.status(),
                 downloadFiles,
                 downloadBatchStatus.downloadedDateTimeInMillis(),
-                downloadBatchStatus.notificationSeen()
+                downloadBatchStatus.notificationSeen(),
+                downloadBatchStatus.storageRoot()
         );
     }
 
@@ -375,7 +376,8 @@ class DownloadBatch {
                 downloadBatchStatus.status(),
                 downloadFiles,
                 downloadBatchStatus.downloadedDateTimeInMillis(),
-                downloadBatchStatus.notificationSeen()
+                downloadBatchStatus.notificationSeen(),
+                downloadBatchStatus.storageRoot()
         );
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -22,6 +22,7 @@ final class DownloadBatchFactory {
                                      FileCallbackThrottle fileCallbackThrottle,
                                      ConnectionChecker connectionChecker) {
         DownloadBatchTitle downloadBatchTitle = DownloadBatchTitleCreator.createFrom(batch);
+        StorageRoot storageRoot = batch.storageRoot();
         DownloadBatchId downloadBatchId = batch.downloadBatchId();
         long downloadedDateTimeInMillis = System.currentTimeMillis();
 
@@ -67,6 +68,7 @@ final class DownloadBatchFactory {
         InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                 downloadBatchId,
                 downloadBatchTitle,
+                storageRoot.path(),
                 downloadedDateTimeInMillis,
                 BYTES_DOWNLOADED,
                 TOTAL_BATCH_SIZE_BYTES,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatus.java
@@ -35,6 +35,8 @@ public interface DownloadBatchStatus {
 
     DownloadBatchTitle getDownloadBatchTitle();
 
+    String storageRoot();
+
     int percentageDownloaded();
 
     long bytesDownloaded();

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersisted.java
@@ -11,4 +11,6 @@ public interface DownloadsBatchPersisted {
     long downloadedDateTimeInMillis();
 
     boolean notificationSeen();
+
+    String storageRoot();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -37,9 +37,10 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                       DownloadBatchStatus.Status status,
                       List<DownloadFile> downloadFiles,
                       long downloadedDateTimeInMillis,
-                      boolean notificationSeen) {
+                      boolean notificationSeen,
+                      String storageRoot) {
         executor.execute(() -> {
-            persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen);
+            persist(downloadBatchTitle, downloadBatchId, status, downloadFiles, downloadedDateTimeInMillis, notificationSeen, storageRoot);
         });
     }
 
@@ -49,7 +50,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                  DownloadBatchStatus.Status status,
                  List<DownloadFile> downloadFiles,
                  long downloadedDateTimeInMillis,
-                 boolean notificationSeen) {
+                 boolean notificationSeen,
+                 String storageRoot) {
         List<DownloadFile> downloadFilesToPersist = new ArrayList<>(downloadFiles);
         downloadsPersistence.startTransaction();
 
@@ -59,7 +61,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                     downloadBatchId,
                     status,
                     downloadedDateTimeInMillis,
-                    notificationSeen
+                    notificationSeen,
+                    storageRoot
             );
             downloadsPersistence.persistBatch(batchPersisted);
             for (DownloadFile downloadFile : downloadFilesToPersist) {
@@ -95,6 +98,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         DownloadBatchTitle downloadBatchTitle = batchPersisted.downloadBatchTitle();
         long downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
         boolean notificationSeen = batchPersisted.notificationSeen();
+        String storageRoot = batchPersisted.storageRoot();
 
         List<DownloadFile> downloadFiles = downloadsFilePersistence.loadSync(
                 downloadBatchId,
@@ -125,6 +129,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
         InternalDownloadBatchStatus liteDownloadBatchStatus = new LiteDownloadBatchStatus(
                 downloadBatchId,
                 downloadBatchTitle,
+                storageRoot,
                 downloadedDateTimeInMillis,
                 currentBytesDownloaded,
                 totalBatchSizeBytes,

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -9,6 +9,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private final DownloadBatchTitle downloadBatchTitle;
     private final DownloadBatchId downloadBatchId;
+    private final String storageRoot;
     private final long downloadedDateTimeInMillis;
 
     private Status status;
@@ -21,6 +22,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
     LiteDownloadBatchStatus(DownloadBatchId downloadBatchId,
                             DownloadBatchTitle downloadBatchTitle,
+                            String storageRoot,
                             long downloadedDateTimeInMillis,
                             long bytesDownloaded,
                             long totalBatchSizeBytes,
@@ -29,6 +31,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
                             Optional<DownloadError> downloadError) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
+        this.storageRoot = storageRoot;
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.bytesDownloaded = bytesDownloaded;
         this.totalBatchSizeBytes = totalBatchSizeBytes;
@@ -80,6 +83,11 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     @Override
     public DownloadBatchTitle getDownloadBatchTitle() {
         return downloadBatchTitle;
+    }
+
+    @Override
+    public String storageRoot() {
+        return storageRoot;
     }
 
     @Override
@@ -146,6 +154,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         return new LiteDownloadBatchStatus(
                 downloadBatchId,
                 downloadBatchTitle,
+                storageRoot,
                 downloadedDateTimeInMillis,
                 bytesDownloaded,
                 totalBatchSizeBytes,
@@ -188,6 +197,9 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         if (downloadedDateTimeInMillis != that.downloadedDateTimeInMillis) {
             return false;
         }
+        if (notificationSeen != that.notificationSeen) {
+            return false;
+        }
         if (bytesDownloaded != that.bytesDownloaded) {
             return false;
         }
@@ -197,13 +209,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         if (percentageDownloaded != that.percentageDownloaded) {
             return false;
         }
-        if (notificationSeen != that.notificationSeen) {
-            return false;
-        }
         if (downloadBatchTitle != null ? !downloadBatchTitle.equals(that.downloadBatchTitle) : that.downloadBatchTitle != null) {
             return false;
         }
         if (downloadBatchId != null ? !downloadBatchId.equals(that.downloadBatchId) : that.downloadBatchId != null) {
+            return false;
+        }
+        if (storageRoot != null ? !storageRoot.equals(that.storageRoot) : that.storageRoot != null) {
             return false;
         }
         if (status != that.status) {
@@ -216,12 +228,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     public int hashCode() {
         int result = downloadBatchTitle != null ? downloadBatchTitle.hashCode() : 0;
         result = 31 * result + (downloadBatchId != null ? downloadBatchId.hashCode() : 0);
+        result = 31 * result + (storageRoot != null ? storageRoot.hashCode() : 0);
         result = 31 * result + (int) (downloadedDateTimeInMillis ^ (downloadedDateTimeInMillis >>> 32));
+        result = 31 * result + (status != null ? status.hashCode() : 0);
+        result = 31 * result + (notificationSeen ? 1 : 0);
         result = 31 * result + (int) (bytesDownloaded ^ (bytesDownloaded >>> 32));
         result = 31 * result + (int) (totalBatchSizeBytes ^ (totalBatchSizeBytes >>> 32));
         result = 31 * result + percentageDownloaded;
-        result = 31 * result + (status != null ? status.hashCode() : 0);
-        result = 31 * result + (notificationSeen ? 1 : 0);
         result = 31 * result + (downloadError != null ? downloadError.hashCode() : 0);
         return result;
     }
@@ -231,12 +244,13 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
         return "LiteDownloadBatchStatus{"
                 + "downloadBatchTitle=" + downloadBatchTitle
                 + ", downloadBatchId=" + downloadBatchId
+                + ", storageRoot='" + storageRoot + '\''
                 + ", downloadedDateTimeInMillis=" + downloadedDateTimeInMillis
+                + ", status=" + status
+                + ", notificationSeen=" + notificationSeen
                 + ", bytesDownloaded=" + bytesDownloaded
                 + ", totalBatchSizeBytes=" + totalBatchSizeBytes
                 + ", percentageDownloaded=" + percentageDownloaded
-                + ", status=" + status
-                + ", notificationSeen=" + notificationSeen
                 + ", downloadError=" + downloadError
                 + '}';
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsBatchPersisted.java
@@ -7,17 +7,20 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     private final DownloadBatchStatus.Status status;
     private final long downloadedDateTimeInMillis;
     private final boolean notificationSeen;
+    private final String storageRoot;
 
     LiteDownloadsBatchPersisted(DownloadBatchTitle downloadBatchTitle,
                                 DownloadBatchId downloadBatchId,
                                 DownloadBatchStatus.Status status,
                                 long downloadedDateTimeInMillis,
-                                boolean notificationSeen) {
+                                boolean notificationSeen,
+                                String storageRoot) {
         this.downloadBatchTitle = downloadBatchTitle;
         this.downloadBatchId = downloadBatchId;
         this.status = status;
         this.downloadedDateTimeInMillis = downloadedDateTimeInMillis;
         this.notificationSeen = notificationSeen;
+        this.storageRoot = storageRoot;
     }
 
     @Override
@@ -43,5 +46,10 @@ class LiteDownloadsBatchPersisted implements DownloadsBatchPersisted {
     @Override
     public boolean notificationSeen() {
         return notificationSeen;
+    }
+
+    @Override
+    public String storageRoot() {
+        return storageRoot;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
+++ b/library/src/main/java/com/novoda/downloadmanager/MigrationJob.java
@@ -133,7 +133,8 @@ class MigrationJob implements Runnable {
                 downloadBatchId,
                 downloadBatchStatus,
                 downloadedDateTimeInMillis,
-                notificationSeen
+                notificationSeen,
+                StorageRootFactory.createMissingStorageRoot().path()
         );
         downloadsPersistence.persistBatch(persistedBatch);
 

--- a/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
@@ -11,6 +11,10 @@ import android.support.annotation.NonNull;
 @Database(entities = {RoomBatch.class, RoomFile.class}, version = 3)
 abstract class RoomAppDatabase extends RoomDatabase {
 
+    private static final int VERSION_ONE = 1;
+    private static final int VERSION_TWO = 2;
+    private static final int VERSION_THREE = 3;
+
     private static volatile RoomAppDatabase singleInstance;
 
     abstract RoomBatchDao roomBatchDao();
@@ -41,7 +45,7 @@ abstract class RoomAppDatabase extends RoomDatabase {
                 .build();
     }
 
-    private static final Migration MIGRATION_V1_TO_V2 = new Migration(1, 2) {
+    private static final Migration MIGRATION_V1_TO_V2 = new Migration(VERSION_ONE, VERSION_TWO) {
         @Override
         public void migrate(@NonNull SupportSQLiteDatabase database) {
             database.execSQL("CREATE TABLE IF NOT EXISTS `RoomFileTemp` (`file_id` TEXT NOT NULL, `batch_id` TEXT NOT NULL, "
@@ -56,12 +60,12 @@ abstract class RoomAppDatabase extends RoomDatabase {
         }
     };
 
-    private static class VersionTwoToVersionThreeMigration extends Migration {
+    private static final class VersionTwoToVersionThreeMigration extends Migration {
 
         private final StorageRoot storageRoot;
 
         private VersionTwoToVersionThreeMigration(StorageRoot storageRoot) {
-            super(2, 3);
+            super(VERSION_TWO, VERSION_THREE);
             this.storageRoot = storageRoot;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
@@ -64,7 +64,7 @@ abstract class RoomAppDatabase extends RoomDatabase {
 
         private final StorageRoot storageRoot;
 
-        private VersionTwoToVersionThreeMigration(StorageRoot storageRoot) {
+        VersionTwoToVersionThreeMigration(StorageRoot storageRoot) {
             super(VERSION_TWO, VERSION_THREE);
             this.storageRoot = storageRoot;
         }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomBatch.java
@@ -26,4 +26,7 @@ class RoomBatch {
 
     @ColumnInfo(name = "notification_seen")
     public boolean notificationSeen;
+
+    @ColumnInfo(name = "storage_root")
+    public String storageRoot;
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -56,7 +56,8 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
                     DownloadBatchIdCreator.createSanitizedFrom(roomBatch.id),
                     DownloadBatchStatus.Status.from(roomBatch.status),
                     roomBatch.downloadedDateTimeInMillis,
-                    roomBatch.notificationSeen
+                    roomBatch.notificationSeen,
+                    "foo" // TODO:
             );
             batchPersistedList.add(batchPersisted);
         }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -41,6 +41,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
         roomBatch.title = batchPersisted.downloadBatchTitle().asString();
         roomBatch.downloadedDateTimeInMillis = batchPersisted.downloadedDateTimeInMillis();
         roomBatch.notificationSeen = batchPersisted.notificationSeen();
+        roomBatch.storageRoot = batchPersisted.storageRoot();
 
         database.roomBatchDao().insert(roomBatch);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomDownloadsPersistence.java
@@ -57,7 +57,7 @@ final class RoomDownloadsPersistence implements DownloadsPersistence {
                     DownloadBatchStatus.Status.from(roomBatch.status),
                     roomBatch.downloadedDateTimeInMillis,
                     roomBatch.notificationSeen,
-                    "foo" // TODO:
+                    roomBatch.storageRoot
             );
             batchPersistedList.add(batchPersisted);
         }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadsBatchPersistedFixtures.java
@@ -8,6 +8,7 @@ final class DownloadsBatchPersistedFixtures {
     private DownloadBatchTitle downloadBatchTitle = new LiteDownloadBatchTitle("title");
     private long downloadedDateTimeInMillis = 123456789L;
     private boolean notificationSeen = false;
+    private String storageRoot = "/storage/root/";
 
     static DownloadsBatchPersistedFixtures aDownloadsBatchPersisted() {
         return new DownloadsBatchPersistedFixtures();
@@ -47,6 +48,11 @@ final class DownloadsBatchPersistedFixtures {
         return this;
     }
 
+    DownloadsBatchPersistedFixtures withStorageRoot(String storageRoot) {
+        this.storageRoot = storageRoot;
+        return this;
+    }
+
     DownloadsBatchPersisted build() {
         return new DownloadsBatchPersisted() {
             @Override
@@ -72,6 +78,11 @@ final class DownloadsBatchPersistedFixtures {
             @Override
             public boolean notificationSeen() {
                 return notificationSeen;
+            }
+
+            @Override
+            public String storageRoot() {
+                return storageRoot;
             }
         };
     }

--- a/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/InternalDownloadBatchStatusFixtures.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 class InternalDownloadBatchStatusFixtures {
 
     private DownloadBatchTitle downloadBatchTitle = DownloadBatchTitleFixtures.aDownloadBatchTitle().build();
+    private String storageRoot = "/storage/root/";
     private int percentageDownloaded = 10;
     private long bytesDownloaded = 100;
     private long bytesTotalSize = 1000;
@@ -18,6 +19,11 @@ class InternalDownloadBatchStatusFixtures {
 
     InternalDownloadBatchStatusFixtures withDownloadBatchTitle(DownloadBatchTitle downloadBatchTitle) {
         this.downloadBatchTitle = downloadBatchTitle;
+        return this;
+    }
+
+    InternalDownloadBatchStatusFixtures withStorageRoot(String storageRoot) {
+        this.storageRoot = storageRoot;
         return this;
     }
 
@@ -65,6 +71,7 @@ class InternalDownloadBatchStatusFixtures {
         return new LiteDownloadBatchStatus(
                 downloadBatchId,
                 downloadBatchTitle,
+                storageRoot,
                 downloadedDateTimeInMillis,
                 bytesDownloaded,
                 bytesTotalSize,


### PR DESCRIPTION
## Problem
In a client application we want to prevent downloads from being shown when the SD card is removed. This means we need a way to filter the downloads on the client side. We don't want to iterate through all of the files as this is an expensive operation.

## Solution
Add the `storage root` to the `Batch`. This storage root can then be used to filter the downloads in the client application.

## Screen Capture
This shows that the default value is now the internal storage.
![screen shot 2018-07-12 at 20 42 43](https://user-images.githubusercontent.com/3380092/42656461-426af904-8617-11e8-8f0a-6c41f7a36cf4.png)
