### PR TITLE
Update to Queued before persisting, to remove UNKNOWN status

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -83,9 +83,9 @@ class LiteDownloadManagerDownloader {
 
     private Wait.ThenPerform.Action<Void> executeDownload(DownloadBatch downloadBatch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         return () -> {
-            downloadBatch.persistAsync();
             InternalDownloadBatchStatus downloadBatchStatus = downloadBatch.status();
             updateStatusToQueuedIfNeeded(downloadBatchStatus);
+            downloadBatch.persistAsync();
             downloadService.download(downloadBatch, downloadBatchCallback(downloadBatchMap));
             return null;
         };


### PR DESCRIPTION
## Problem
We are seeing crashes on client devices where `DownloadsFilePersistence.getFileStatusFrom` cannot convert `DownloadBatchStatus.Status.UNKNOWN` to an equivalent `FileStatus`. This is fine, we don't want to convert an `UNKNOWN` to anything because this would be an error really for a file. 

After looking some more the `UNKNOWN` is used in a single place, the `DownloadBatchFactory`, to create a `DownloadBatch` before passing it to the `download-manager`. This implies that the `UNKNOWN` is just used as an initial state before it is inserted into the DB. Looking at `LiteDownloadManagerDownloader` this is the case, the `DownloadBatch` is persisted and then the status is immediately updated. 

## Solution
Switch the update and persist so that we always update to `QUEUED` if necessary before persisting into the database. Persisting after the update means we will never read an `UNKNOWN` from the DB which means we will never hit this error. 