### PR TITLE
Revert file size request fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    version = '2.0.0'
+    version = '2.0.1'
 }
 
 def teamPropsFile(propsFile) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileSizeRequester.java
@@ -33,12 +33,12 @@ class NetworkFileSizeRequester implements FileSizeRequester {
     }
 
     private long executeRequestFileSize(String url) throws IOException {
-        long fileSize = requestFileSizeThroughBodyRequest(url);
+        long fileSize = requestFileSizeThroughHeaderRequest(url);
         if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
-            Logger.w(String.format("file size body request '%s' returned %s, we'll try with a header request", url, fileSize));
-            fileSize = requestFileSizeThroughHeaderRequest(url);
+            Logger.w(String.format("file size header request '%s' returned %s, we'll try with a body request", url, fileSize));
+            fileSize = requestFileSizeThroughBodyRequest(url);
             if (fileSize == UNKNOWN_CONTENT_LENGTH || fileSize == ZERO_FILE_SIZE) {
-                Logger.w(String.format("file size header request '%s' returned %s", url, fileSize));
+                Logger.w(String.format("file size body request '%s' returned %s", url, fileSize));
             }
         }
 

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileSizeRequesterTest.java
@@ -12,10 +12,10 @@ import static org.mockito.Mockito.mock;
 
 public class NetworkFileSizeRequesterTest {
 
-    private static final int FILE_BYTES = 1000;
     private static final HttpClient.NetworkResponse UNSUCCESSFUL_RESPONSE = aNetworkResponse().withSuccessful(false).build();
-    private static final HttpClient.NetworkResponse SUCCESSFUL_RESPONSE = aNetworkResponse().withHeader("1000").withSuccessful(true).withBodyContentLength(FILE_BYTES).build();
+    private static final HttpClient.NetworkResponse SUCCESSFUL_RESPONSE = aNetworkResponse().withHeader("1000").withSuccessful(true).build();
     private static final String ANY_RAW_URL = "http://example.com";
+    private static final int FILE_BYTES = 1000;
 
     private final HttpClient httpClient = mock(HttpClient.class);
     private final NetworkRequestCreator requestCreator = new NetworkRequestCreator();
@@ -29,7 +29,7 @@ public class NetworkFileSizeRequesterTest {
 
     @Test
     public void returnsUnknownSize_whenHttpClientErrors() throws IOException {
-        given(httpClient.execute(requestCreator.createFileSizeBodyRequest(ANY_RAW_URL))).willThrow(IOException.class);
+        given(httpClient.execute(requestCreator.createFileSizeHeadRequest(ANY_RAW_URL))).willThrow(IOException.class);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 
@@ -48,7 +48,7 @@ public class NetworkFileSizeRequesterTest {
 
     @Test
     public void returnsFileSize_whenResponseSuccessful() throws IOException {
-        given(httpClient.execute(requestCreator.createFileSizeBodyRequest(ANY_RAW_URL))).willReturn(SUCCESSFUL_RESPONSE);
+        given(httpClient.execute(requestCreator.createFileSizeHeadRequest(ANY_RAW_URL))).willReturn(SUCCESSFUL_RESPONSE);
 
         FileSize fileSize = fileSizeRequester.requestFileSize(ANY_RAW_URL);
 


### PR DESCRIPTION
When testing https://github.com/novoda/download-manager/pull/424 in a production app it takes a very long time to transition a download to the queued state. We have surmised that it is this change and are reverting the changes. 

The version has been updated in this PR because we will need to push this update ASAP to avoid affecting other client applications. 