### PR TITLE
Add transaction annotation to Room queries.

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/RoomBatchDao.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomBatchDao.java
@@ -5,6 +5,7 @@ import android.arch.persistence.room.Delete;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Transaction;
 import android.arch.persistence.room.Update;
 
 import java.util.List;
@@ -15,9 +16,11 @@ interface RoomBatchDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(RoomBatch roomBatch);
 
+    @Transaction
     @Query("SELECT * FROM RoomBatch")
     List<RoomBatch> loadAll();
 
+    @Transaction
     @Query("SELECT * FROM RoomBatch WHERE RoomBatch.batch_id = :batchId")
     RoomBatch load(String batchId);
 

--- a/library/src/main/java/com/novoda/downloadmanager/RoomFileDao.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomFileDao.java
@@ -4,6 +4,7 @@ import android.arch.persistence.room.Dao;
 import android.arch.persistence.room.Insert;
 import android.arch.persistence.room.OnConflictStrategy;
 import android.arch.persistence.room.Query;
+import android.arch.persistence.room.Transaction;
 
 import java.util.List;
 
@@ -13,9 +14,11 @@ interface RoomFileDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(RoomFile roomFile);
 
+    @Transaction
     @Query("SELECT * FROM RoomFile WHERE RoomFile.batch_id = :batchId")
     List<RoomFile> loadAllFilesFor(String batchId);
 
+    @Transaction
     @Query("SELECT * FROM RoomFile")
     List<RoomFile> loadAllFiles();
 }


### PR DESCRIPTION
## Problem

We're seeing the following error on some client applications:
```
Fatal Exception: android.database.sqlite.SQLiteDatabaseCorruptException
database disk image is malformed (code 11): , while compiling: PRAGMA journal_mode
```
The stacktrace points towards the load batches query. After reading some blog posts by the Room team I stumbled across this post: https://medium.com/google-developers/7-pro-tips-for-room-fbadea4bfbd1 point two suggests implementing transactions for large queries to prevent corruption of the database.

## Solution
Use the `Transaction` annotation for `Dao` query methods. 