### PR TITLE
Migration create index crash 

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -58,7 +58,7 @@ publish {
     userOrg = 'novoda'
     groupId = 'com.novoda'
     artifactId = 'download-manager'
-    publishVersion = 'SNAPSHOT-2.0.53'
+    publishVersion = 'SNAPSHOT-2.0.54'
     desc = 'Download Manager capable of batching, auto-resume, internal and external storage and highly customizable.'
     website = 'https://github.com/novoda/download-manager'
 }

--- a/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
@@ -59,6 +59,7 @@ abstract class RoomAppDatabase extends RoomDatabase {
                                      + "`file_path` TEXT, `total_size` INTEGER NOT NULL, `url` TEXT, `persistence_type` TEXT, "
                                      + "PRIMARY KEY(`file_id`, `batch_id`), FOREIGN KEY(`batch_id`) "
                                      + "REFERENCES `RoomBatch`(`batch_id`) ON UPDATE NO ACTION ON DELETE CASCADE )");
+            database.execSQL("DROP INDEX IF EXISTS `index_RoomFileTemp_batch_id`");
             database.execSQL("CREATE INDEX IF NOT EXISTS `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
             database.execSQL("INSERT INTO RoomFileTemp (file_id, batch_id, file_path, total_size, url, persistence_type) "
                                      + "SELECT file_id, batch_id, file_path, total_size, url, persistence_type FROM RoomFile");
@@ -94,6 +95,7 @@ abstract class RoomAppDatabase extends RoomDatabase {
                                      + "`file_path` TEXT, `total_size` INTEGER NOT NULL, `url` TEXT, "
                                      + "PRIMARY KEY(`file_id`, `batch_id`), FOREIGN KEY(`batch_id`) "
                                      + "REFERENCES `RoomBatch`(`batch_id`) ON UPDATE NO ACTION ON DELETE CASCADE )");
+            database.execSQL("DROP INDEX IF EXISTS `index_RoomFileTemp_batch_id`");
             database.execSQL("CREATE INDEX IF NOT EXISTS `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
             database.execSQL("INSERT INTO RoomFileTemp (file_id, batch_id, file_path, total_size, url) "
                                      + "SELECT file_id, batch_id, file_path, total_size, url FROM RoomFile");

--- a/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
+++ b/library/src/main/java/com/novoda/downloadmanager/RoomAppDatabase.java
@@ -59,10 +59,10 @@ abstract class RoomAppDatabase extends RoomDatabase {
                                      + "`file_path` TEXT, `total_size` INTEGER NOT NULL, `url` TEXT, `persistence_type` TEXT, "
                                      + "PRIMARY KEY(`file_id`, `batch_id`), FOREIGN KEY(`batch_id`) "
                                      + "REFERENCES `RoomBatch`(`batch_id`) ON UPDATE NO ACTION ON DELETE CASCADE )");
-            database.execSQL("CREATE INDEX `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
+            database.execSQL("CREATE INDEX IF NOT EXISTS `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
             database.execSQL("INSERT INTO RoomFileTemp (file_id, batch_id, file_path, total_size, url, persistence_type) "
                                      + "SELECT file_id, batch_id, file_path, total_size, url, persistence_type FROM RoomFile");
-            database.execSQL("DROP TABLE RoomFile");
+            database.execSQL("DROP TABLE IF EXISTS RoomFile");
             database.execSQL("ALTER TABLE RoomFileTemp RENAME TO RoomFile");
         }
     }
@@ -94,10 +94,10 @@ abstract class RoomAppDatabase extends RoomDatabase {
                                      + "`file_path` TEXT, `total_size` INTEGER NOT NULL, `url` TEXT, "
                                      + "PRIMARY KEY(`file_id`, `batch_id`), FOREIGN KEY(`batch_id`) "
                                      + "REFERENCES `RoomBatch`(`batch_id`) ON UPDATE NO ACTION ON DELETE CASCADE )");
-            database.execSQL("CREATE INDEX `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
+            database.execSQL("CREATE INDEX IF NOT EXISTS `index_RoomFileTemp_batch_id` ON `RoomFileTemp` (`batch_id`)");
             database.execSQL("INSERT INTO RoomFileTemp (file_id, batch_id, file_path, total_size, url) "
                                      + "SELECT file_id, batch_id, file_path, total_size, url FROM RoomFile");
-            database.execSQL("DROP TABLE RoomFile");
+            database.execSQL("DROP TABLE IF EXISTS RoomFile");
             database.execSQL("ALTER TABLE RoomFileTemp RENAME TO RoomFile");
         }
     }


### PR DESCRIPTION
## Problem 
We are seeing some crashes when migrating from one version of the RoomDatabase to another 😬 it seems to be occurring because we are attempting to create an index that already exists.

## Solution
Remove the index if it exists and then attempt to create it. I've done the same to the other calls when I have been able to.

⚠️ I've also updated the version number so we can ship when this is merged ⚠️ 