### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.novoda:bintray-release:0.8.1'
-        classpath 'com.novoda:gradle-static-analysis-plugin:0.5.2'
+        classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
     }
 }

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation project(path: ':library')
-    testImplementation 'org.mockito:mockito-core:2.21.0'
+    testImplementation 'org.mockito:mockito-core:2.22.0'
     testImplementation 'com.google.truth:truth:0.41'
 }

--- a/demo-simple/src/main/AndroidManifest.xml
+++ b/demo-simple/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.novoda.downloadmanager.demo">
 
   <application
@@ -7,9 +8,11 @@
     android:allowBackup="false"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
+    android:networkSecurityConfig="@xml/network_security_config"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
-    android:theme="@style/AppTheme">
+    android:theme="@style/AppTheme"
+    tools:targetApi="n">
 
     <activity android:name="com.novoda.downloadmanager.demo.LandingActivity">
       <intent-filter>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.21.0'
+    testImplementation 'org.mockito:mockito-core:2.22.0'
     testImplementation 'com.google.truth:truth:0.41'
 }
 


### PR DESCRIPTION
## Problem
I noticed that our CIs had different configs so the `prb` would pass but then the `snapshot` build would fail.

Turns out the `network_security_config` needs to be specified on the `demo` android manifest too!

## Solution
Update the CI jobs to have the same config and update the project dependencies.

https://github.com/novoda/gradle-static-analysis-plugin/releases
https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md 