### PR TITLE
Rename lite download manager commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dependencies {
 1. Create a `LiteDownloadManagerCommands`:
 
 ```
-LiteDownloadManagerCommands liteDownloadManagerCommands = DownloadManagerBuilder
+DownloadManager downloadManager = DownloadManagerBuilder
         .newInstance(this, handler, R.mipmap.ic_launcher_round)
         .withLogHandle(new DemoLogHandle())
         .withStorageRequirementRules(StorageRequirementRuleFactory.createByteBasedRule(TWO_HUNDRED_MB_IN_BYTES))
@@ -41,5 +41,5 @@ Batch batch = Batch.with(primaryStorageWithDownloadsSubpackage, DownloadBatchIdC
 3. Schedule the batch for download:
 
 ```
-liteDownloadManagerCommands.download(batch);
+downloadManager.download(batch);
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ dependencies {
 
 ## Simple usage
 
-1. Create a `LiteDownloadManagerCommands`:
+1. Create a `DownloadManager`:
 
 ```
 DownloadManager downloadManager = DownloadManagerBuilder

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/DemoApplication.java
@@ -5,14 +5,14 @@ import android.os.Handler;
 import android.os.Looper;
 
 import com.facebook.stetho.Stetho;
+import com.novoda.downloadmanager.DownloadManager;
 import com.novoda.downloadmanager.DownloadManagerBuilder;
-import com.novoda.downloadmanager.LiteDownloadManagerCommands;
 import com.novoda.downloadmanager.StorageRequirementRuleFactory;
 
 public class DemoApplication extends Application {
 
     private static final int TWO_HUNDRED_MB_IN_BYTES = 209715200;
-    private volatile LiteDownloadManagerCommands liteDownloadManagerCommands;
+    private volatile DownloadManager downloadManager;
 
     @Override
     public void onCreate() {
@@ -24,14 +24,14 @@ public class DemoApplication extends Application {
     private void createLiteDownloadManager() {
         Handler handler = new Handler(Looper.getMainLooper());
 
-        liteDownloadManagerCommands = DownloadManagerBuilder
+        downloadManager = DownloadManagerBuilder
                 .newInstance(this, handler, R.mipmap.ic_launcher_round)
                 .withLogHandle(new DemoLogHandle())
                 .withStorageRequirementRules(StorageRequirementRuleFactory.createByteBasedRule(TWO_HUNDRED_MB_IN_BYTES))
                 .build();
     }
 
-    public LiteDownloadManagerCommands getLiteDownloadManagerCommands() {
-        return liteDownloadManagerCommands;
+    public DownloadManager getDownloadManager() {
+        return downloadManager;
     }
 }

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MainActivity.java
@@ -16,7 +16,7 @@ import com.novoda.downloadmanager.DownloadBatchStatus;
 import com.novoda.downloadmanager.DownloadBatchStatusCallback;
 import com.novoda.downloadmanager.DownloadFileId;
 import com.novoda.downloadmanager.DownloadFileIdCreator;
-import com.novoda.downloadmanager.LiteDownloadManagerCommands;
+import com.novoda.downloadmanager.DownloadManager;
 import com.novoda.downloadmanager.StorageRoot;
 import com.novoda.downloadmanager.StorageRootFactory;
 
@@ -38,7 +38,7 @@ public class MainActivity extends AppCompatActivity {
     private DownloadBatchStatusView downloadBatchStatusViewOne;
     private DownloadBatchStatusView downloadBatchStatusViewTwo;
 
-    private LiteDownloadManagerCommands liteDownloadManagerCommands;
+    private DownloadManager downloadManager;
     private StorageRoot primaryStorageWithDownloadsSubpackage;
 
     @Override
@@ -47,9 +47,9 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         DemoApplication demoApplication = (DemoApplication) getApplicationContext();
-        liteDownloadManagerCommands = demoApplication.getLiteDownloadManagerCommands();
-        liteDownloadManagerCommands.addDownloadBatchCallback(callback);
-        liteDownloadManagerCommands.getAllDownloadBatchStatuses(batchStatusesCallback);
+        downloadManager = demoApplication.getDownloadManager();
+        downloadManager.addDownloadBatchCallback(callback);
+        downloadManager.getAllDownloadBatchStatuses(batchStatusesCallback);
 
         downloadBatchStatusViewOne = findViewById(R.id.batch_1);
         downloadBatchStatusViewTwo = findViewById(R.id.batch_2);
@@ -57,24 +57,24 @@ public class MainActivity extends AppCompatActivity {
         downloadBatchStatusViewOne.setListener(new DownloadBatchStatusView.DownloadBatchStatusListener() {
             @Override
             public void onBatchPaused() {
-                liteDownloadManagerCommands.pause(BATCH_ID_1);
+                downloadManager.pause(BATCH_ID_1);
             }
 
             @Override
             public void onBatchResumed() {
-                liteDownloadManagerCommands.resume(BATCH_ID_1);
+                downloadManager.resume(BATCH_ID_1);
             }
         });
 
         downloadBatchStatusViewTwo.setListener(new DownloadBatchStatusView.DownloadBatchStatusListener() {
             @Override
             public void onBatchPaused() {
-                liteDownloadManagerCommands.pause(BATCH_ID_2);
+                downloadManager.pause(BATCH_ID_2);
             }
 
             @Override
             public void onBatchResumed() {
-                liteDownloadManagerCommands.resume(BATCH_ID_2);
+                downloadManager.resume(BATCH_ID_2);
             }
         });
 
@@ -94,7 +94,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private final CompoundButton.OnCheckedChangeListener wifiOnlyOnCheckedChange = (buttonView, isChecked) -> {
-        LiteDownloadManagerCommands downloadManagerCommands = ((DemoApplication) getApplication()).getLiteDownloadManagerCommands();
+        DownloadManager downloadManagerCommands = ((DemoApplication) getApplication()).getDownloadManager();
         if (isChecked) {
             downloadManagerCommands.updateAllowedConnectionType(ConnectionType.UNMETERED);
         } else {
@@ -107,18 +107,18 @@ public class MainActivity extends AppCompatActivity {
                 .downloadFrom(FIVE_MB_FILE_URL).saveTo("foo/bar", "5mb.zip").withIdentifier(FILE_ID_1).apply()
                 .downloadFrom(TEN_MB_FILE_URL).apply()
                 .build();
-        liteDownloadManagerCommands.download(batch);
+        downloadManager.download(batch);
 
         batch = Batch.with(primaryStorageWithDownloadsSubpackage, BATCH_ID_2, "Batch 2 Title")
                 .downloadFrom(TEN_MB_FILE_URL).apply()
                 .downloadFrom(TWENTY_MB_FILE_URL).apply()
                 .build();
-        liteDownloadManagerCommands.download(batch);
+        downloadManager.download(batch);
     };
 
     private final View.OnClickListener deleteAllOnClick = v -> {
-        liteDownloadManagerCommands.delete(BATCH_ID_1);
-        liteDownloadManagerCommands.delete(BATCH_ID_2);
+        downloadManager.delete(BATCH_ID_1);
+        downloadManager.delete(BATCH_ID_2);
     };
 
     private final View.OnClickListener logFileDirectoryOnClick = v -> {

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MigrationActivity.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/MigrationActivity.java
@@ -9,7 +9,7 @@ import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
-import com.novoda.downloadmanager.LiteDownloadManagerCommands;
+import com.novoda.downloadmanager.DownloadManager;
 import com.novoda.downloadmanager.StorageRootFactory;
 import com.novoda.downloadmanager.demo.migration.MigrationJob;
 
@@ -26,7 +26,7 @@ public class MigrationActivity extends AppCompatActivity {
         setContentView(R.layout.activity_migration);
 
         DemoApplication demoApplication = (DemoApplication) getApplicationContext();
-        LiteDownloadManagerCommands liteDownloadManagerCommands = demoApplication.getLiteDownloadManagerCommands();
+        DownloadManager downloadManager = demoApplication.getDownloadManager();
 
         TextView databaseMigrationUpdates = findViewById(R.id.database_migration_updates);
         Handler migrationCallbackHandler = new Handler(Looper.getMainLooper());
@@ -34,7 +34,7 @@ public class MigrationActivity extends AppCompatActivity {
                 getDatabasePath("downloads.db"),
                 StorageRootFactory.createPrimaryStorageDownloadsDirectoryRoot(getApplicationContext()),
                 new PrimaryStoragePicturesDirectoryRoot(getApplicationContext()),
-                liteDownloadManagerCommands,
+                downloadManager,
                 migrationCallbackHandler,
                 databaseMigrationUpdates::setText
         );

--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/migration/MigrationJob.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/migration/MigrationJob.java
@@ -6,8 +6,8 @@ import android.os.Handler;
 import android.util.Log;
 
 import com.novoda.downloadmanager.CompletedDownloadBatch;
+import com.novoda.downloadmanager.DownloadManager;
 import com.novoda.downloadmanager.FileSizeExtractor;
-import com.novoda.downloadmanager.LiteDownloadManagerCommands;
 import com.novoda.downloadmanager.SqlDatabaseWrapper;
 import com.novoda.downloadmanager.StorageRoot;
 
@@ -22,7 +22,7 @@ public class MigrationJob implements Runnable {
     private final File databaseFile;
     private final StorageRoot primaryStorageWithDownloadsSubpackage;
     private final StorageRoot primaryStorageWithPicturesSubpackage;
-    private final LiteDownloadManagerCommands downloadManager;
+    private final DownloadManager downloadManager;
     private final Handler callbackHandler;
     private final MigrationJobCallback migrationJobCallback;
 
@@ -33,7 +33,7 @@ public class MigrationJob implements Runnable {
     public MigrationJob(File databaseFile,
                         StorageRoot primaryStorageWithDownloadsSubpackage,
                         StorageRoot primaryStorageWithPicturesSubpackage,
-                        LiteDownloadManagerCommands downloadManager,
+                        DownloadManager downloadManager,
                         Handler callbackHandler,
                         MigrationJobCallback migrationJobCallback) {
         this.databaseFile = databaseFile;

--- a/library/src/main/java/com/novoda/downloadmanager/AllBatchStatusesCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/AllBatchStatusesCallback.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager;
 import java.util.List;
 
 /**
- * Given to the asynchronous call {@link LiteDownloadManagerCommands#getAllDownloadBatchStatuses(AllBatchStatusesCallback)},
+ * Given to the asynchronous call {@link DownloadManager#getAllDownloadBatchStatuses(AllBatchStatusesCallback)},
  * to receive a List of the current {@link DownloadBatchStatus} stored by the download-manager.
  */
 public interface AllBatchStatusesCallback {

--- a/library/src/main/java/com/novoda/downloadmanager/AllStoredDownloadsSubmittedCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/AllStoredDownloadsSubmittedCallback.java
@@ -1,7 +1,7 @@
 package com.novoda.downloadmanager;
 
 /**
- * Given to the asynchronous call {@link LiteDownloadManagerCommands#submitAllStoredDownloads(AllStoredDownloadsSubmittedCallback)}
+ * Given to the asynchronous call {@link DownloadManager#submitAllStoredDownloads(AllStoredDownloadsSubmittedCallback)}
  * that notifies when all currently stored download batches have been submitted for download.
  */
 public interface AllStoredDownloadsSubmittedCallback {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusCallback.java
@@ -1,7 +1,7 @@
 package com.novoda.downloadmanager;
 
 /**
- * Given to the asynchronous call {@link LiteDownloadManagerCommands#addDownloadBatchCallback(DownloadBatchStatusCallback)},
+ * Given to the asynchronous call {@link DownloadManager#addDownloadBatchCallback(DownloadBatchStatusCallback)},
  * to receive {@link DownloadBatchStatus} updates as they are emitted by the download-manager.
  */
 public interface DownloadBatchStatusCallback {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFileStatusCallback.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFileStatusCallback.java
@@ -3,7 +3,7 @@ package com.novoda.downloadmanager;
 import android.support.annotation.Nullable;
 
 /**
- * Given to the asynchronous call {@link LiteDownloadManagerCommands#getDownloadFileStatusWithMatching(DownloadBatchId, DownloadFileId, DownloadFileStatusCallback)}
+ * Given to the asynchronous call {@link DownloadManager#getDownloadFileStatusWithMatching(DownloadBatchId, DownloadFileId, DownloadFileStatusCallback)}
  * to receive the {@link DownloadFileStatus} of a {@link DownloadFile} matching the given {@link DownloadBatchId} and {@link DownloadFileId}.
  */
 public interface DownloadFileStatusCallback {

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManager.java
@@ -5,7 +5,7 @@ import android.support.annotation.WorkerThread;
 
 import java.util.List;
 
-public interface LiteDownloadManagerCommands {
+public interface DownloadManager {
 
     /**
      * Downloads a given batch of files.

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -214,7 +214,7 @@ public final class DownloadManagerBuilder {
 
     // It creates the whole LiteDownloadManager, it is a long process!
     @SuppressWarnings("PMD.ExcessiveMethodLength")
-    public LiteDownloadManagerCommands build() {
+    public DownloadManager build() {
         if (logHandle.isPresent()) {
             Logger.attach(logHandle.get());
         }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -44,7 +44,7 @@ public final class DownloadManagerBuilder {
     private FileSizeRequester fileSizeRequester;
     private FileDownloaderCreator fileDownloaderCreator;
     private DownloadService downloadService;
-    private DownloadManager downloadManager;
+    private LiteDownloadManager liteDownloadManager;
     private NotificationCreator<DownloadBatchStatus> notificationCreator;
     private NotificationChannelProvider notificationChannelProvider;
     private ConnectionType connectionTypeAllowed;
@@ -212,7 +212,7 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
-    // It creates the whole DownloadManager, it is a long process!
+    // It creates the whole LiteDownloadManager, it is a long process!
     @SuppressWarnings("PMD.ExcessiveMethodLength")
     public LiteDownloadManagerCommands build() {
         if (logHandle.isPresent()) {
@@ -226,11 +226,11 @@ public final class DownloadManagerBuilder {
                 if (service instanceof LiteDownloadService.DownloadServiceBinder) {
                     LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
                     downloadService = binder.getService();
-                    downloadManager.submitAllStoredDownloads(() -> {
-                        downloadManager.initialise(downloadService);
+                    liteDownloadManager.submitAllStoredDownloads(() -> {
+                        liteDownloadManager.initialise(downloadService);
 
                         if (allowNetworkRecovery) {
-                            DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, downloadManager, connectionTypeAllowed);
+                            DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, liteDownloadManager, connectionTypeAllowed);
                         } else {
                             DownloadsNetworkRecoveryCreator.createDisabled();
                         }
@@ -302,7 +302,7 @@ public final class DownloadManagerBuilder {
                 downloadBatchStatusFilter
         );
 
-        downloadManager = new DownloadManager(
+        liteDownloadManager = new LiteDownloadManager(
                 SERVICE_LOCK,
                 CALLBACK_LOCK,
                 EXECUTOR,
@@ -315,7 +315,7 @@ public final class DownloadManagerBuilder {
                 connectionChecker
         );
 
-        return downloadManager;
+        return liteDownloadManager;
     }
 
     private CallbackThrottleCreator getCallbackThrottleCreator(CallbackThrottleCreator.Type callbackThrottleType,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsNetworkRecoveryCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsNetworkRecoveryCreator.java
@@ -14,8 +14,8 @@ final class DownloadsNetworkRecoveryCreator {
         DownloadsNetworkRecoveryCreator.singleInstance = DownloadsNetworkRecovery.DISABLED;
     }
 
-    static void createEnabled(Context context, DownloadManager downloadManager, ConnectionType connectionType) {
-        DownloadsNetworkRecoveryCreator.singleInstance = new LiteDownloadsNetworkRecoveryEnabled(context, downloadManager, connectionType);
+    static void createEnabled(Context context, LiteDownloadManager liteDownloadManager, ConnectionType connectionType) {
+        DownloadsNetworkRecoveryCreator.singleInstance = new LiteDownloadsNetworkRecoveryEnabled(context, liteDownloadManager, connectionType);
     }
 
     static DownloadsNetworkRecovery getInstance() {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-class DownloadManager implements LiteDownloadManagerCommands {
+class LiteDownloadManager implements LiteDownloadManagerCommands {
 
     private final Object waitForDownloadService;
     private final Object waitForDownloadBatchStatusCallback;
@@ -25,18 +25,18 @@ class DownloadManager implements LiteDownloadManagerCommands {
 
     private DownloadService downloadService;
 
-    // DownloadManager is a complex object.
+    // LiteDownloadManager is a complex object.
     @SuppressWarnings({"checkstyle:parameternumber", "PMD.ExcessiveParameterList"})
-    DownloadManager(Object waitForDownloadService,
-                    Object waitForDownloadBatchStatusCallback,
-                    ExecutorService executor,
-                    Handler callbackHandler,
-                    Map<DownloadBatchId, DownloadBatch> downloadBatchMap,
-                    Set<DownloadBatchStatusCallback> callbacks,
-                    FileOperations fileOperations,
-                    DownloadsBatchPersistence downloadsBatchPersistence,
-                    LiteDownloadManagerDownloader downloader,
-                    ConnectionChecker connectionChecker) {
+    LiteDownloadManager(Object waitForDownloadService,
+                        Object waitForDownloadBatchStatusCallback,
+                        ExecutorService executor,
+                        Handler callbackHandler,
+                        Map<DownloadBatchId, DownloadBatch> downloadBatchMap,
+                        Set<DownloadBatchStatusCallback> callbacks,
+                        FileOperations fileOperations,
+                        DownloadsBatchPersistence downloadsBatchPersistence,
+                        LiteDownloadManagerDownloader downloader,
+                        ConnectionChecker connectionChecker) {
         this.waitForDownloadService = waitForDownloadService;
         this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
@@ -10,7 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
-class LiteDownloadManager implements LiteDownloadManagerCommands {
+class LiteDownloadManager implements DownloadManager {
 
     private final Object waitForDownloadService;
     private final Object waitForDownloadBatchStatusCallback;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadsNetworkRecoveryEnabled.java
@@ -15,10 +15,10 @@ class LiteDownloadsNetworkRecoveryEnabled implements DownloadsNetworkRecovery {
 
     private ConnectionType connectionType;
 
-    LiteDownloadsNetworkRecoveryEnabled(Context context, DownloadManager downloadManager, ConnectionType connectionType) {
+    LiteDownloadsNetworkRecoveryEnabled(Context context, LiteDownloadManager liteDownloadManager, ConnectionType connectionType) {
         this.connectionType = connectionType;
         JobManager jobManager = JobManager.create(context);
-        jobManager.addJobCreator(new LiteJobCreator(downloadManager));
+        jobManager.addJobCreator(new LiteJobCreator(liteDownloadManager));
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteJobCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteJobCreator.java
@@ -7,16 +7,16 @@ class LiteJobCreator implements JobCreator {
 
     static final String TAG = "download-manager-reschedule";
 
-    private final DownloadManager downloadManager;
+    private final LiteDownloadManager liteDownloadManager;
 
-    LiteJobCreator(DownloadManager downloadManager) {
-        this.downloadManager = downloadManager;
+    LiteJobCreator(LiteDownloadManager liteDownloadManager) {
+        this.liteDownloadManager = liteDownloadManager;
     }
 
     @Override
     public Job create(String tag) {
         if (tag.equals(TAG)) {
-            return new LiteJobDownload(downloadManager);
+            return new LiteJobDownload(liteDownloadManager);
         }
 
         return null;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteJobDownload.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteJobDownload.java
@@ -6,16 +6,16 @@ import com.evernote.android.job.Job;
 
 class LiteJobDownload extends Job {
 
-    private final DownloadManager downloadManager;
+    private final LiteDownloadManager liteDownloadManager;
 
-    LiteJobDownload(DownloadManager downloadManager) {
-        this.downloadManager = downloadManager;
+    LiteJobDownload(LiteDownloadManager liteDownloadManager) {
+        this.liteDownloadManager = liteDownloadManager;
     }
 
     @NonNull
     @Override
     protected Result onRunJob(Params params) {
-        downloadManager.submitAllStoredDownloads(() -> Logger.v("LiteJobDownload all jobs submitted"));
+        liteDownloadManager.submitAllStoredDownloads(() -> Logger.v("LiteJobDownload all jobs submitted"));
         Logger.v("LiteJobDownload run network recovery job");
         return Result.SUCCESS;
     }


### PR DESCRIPTION
❌  This is waiting on #426 to be merged ❌ 

## Problem
The `LiteDownloadManagerCommands` interface is a confusing name and is exposed from a `DownloadManagerBuilder`. 

## Solution 
Align the names and call the interface `DownloadManager` and the child `LiteDownloadManager` to match the other classes in the repo.