### PR TITLE
Fix timer task

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/FixedRateTimerActionScheduler.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FixedRateTimerActionScheduler.java
@@ -45,7 +45,10 @@ class FixedRateTimerActionScheduler implements ActionScheduler {
 
     @Override
     public void cancelAll() {
-        timer.cancel();
+        for (Map.Entry<Action, TimerTask> timerTaskEntry : actionTimerTasks.entrySet()) {
+            TimerTask timerTask = timerTaskEntry.getValue();
+            timerTask.cancel();
+        }
         actionTimerTasks.clear();
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FixedRateTimerActionSchedulerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FixedRateTimerActionSchedulerTest.java
@@ -97,7 +97,9 @@ public class FixedRateTimerActionSchedulerTest {
 
         scheduler.cancelAll();
 
-        verify(timer).cancel();
+        for (Map.Entry<ActionScheduler.Action, TimerTask> actionTimerTaskEntry : actionTimerTasks.entrySet()) {
+            verify(actionTimerTaskEntry.getValue()).cancel();
+        }
     }
 
     @Test


### PR DESCRIPTION
## Problem
Steps to reproduce:

- Open demo
- Start downloading batches
- Pause both batches
- Resume either of the two batches

Expected: Resumes the given batch
Actual: Crash

Reason: When calling `Timer.cancel` that instance of `Timer` cannot be used again. Two options present itself either use a new instance of timer when the previous has been cancelled OR keep the timer constant and just ensure that we remove timer tasks.

## Solution
We went for removing all of the timer tasks 😄 the Timer instance is used until the who tree is eligible for garbage collection. 

## Screen Capture

Before | After
--- | ---
![before_timer mp4](https://user-images.githubusercontent.com/3380092/42765584-45279b9c-8910-11e8-884d-505eee51e5b1.gif) | ![after_timer mp4](https://user-images.githubusercontent.com/3380092/42765583-44f7dfba-8910-11e8-80f2-adabdf683e93.gif)
