### PR TITLE
Wait.Then Holder

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -36,8 +36,8 @@ class DownloadBatchStatusNotificationDispatcher {
         if (notificationIsNotMarkedAsSeenYet(downloadBatchStatus, rawDownloadBatchId)) {
             downloadBatchIdNotificationSeen.add(rawDownloadBatchId);
             Logger.v("start updateNotificationSeenAsync " + rawDownloadBatchId
-                    + ", seen: " + NOTIFICATION_SEEN
-                    + ", status: " + downloadBatchStatus.status());
+                             + ", seen: " + NOTIFICATION_SEEN
+                             + ", status: " + downloadBatchStatus.status());
             notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus, NOTIFICATION_SEEN);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -291,6 +291,8 @@ public final class DownloadManagerBuilder {
 
         DownloadBatchStatusFilter downloadBatchStatusFilter = new DownloadBatchStatusFilter();
 
+        Wait.Holder serviceHolder = new Wait.Holder();
+
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 SERVICE_LOCK,
                 CALLBACK_LOCK,
@@ -303,7 +305,8 @@ public final class DownloadManagerBuilder {
                 connectionChecker,
                 callbacks,
                 callbackThrottleCreator,
-                downloadBatchStatusFilter
+                downloadBatchStatusFilter,
+                serviceHolder
         );
 
         liteDownloadManager = new LiteDownloadManager(
@@ -316,7 +319,8 @@ public final class DownloadManagerBuilder {
                 fileOperations,
                 downloadsBatchPersistence,
                 downloader,
-                connectionChecker
+                connectionChecker,
+                serviceHolder
         );
 
         return liteDownloadManager;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -277,9 +277,11 @@ public final class DownloadManagerBuilder {
             notificationChannelProvider.registerNotificationChannel(applicationContext);
         }
 
+        Wait.Criteria serviceCriteria = new Wait.Criteria();
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(applicationContext);
         ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher = new ServiceNotificationDispatcher<>(
                 SERVICE_LOCK,
+                serviceCriteria,
                 notificationCreator,
                 notificationManager
         );
@@ -290,8 +292,6 @@ public final class DownloadManagerBuilder {
         );
 
         DownloadBatchStatusFilter downloadBatchStatusFilter = new DownloadBatchStatusFilter();
-
-        Wait.Criteria serviceCriteria = new Wait.Criteria();
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 SERVICE_LOCK,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -291,7 +291,7 @@ public final class DownloadManagerBuilder {
 
         DownloadBatchStatusFilter downloadBatchStatusFilter = new DownloadBatchStatusFilter();
 
-        Wait.Holder serviceHolder = new Wait.Holder();
+        Wait.Criteria serviceCriteria = new Wait.Criteria();
 
         LiteDownloadManagerDownloader downloader = new LiteDownloadManagerDownloader(
                 SERVICE_LOCK,
@@ -306,7 +306,7 @@ public final class DownloadManagerBuilder {
                 callbacks,
                 callbackThrottleCreator,
                 downloadBatchStatusFilter,
-                serviceHolder
+                serviceCriteria
         );
 
         liteDownloadManager = new LiteDownloadManager(
@@ -320,7 +320,7 @@ public final class DownloadManagerBuilder {
                 downloadsBatchPersistence,
                 downloader,
                 connectionChecker,
-                serviceHolder
+                serviceCriteria
         );
 
         return liteDownloadManager;

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -25,7 +25,7 @@ class LiteDownloadManagerDownloader {
     private final ConnectionChecker connectionChecker;
     private final CallbackThrottleCreator callbackThrottleCreator;
     private final DownloadBatchStatusFilter downloadBatchStatusFilter;
-    private final Wait.Holder serviceHolder;
+    private final Wait.Criteria serviceCriteria;
 
     private DownloadService downloadService;
 
@@ -43,7 +43,7 @@ class LiteDownloadManagerDownloader {
                                   Set<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator,
                                   DownloadBatchStatusFilter downloadBatchStatusFilter,
-                                  Wait.Holder serviceHolder) {
+                                  Wait.Criteria serviceCriteria) {
         this.waitForDownloadService = waitForDownloadService;
         this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;
@@ -56,7 +56,7 @@ class LiteDownloadManagerDownloader {
         this.callbacks = callbacks;
         this.callbackThrottleCreator = callbackThrottleCreator;
         this.downloadBatchStatusFilter = downloadBatchStatusFilter;
-        this.serviceHolder = serviceHolder;
+        this.serviceCriteria = serviceCriteria;
     }
 
     void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
@@ -83,7 +83,7 @@ class LiteDownloadManagerDownloader {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                Wait.<Void>waitFor(serviceHolder, waitForDownloadService)
+                Wait.<Void>waitFor(serviceCriteria, waitForDownloadService)
                         .thenPerform(executeDownload(downloadBatch, downloadBatchMap));
             }
         });

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -25,6 +25,7 @@ class LiteDownloadManagerDownloader {
     private final ConnectionChecker connectionChecker;
     private final CallbackThrottleCreator callbackThrottleCreator;
     private final DownloadBatchStatusFilter downloadBatchStatusFilter;
+    private final Wait.Holder serviceHolder;
 
     private DownloadService downloadService;
 
@@ -41,7 +42,8 @@ class LiteDownloadManagerDownloader {
                                   ConnectionChecker connectionChecker,
                                   Set<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator,
-                                  DownloadBatchStatusFilter downloadBatchStatusFilter) {
+                                  DownloadBatchStatusFilter downloadBatchStatusFilter,
+                                  Wait.Holder serviceHolder) {
         this.waitForDownloadService = waitForDownloadService;
         this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;
@@ -54,6 +56,7 @@ class LiteDownloadManagerDownloader {
         this.callbacks = callbacks;
         this.callbackThrottleCreator = callbackThrottleCreator;
         this.downloadBatchStatusFilter = downloadBatchStatusFilter;
+        this.serviceHolder = serviceHolder;
     }
 
     void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
@@ -80,7 +83,7 @@ class LiteDownloadManagerDownloader {
         executor.submit(new Runnable() {
             @Override
             public void run() {
-                Wait.<Void>waitFor(downloadService, waitForDownloadService)
+                Wait.<Void>waitFor(serviceHolder, waitForDownloadService)
                         .thenPerform(executeDownload(downloadBatch, downloadBatchMap));
             }
         });

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -14,11 +14,14 @@ class ServiceNotificationDispatcher<T> {
 
     private Wait.Criteria serviceCriteria;
     private int persistentNotificationId;
+    private DownloadManagerService service;
 
     ServiceNotificationDispatcher(Object waitForDownloadService,
+                                  Wait.Criteria serviceCriteria,
                                   NotificationCreator<T> notificationCreator,
                                   NotificationManagerCompat notificationManager) {
         this.waitForDownloadService = waitForDownloadService;
+        this.serviceCriteria = serviceCriteria;
         this.notificationCreator = notificationCreator;
         this.notificationManager = notificationManager;
     }
@@ -67,7 +70,7 @@ class ServiceNotificationDispatcher<T> {
 
     private void updatePersistentNotification(NotificationInformation notificationInformation) {
         persistentNotificationId = notificationInformation.getId();
-        ((DownloadManagerService) serviceCriteria).start(notificationInformation.getId(), notificationInformation.getNotification());
+        service.start(notificationInformation.getId(), notificationInformation.getNotification());
     }
 
     private void stackNotification(NotificationInformation notificationInformation) {
@@ -85,11 +88,12 @@ class ServiceNotificationDispatcher<T> {
 
     private void dismissPersistentIfCurrent(NotificationInformation notificationInformation) {
         if (persistentNotificationId == notificationInformation.getId()) {
-            ((DownloadManagerService) serviceCriteria).stop(true);
+            service.stop(true);
         }
     }
 
     void setService(DownloadManagerService service) {
+        this.service = service;
         serviceCriteria.update(service);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -12,7 +12,7 @@ class ServiceNotificationDispatcher<T> {
     private final NotificationCreator<T> notificationCreator;
     private final NotificationManagerCompat notificationManager;
 
-    private Wait.Holder serviceHolder;
+    private Wait.Criteria serviceCriteria;
     private int persistentNotificationId;
 
     ServiceNotificationDispatcher(Object waitForDownloadService,
@@ -25,7 +25,7 @@ class ServiceNotificationDispatcher<T> {
 
     @WorkerThread
     void updateNotification(T payload) {
-        Wait.<Void>waitFor(serviceHolder, waitForDownloadService)
+        Wait.<Void>waitFor(serviceCriteria, waitForDownloadService)
                 .thenPerform(executeUpdateNotification(payload));
     }
 
@@ -67,7 +67,7 @@ class ServiceNotificationDispatcher<T> {
 
     private void updatePersistentNotification(NotificationInformation notificationInformation) {
         persistentNotificationId = notificationInformation.getId();
-        ((DownloadManagerService) serviceHolder).start(notificationInformation.getId(), notificationInformation.getNotification());
+        ((DownloadManagerService) serviceCriteria).start(notificationInformation.getId(), notificationInformation.getNotification());
     }
 
     private void stackNotification(NotificationInformation notificationInformation) {
@@ -85,11 +85,11 @@ class ServiceNotificationDispatcher<T> {
 
     private void dismissPersistentIfCurrent(NotificationInformation notificationInformation) {
         if (persistentNotificationId == notificationInformation.getId()) {
-            ((DownloadManagerService) serviceHolder).stop(true);
+            ((DownloadManagerService) serviceCriteria).stop(true);
         }
     }
 
     void setService(DownloadManagerService service) {
-        serviceHolder.update(service);
+        serviceCriteria.update(service);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -12,7 +12,7 @@ class ServiceNotificationDispatcher<T> {
     private final NotificationCreator<T> notificationCreator;
     private final NotificationManagerCompat notificationManager;
 
-    private DownloadManagerService service;
+    private Wait.Holder serviceHolder;
     private int persistentNotificationId;
 
     ServiceNotificationDispatcher(Object waitForDownloadService,
@@ -25,7 +25,7 @@ class ServiceNotificationDispatcher<T> {
 
     @WorkerThread
     void updateNotification(T payload) {
-        Wait.<Void>waitFor(service, waitForDownloadService)
+        Wait.<Void>waitFor(serviceHolder, waitForDownloadService)
                 .thenPerform(executeUpdateNotification(payload));
     }
 
@@ -67,7 +67,7 @@ class ServiceNotificationDispatcher<T> {
 
     private void updatePersistentNotification(NotificationInformation notificationInformation) {
         persistentNotificationId = notificationInformation.getId();
-        service.start(notificationInformation.getId(), notificationInformation.getNotification());
+        ((DownloadManagerService) serviceHolder).start(notificationInformation.getId(), notificationInformation.getNotification());
     }
 
     private void stackNotification(NotificationInformation notificationInformation) {
@@ -85,11 +85,11 @@ class ServiceNotificationDispatcher<T> {
 
     private void dismissPersistentIfCurrent(NotificationInformation notificationInformation) {
         if (persistentNotificationId == notificationInformation.getId()) {
-            service.stop(true);
+            ((DownloadManagerService) serviceHolder).stop(true);
         }
     }
 
     void setService(DownloadManagerService service) {
-        this.service = service;
+        serviceHolder.update(service);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -9,10 +9,10 @@ class ServiceNotificationDispatcher<T> {
     private static final String NOTIFICATION_TAG = "download-manager";
 
     private final Object waitForDownloadService;
+    private final Wait.Criteria serviceCriteria;
     private final NotificationCreator<T> notificationCreator;
     private final NotificationManagerCompat notificationManager;
 
-    private Wait.Criteria serviceCriteria;
     private int persistentNotificationId;
     private DownloadManagerService service;
 

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -60,7 +60,7 @@ public class LiteDownloadManagerTest {
     private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
     private final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
     private final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
-    private final Wait.Holder serviceHolder = new Wait.Holder();
+    private final Wait.Criteria serviceCriteria = new Wait.Criteria();
 
     private LiteDownloadManager liteDownloadManager;
     private Map<DownloadBatchId, DownloadBatch> downloadingBatches = new HashMap<>();
@@ -87,7 +87,7 @@ public class LiteDownloadManagerTest {
                 downloadsBatchPersistence,
                 downloadManagerDownloader,
                 connectionChecker,
-                serviceHolder
+                serviceCriteria
         );
 
         setupDownloadBatchesResponse();

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -10,10 +10,17 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.internal.runners.statements.FailOnTimeout;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 
@@ -32,350 +39,333 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
+@RunWith(Enclosed.class)
 public class LiteDownloadManagerTest {
 
-    private static final InternalDownloadBatchStatus BATCH_STATUS = anInternalDownloadsBatchStatus().build();
-    private static final InternalDownloadBatchStatus ADDITIONAL_BATCH_STATUS = anInternalDownloadsBatchStatus().build();
-    private static final DownloadBatchId DOWNLOAD_BATCH_ID = aDownloadBatchId().withRawDownloadBatchId("id01").build();
-    private static final DownloadBatchId ADDITIONAL_DOWNLOAD_BATCH_ID = aDownloadBatchId().withRawDownloadBatchId("id02").build();
-    private static final Batch BATCH = Batch.with(TestStorageRootFactory.create(), DOWNLOAD_BATCH_ID, "title").build();
-    private static final DownloadFileId DOWNLOAD_FILE_ID = aDownloadFileId().withRawDownloadFileId("file_id_01").build();
-    private static final DownloadFileStatus DOWNLOAD_FILE_STATUS = aDownloadFileStatus().withDownloadFileId(DOWNLOAD_FILE_ID).build();
-    private static final ConnectionType ANY_CONNECTION_TYPE = ConnectionType.METERED;
-
-    private final AllStoredDownloadsSubmittedCallback allStoredDownloadsSubmittedCallback = mock(AllStoredDownloadsSubmittedCallback.class);
-    private final AllBatchStatusesCallback allBatchStatusesCallback = mock(AllBatchStatusesCallback.class);
-    private final DownloadFileStatusCallback downloadFileStatusCallback = mock(DownloadFileStatusCallback.class);
-    private final DownloadService downloadService = mock(DownloadService.class);
-    private final Object serviceLock = spy(new Object());
-    private final Object callbackLock = spy(new Object());
-    private final ExecutorService executorService = mock(ExecutorService.class);
-    private final Handler handler = mock(Handler.class);
-    private final DownloadBatch downloadBatch = mock(DownloadBatch.class);
-    private final DownloadBatch additionalDownloadBatch = mock(DownloadBatch.class);
-    private final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
-    private final FileOperations fileOperations = mock(FileOperations.class);
-    private final FileDownloader fileDownloader = mock(FileDownloader.class);
-    private final FileDownloaderCreator fileDownloaderCreator = mock(FileDownloaderCreator.class);
-    private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
-    private final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
-    private final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
-    private final Wait.Criteria serviceCriteria = new Wait.Criteria();
-
-    private LiteDownloadManager liteDownloadManager;
-    private Map<DownloadBatchId, DownloadBatch> downloadingBatches = new HashMap<>();
-    private List<DownloadBatchStatus> downloadBatchStatuses = new ArrayList<>();
-    private Set<DownloadBatchStatusCallback> downloadBatchCallbacks = new CopyOnWriteArraySet<>();
-    private DownloadFileStatus downloadFileStatus = null;
-
-    @Before
-    public void setUp() {
-        downloadingBatches = new HashMap<>();
-        downloadingBatches.put(DOWNLOAD_BATCH_ID, downloadBatch);
-        downloadingBatches.put(ADDITIONAL_DOWNLOAD_BATCH_ID, additionalDownloadBatch);
-
-        downloadBatchCallbacks.add(downloadBatchCallback);
-
-        liteDownloadManager = new LiteDownloadManager(
-                serviceLock,
-                callbackLock,
-                executorService,
-                handler,
-                downloadingBatches,
-                downloadBatchCallbacks,
-                fileOperations,
-                downloadsBatchPersistence,
-                downloadManagerDownloader,
-                connectionChecker,
-                serviceCriteria
-        );
-
-        setupDownloadBatchesResponse();
-        setupDownloadBatchStatusesResponse();
-        setupDownloadStatusResponse();
-        setupNetworkRecoveryCreator();
-        setupFileOperations();
-
-        given(downloadBatch.status()).willReturn(BATCH_STATUS);
-        given(downloadBatch.downloadFileStatusWith(DOWNLOAD_FILE_ID)).willReturn(DOWNLOAD_FILE_STATUS);
-        given(additionalDownloadBatch.downloadFileStatusWith(DOWNLOAD_FILE_ID)).willReturn(DOWNLOAD_FILE_STATUS);
-        given(additionalDownloadBatch.status()).willReturn(ADDITIONAL_BATCH_STATUS);
-
-        willAnswer(invocation -> {
-            ((Runnable) invocation.getArgument(0)).run();
-            return null;
-        }).given(executorService).submit(any(Runnable.class));
-
-        willAnswer(invocation -> {
-            ((Runnable) invocation.getArgument(0)).run();
-            return null;
-        }).given(handler).post(any(Runnable.class));
-    }
-
-    private void setupDownloadBatchesResponse() {
-        willAnswer(invocation -> {
-            DownloadsBatchPersistence.LoadBatchesCallback loadBatchesCallback = invocation.getArgument(1);
-            loadBatchesCallback.onLoaded(Arrays.asList(downloadBatch, additionalDownloadBatch));
-            return null;
-        }).given(downloadsBatchPersistence).loadAsync(any(FileOperations.class), any(DownloadsBatchPersistence.LoadBatchesCallback.class));
-    }
-
-    private void setupDownloadBatchStatusesResponse() {
-        willAnswer(invocation -> {
-            downloadBatchStatuses = invocation.getArgument(0);
-            return null;
-        }).given(allBatchStatusesCallback).onReceived(ArgumentMatchers.anyList());
-    }
-
-    private void setupDownloadStatusResponse() {
-        willAnswer(invocation -> {
-            downloadFileStatus = invocation.getArgument(0);
-            return null;
-        }).given(downloadFileStatusCallback).onReceived(any(DownloadFileStatus.class));
-    }
-
-    private void setupNetworkRecoveryCreator() {
-        DownloadsNetworkRecoveryCreator.createDisabled();
-    }
-
-    private void setupFileOperations() {
-        given(fileOperations.fileDownloaderCreator()).willReturn(fileDownloaderCreator);
-        given(fileDownloaderCreator.create()).willReturn(fileDownloader);
-    }
-
-    @Test
-    public void setDownloadService_whenInitialising() {
-        liteDownloadManager.initialise(downloadService);
-
-        verify(downloadManagerDownloader).setDownloadService(downloadService);
-    }
-
-    @Test(timeout = 500)
-    public void notifyAll_whenInitialising() throws InterruptedException {
-        synchronized (serviceLock) {
-            Executors.newSingleThreadExecutor().submit(() -> liteDownloadManager.initialise(downloadService));
-
-            serviceLock.wait();
-        }
-    }
-
-    @Test
-    public void triggersDownloadOfBatches_whenSubmittingAllStoredDownloads() {
-        liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
-
-        InOrder inOrder = inOrder(downloadManagerDownloader);
-        inOrder.verify(downloadManagerDownloader).download(downloadBatch, downloadingBatches);
-        inOrder.verify(downloadManagerDownloader).download(additionalDownloadBatch, downloadingBatches);
-    }
-
-    @Test
-    public void notifies_whenSubmittingAllStoredDownloads() {
-        liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
-
-        verify(allStoredDownloadsSubmittedCallback).onAllDownloadsSubmitted();
-    }
-
-    @Test
-    public void downloadGivenBatch_whenBatchIsNotAlreadyBeingDownloaded() {
-        downloadingBatches.clear();
-
-        liteDownloadManager.download(BATCH);
-
-        verify(downloadManagerDownloader).download(BATCH, downloadingBatches);
-    }
-
-    @Test
-    public void doesNotDownload_whenBatchIsAlreadyBeingDownloaded() {
-        liteDownloadManager.download(BATCH);
-
-        verify(downloadManagerDownloader, never()).download(BATCH, downloadingBatches);
-    }
-
-    @Test
-    public void doesNotPause_whenBatchIdIsUnknown() {
-        liteDownloadManager.pause(new LiteDownloadBatchId("unknown"));
-
-        verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
-    }
-
-    @Test
-    public void pausesBatch() {
-        liteDownloadManager.pause(DOWNLOAD_BATCH_ID);
-
-        verify(downloadBatch).pause();
-    }
-
-    @Test
-    public void doesNotResume_whenBatchIdIsUnknown() {
-        liteDownloadManager.pause(new LiteDownloadBatchId("unknown"));
-
-        verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
-    }
-
-    @Test
-    public void doesNotResume_whenBatchIsAlreadyDownloading() {
-        given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build());
-
-        liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
-
-        InOrder inOrder = inOrder(downloadBatch);
-        inOrder.verify(downloadBatch).status();
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void resumesBatch() {
-        given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
-
-        liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
-
-        verify(downloadBatch).resume();
-    }
-
-    @Test
-    public void triggersDownload_whenResumingBatch() {
-        given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
-
-        liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
-
-        verify(downloadManagerDownloader).download(downloadBatch, downloadingBatches);
-    }
-
-    @Test
-    public void doesNotDelete_whenBatchIdIsUnknown() {
-        liteDownloadManager.delete(new LiteDownloadBatchId("unknown"));
-
-        verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
-    }
-
-    @Test
-    public void deletesBatch() {
-        liteDownloadManager.delete(DOWNLOAD_BATCH_ID);
-
-        verify(downloadBatch).delete();
-    }
-
-    @Test
-    public void addsCallbackToInternalList() {
-        DownloadBatchStatusCallback additionalDownloadBatchCallback = mock(DownloadBatchStatusCallback.class);
-
-        liteDownloadManager.addDownloadBatchCallback(additionalDownloadBatchCallback);
-
-        assertThat(downloadBatchCallbacks).contains(additionalDownloadBatchCallback);
-    }
-
-    @Test
-    public void removesCallbackFromInternalList() {
-        liteDownloadManager.removeDownloadBatchCallback(downloadBatchCallback);
-
-        assertThat(downloadBatchCallbacks).doesNotContain(downloadBatchCallback);
-    }
-
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenGettingAllBatchStatuses() {
-        initialiseOnAnotherThread();
-
-        liteDownloadManager.getAllDownloadBatchStatuses(allBatchStatusesCallback);
-
-        assertThat(downloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
-    }
-
-    @Test
-    public void getsAllBatchStatuses_whenServiceAlreadyExists() {
-        liteDownloadManager.initialise(mock(DownloadService.class));
-
-        liteDownloadManager.getAllDownloadBatchStatuses(allBatchStatusesCallback);
-
-        assertThat(downloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
-    }
-
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenGettingAllBatchStatusesWithSynchronousCall() {
-        initialiseOnAnotherThread();
-
-        List<DownloadBatchStatus> allDownloadBatchStatuses = liteDownloadManager.getAllDownloadBatchStatuses();
-
-        assertThat(allDownloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
-    }
-
-    @Test
-    public void getsAllBatchStatusesWithSynchronousCall_whenServiceAlreadyExists() {
-        liteDownloadManager.initialise(mock(DownloadService.class));
-
-        List<DownloadBatchStatus> allDownloadBatchStatuses = liteDownloadManager.getAllDownloadBatchStatuses();
-
-        assertThat(allDownloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
-    }
-
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenGettingDownloadStatusWithMatchingId() {
-        initialiseOnAnotherThread();
-
-        liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID, downloadFileStatusCallback);
-
-        assertThat(downloadFileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
-    }
-
-    @Test
-    public void getsDownloadStatusMatchingId_whenServiceAlreadyExists() {
-        liteDownloadManager.initialise(mock(DownloadService.class));
-
-        liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID, downloadFileStatusCallback);
-
-        assertThat(downloadFileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
-    }
-
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenGettingDownloadStatusWithMatchingIdWithSynchronousCall() {
-        initialiseOnAnotherThread();
-
-        DownloadFileStatus fileStatus = liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID);
-
-        assertThat(fileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
-    }
-
-    @Test
-    public void getsDownloadStatusMatchingIdWithSynchronousCall_whenServiceAlreadyExists() {
-        liteDownloadManager.initialise(mock(DownloadService.class));
-
-        DownloadFileStatus fileStatus = liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID);
-
-        assertThat(fileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
-    }
-
-    @Test
-    public void updateAllowedConnectionTypeInConnectionChecker_whenUpdatedInDownloadManager() {
-        liteDownloadManager.updateAllowedConnectionType(ANY_CONNECTION_TYPE);
-
-        verify(connectionChecker).updateAllowedConnectionType(ANY_CONNECTION_TYPE);
-    }
-
-    @Test
-    public void stopFileDownloader_whenUpdatedInDownloadManager_andConnectionTypeNotAllowed() {
-        given(connectionChecker.isAllowedToDownload()).willReturn(false);
-
-        liteDownloadManager.updateAllowedConnectionType(ANY_CONNECTION_TYPE);
-
-        for (DownloadBatch batch : downloadingBatches.values()) {
-            verify(batch).waitForNetwork();
-        }
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void throwException_whenUpdatedWithNullConnectionType() {
-        liteDownloadManager.updateAllowedConnectionType(null);
-    }
-
-    private void initialiseOnAnotherThread() {
-        Executors.newSingleThreadExecutor()
-                .submit(() -> {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
+    public static class ServiceDoesNotExist extends BaseTest {
+
+        @Rule
+        public Timeout timeout = new Timeout(100) {
+            public Statement apply(Statement base, Description description) {
+                return new FailOnTimeout(base, 100) {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        try {
+                            super.evaluate();
+                            throw new TimeoutException();
+                        } catch (Exception e) {
+                        }
                     }
-                    liteDownloadManager.initialise(downloadService);
-                });
+                };
+            }
+        };
+
+        @Test(expected = TimeoutException.class)
+        public void waitsForServiceToExist_whenGettingAllBatchStatuses() {
+            liteDownloadManager.getAllDownloadBatchStatuses(allBatchStatusesCallback);
+        }
+
+        @Test(expected = TimeoutException.class)
+        public void waitsForServiceToExist_whenGettingAllBatchStatusesWithSynchronousCall() {
+            liteDownloadManager.getAllDownloadBatchStatuses();
+        }
+
+        @Test(expected = TimeoutException.class)
+        public void waitsForServiceToExist_whenGettingDownloadStatusWithMatchingId() {
+            liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID, downloadFileStatusCallback);
+        }
+
+        @Test(expected = TimeoutException.class)
+        public void waitsForServiceToExist_whenGettingDownloadStatusWithMatchingIdWithSynchronousCall() {
+            liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID);
+        }
     }
 
+    public static class ServiceExists extends BaseTest {
+
+        @Override
+        public void setUp() {
+            super.setUp();
+            liteDownloadManager.initialise(downloadService);
+        }
+
+        @Test
+        public void setsDownloadService() {
+            verify(downloadManagerDownloader).setDownloadService(downloadService);
+        }
+
+        @Test
+        public void triggersDownloadOfBatches_whenSubmittingAllStoredDownloads() {
+            liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
+
+            InOrder inOrder = inOrder(downloadManagerDownloader);
+            inOrder.verify(downloadManagerDownloader).download(downloadBatch, downloadingBatches);
+            inOrder.verify(downloadManagerDownloader).download(additionalDownloadBatch, downloadingBatches);
+        }
+
+        @Test
+        public void notifies_whenSubmittingAllStoredDownloads() {
+            liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
+
+            verify(allStoredDownloadsSubmittedCallback).onAllDownloadsSubmitted();
+        }
+
+        @Test
+        public void downloadGivenBatch_whenBatchIsNotAlreadyBeingDownloaded() {
+            downloadingBatches.clear();
+
+            liteDownloadManager.download(BATCH);
+
+            verify(downloadManagerDownloader).download(BATCH, downloadingBatches);
+        }
+
+        @Test
+        public void doesNotDownload_whenBatchIsAlreadyBeingDownloaded() {
+            liteDownloadManager.download(BATCH);
+
+            verify(downloadManagerDownloader, never()).download(BATCH, downloadingBatches);
+        }
+
+        @Test
+        public void doesNotPause_whenBatchIdIsUnknown() {
+            liteDownloadManager.pause(new LiteDownloadBatchId("unknown"));
+
+            verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
+        }
+
+        @Test
+        public void pausesBatch() {
+            liteDownloadManager.pause(DOWNLOAD_BATCH_ID);
+
+            verify(downloadBatch).pause();
+        }
+
+        @Test
+        public void doesNotResume_whenBatchIdIsUnknown() {
+            liteDownloadManager.pause(new LiteDownloadBatchId("unknown"));
+
+            verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
+        }
+
+        @Test
+        public void doesNotResume_whenBatchIsAlreadyDownloading() {
+            given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DOWNLOADING).build());
+
+            liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
+
+            InOrder inOrder = inOrder(downloadBatch);
+            inOrder.verify(downloadBatch).status();
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        public void resumesBatch() {
+            given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
+
+            liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
+
+            verify(downloadBatch).resume();
+        }
+
+        @Test
+        public void triggersDownload_whenResumingBatch() {
+            given(downloadBatch.status()).willReturn(anInternalDownloadsBatchStatus().build());
+
+            liteDownloadManager.resume(DOWNLOAD_BATCH_ID);
+
+            verify(downloadManagerDownloader).download(downloadBatch, downloadingBatches);
+        }
+
+        @Test
+        public void doesNotDelete_whenBatchIdIsUnknown() {
+            liteDownloadManager.delete(new LiteDownloadBatchId("unknown"));
+
+            verifyZeroInteractions(downloadBatch, additionalDownloadBatch);
+        }
+
+        @Test
+        public void deletesBatch() {
+            liteDownloadManager.delete(DOWNLOAD_BATCH_ID);
+
+            verify(downloadBatch).delete();
+        }
+
+        @Test
+        public void addsCallbackToInternalList() {
+            DownloadBatchStatusCallback additionalDownloadBatchCallback = mock(DownloadBatchStatusCallback.class);
+
+            liteDownloadManager.addDownloadBatchCallback(additionalDownloadBatchCallback);
+
+            assertThat(downloadBatchCallbacks).contains(additionalDownloadBatchCallback);
+        }
+
+        @Test
+        public void removesCallbackFromInternalList() {
+            liteDownloadManager.removeDownloadBatchCallback(downloadBatchCallback);
+
+            assertThat(downloadBatchCallbacks).doesNotContain(downloadBatchCallback);
+        }
+
+        @Test
+        public void getsAllBatchStatuses_whenServiceAlreadyExists() {
+            liteDownloadManager.getAllDownloadBatchStatuses(allBatchStatusesCallback);
+
+            assertThat(downloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
+        }
+
+        @Test
+        public void getsAllBatchStatusesWithSynchronousCall_whenServiceAlreadyExists() {
+            List<DownloadBatchStatus> allDownloadBatchStatuses = liteDownloadManager.getAllDownloadBatchStatuses();
+
+            assertThat(allDownloadBatchStatuses).containsExactly(BATCH_STATUS, ADDITIONAL_BATCH_STATUS);
+        }
+
+        @Test
+        public void getsDownloadStatusMatchingId_whenServiceAlreadyExists() {
+            liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID, downloadFileStatusCallback);
+
+            assertThat(downloadFileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
+        }
+
+        @Test
+        public void getsDownloadStatusMatchingIdWithSynchronousCall_whenServiceAlreadyExists() {
+            DownloadFileStatus fileStatus = liteDownloadManager.getDownloadFileStatusWithMatching(DOWNLOAD_BATCH_ID, DOWNLOAD_FILE_ID);
+
+            assertThat(fileStatus).isEqualTo(DOWNLOAD_FILE_STATUS);
+        }
+
+        @Test
+        public void updateAllowedConnectionTypeInConnectionChecker_whenUpdatedInDownloadManager() {
+            liteDownloadManager.updateAllowedConnectionType(ANY_CONNECTION_TYPE);
+
+            verify(connectionChecker).updateAllowedConnectionType(ANY_CONNECTION_TYPE);
+        }
+
+        @Test
+        public void stopFileDownloader_whenUpdatedInDownloadManager_andConnectionTypeNotAllowed() {
+            given(connectionChecker.isAllowedToDownload()).willReturn(false);
+
+            liteDownloadManager.updateAllowedConnectionType(ANY_CONNECTION_TYPE);
+
+            for (DownloadBatch batch : downloadingBatches.values()) {
+                verify(batch).waitForNetwork();
+            }
+        }
+
+        @Test(expected = IllegalArgumentException.class)
+        public void throwException_whenUpdatedWithNullConnectionType() {
+            liteDownloadManager.updateAllowedConnectionType(null);
+        }
+    }
+
+    public abstract static class BaseTest {
+        static final InternalDownloadBatchStatus BATCH_STATUS = anInternalDownloadsBatchStatus().build();
+        static final InternalDownloadBatchStatus ADDITIONAL_BATCH_STATUS = anInternalDownloadsBatchStatus().build();
+        static final DownloadBatchId DOWNLOAD_BATCH_ID = aDownloadBatchId().withRawDownloadBatchId("id01").build();
+        static final DownloadBatchId ADDITIONAL_DOWNLOAD_BATCH_ID = aDownloadBatchId().withRawDownloadBatchId("id02").build();
+        static final Batch BATCH = Batch.with(TestStorageRootFactory.create(), DOWNLOAD_BATCH_ID, "title").build();
+        static final DownloadFileId DOWNLOAD_FILE_ID = aDownloadFileId().withRawDownloadFileId("file_id_01").build();
+        static final DownloadFileStatus DOWNLOAD_FILE_STATUS = aDownloadFileStatus().withDownloadFileId(DOWNLOAD_FILE_ID).build();
+        static final ConnectionType ANY_CONNECTION_TYPE = ConnectionType.METERED;
+
+        final AllStoredDownloadsSubmittedCallback allStoredDownloadsSubmittedCallback = mock(AllStoredDownloadsSubmittedCallback.class);
+        final AllBatchStatusesCallback allBatchStatusesCallback = mock(AllBatchStatusesCallback.class);
+        final DownloadFileStatusCallback downloadFileStatusCallback = mock(DownloadFileStatusCallback.class);
+        final DownloadService downloadService = mock(DownloadService.class);
+        final Object serviceLock = spy(new Object());
+        final Object callbackLock = spy(new Object());
+        final ExecutorService executorService = mock(ExecutorService.class);
+        final Handler handler = mock(Handler.class);
+        final DownloadBatch downloadBatch = mock(DownloadBatch.class);
+        final DownloadBatch additionalDownloadBatch = mock(DownloadBatch.class);
+        final DownloadBatchStatusCallback downloadBatchCallback = mock(DownloadBatchStatusCallback.class);
+        final FileOperations fileOperations = mock(FileOperations.class);
+        final FileDownloader fileDownloader = mock(FileDownloader.class);
+        final FileDownloaderCreator fileDownloaderCreator = mock(FileDownloaderCreator.class);
+        final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
+        final LiteDownloadManagerDownloader downloadManagerDownloader = mock(LiteDownloadManagerDownloader.class);
+        final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
+        final Wait.Criteria serviceCriteria = new Wait.Criteria();
+
+        LiteDownloadManager liteDownloadManager;
+        Map<DownloadBatchId, DownloadBatch> downloadingBatches = new HashMap<>();
+        List<DownloadBatchStatus> downloadBatchStatuses = new ArrayList<>();
+        Set<DownloadBatchStatusCallback> downloadBatchCallbacks = new CopyOnWriteArraySet<>();
+        DownloadFileStatus downloadFileStatus = null;
+
+        @Before
+        public void setUp() {
+            downloadingBatches = new HashMap<>();
+            downloadingBatches.put(DOWNLOAD_BATCH_ID, downloadBatch);
+            downloadingBatches.put(ADDITIONAL_DOWNLOAD_BATCH_ID, additionalDownloadBatch);
+
+            downloadBatchCallbacks.add(downloadBatchCallback);
+
+            liteDownloadManager = new LiteDownloadManager(
+                    serviceLock,
+                    callbackLock,
+                    executorService,
+                    handler,
+                    downloadingBatches,
+                    downloadBatchCallbacks,
+                    fileOperations,
+                    downloadsBatchPersistence,
+                    downloadManagerDownloader,
+                    connectionChecker,
+                    serviceCriteria
+            );
+
+            setupDownloadBatchesResponse();
+            setupDownloadBatchStatusesResponse();
+            setupDownloadStatusResponse();
+            setupNetworkRecoveryCreator();
+            setupFileOperations();
+
+            given(downloadBatch.status()).willReturn(BATCH_STATUS);
+            given(downloadBatch.downloadFileStatusWith(DOWNLOAD_FILE_ID)).willReturn(DOWNLOAD_FILE_STATUS);
+            given(additionalDownloadBatch.downloadFileStatusWith(DOWNLOAD_FILE_ID)).willReturn(DOWNLOAD_FILE_STATUS);
+            given(additionalDownloadBatch.status()).willReturn(ADDITIONAL_BATCH_STATUS);
+
+            willAnswer(invocation -> {
+                ((Runnable) invocation.getArgument(0)).run();
+                return null;
+            }).given(executorService).submit(any(Runnable.class));
+
+            willAnswer(invocation -> {
+                ((Runnable) invocation.getArgument(0)).run();
+                return null;
+            }).given(handler).post(any(Runnable.class));
+        }
+
+        private void setupDownloadBatchesResponse() {
+            willAnswer(invocation -> {
+                DownloadsBatchPersistence.LoadBatchesCallback loadBatchesCallback = invocation.getArgument(1);
+                loadBatchesCallback.onLoaded(Arrays.asList(downloadBatch, additionalDownloadBatch));
+                return null;
+            }).given(downloadsBatchPersistence).loadAsync(any(FileOperations.class), any(DownloadsBatchPersistence.LoadBatchesCallback.class));
+        }
+
+        private void setupDownloadBatchStatusesResponse() {
+            willAnswer(invocation -> {
+                downloadBatchStatuses = invocation.getArgument(0);
+                return null;
+            }).given(allBatchStatusesCallback).onReceived(ArgumentMatchers.anyList());
+        }
+
+        private void setupDownloadStatusResponse() {
+            willAnswer(invocation -> {
+                downloadFileStatus = invocation.getArgument(0);
+                return null;
+            }).given(downloadFileStatusCallback).onReceived(any(DownloadFileStatus.class));
+        }
+
+        private void setupNetworkRecoveryCreator() {
+            DownloadsNetworkRecoveryCreator.createDisabled();
+        }
+
+        private void setupFileOperations() {
+            given(fileOperations.fileDownloaderCreator()).willReturn(fileDownloaderCreator);
+            given(fileDownloaderCreator.create()).willReturn(fileDownloader);
+        }
+    }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -54,7 +54,7 @@ public class LiteDownloadManagerTest {
                         try {
                             super.evaluate();
                             throw new TimeoutException();
-                        } catch (Exception e) {
+                        } catch (Exception ignored) {
                         }
                     }
                 };

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Before;
@@ -45,9 +46,9 @@ public class LiteDownloadManagerTest {
     public static class ServiceDoesNotExist extends BaseTest {
 
         @Rule
-        public Timeout timeout = new Timeout(100) {
+        public Timeout timeout = new Timeout(500, TimeUnit.MILLISECONDS) {
             public Statement apply(Statement base, Description description) {
-                return new FailOnTimeout(base, 100) {
+                return new FailOnTimeout(base, 500) {
                     @Override
                     public void evaluate() throws Throwable {
                         try {

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -3,8 +3,17 @@ package com.novoda.downloadmanager;
 import android.app.Notification;
 import android.support.v4.app.NotificationManagerCompat;
 
+import java.util.concurrent.TimeoutException;
+
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.internal.runners.statements.FailOnTimeout;
+import org.junit.rules.Timeout;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.Statement;
 import org.mockito.InOrder;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -22,149 +31,184 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
+@RunWith(Enclosed.class)
 public class ServiceNotificationDispatcherTest {
 
-    private static final String NOTIFICATION_TAG = "download-manager";
+    public static class ServiceDoesNotExist extends BaseTest {
 
-    private static final DownloadBatchStatus DOWNLOAD_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
-    private static final DownloadBatchStatus ANOTHER_DOWNLOAD_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
+        @Rule
+        public Timeout timeout = new Timeout(100) {
+            public Statement apply(Statement base, Description description) {
+                return new FailOnTimeout(base, 100) {
+                    @Override
+                    public void evaluate() throws Throwable {
+                        try {
+                            super.evaluate();
+                            throw new TimeoutException();
+                        } catch (Exception e) {
+                        }
+                    }
+                };
+            }
+        };
 
-    private final Object lock = spy(new Object());
-    private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
-    private final NotificationManagerCompat notificationManager = mock(NotificationManagerCompat.class);
-    private final DownloadManagerService downloadService = mock(DownloadManagerService.class);
-    private final Wait.Criteria serviceCriteria = new Wait.Criteria();
-
-    private ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
-
-    @Before
-    public void setUp() {
-        given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100));
-
-        notificationDispatcher = new ServiceNotificationDispatcher<>(lock, serviceCriteria, notificationCreator, notificationManager);
-        notificationDispatcher.setService(downloadService);
+        @Test(expected = TimeoutException.class)
+        public void waitsForServiceToExist_whenUpdatingNotifications() {
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+        }
     }
 
-    @Test
-    public void showsSinglePersistentNotification() {
-        NotificationInformation notificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+    public static class ServiceExists extends BaseTest {
 
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+        @Before
+        public void setUp() {
+            super.setUp();
+            notificationDispatcher.setService(downloadService);
+        }
 
-        verify(downloadService).start(notificationInfo.getId(), notificationInfo.getNotification());
+        @Test
+        public void showsSinglePersistentNotification() {
+            NotificationInformation notificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            verify(downloadService).start(notificationInfo.getId(), notificationInfo.getNotification());
+        }
+
+        @Test
+        public void stacksDismissibleNotification() {
+            NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_DISMISSIBLE, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            verify(downloadService, never()).stop(true);
+            verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
+        }
+
+        @Test
+        public void stopsService_andStacksDismissibleNotification_ifNotificationWasPersistent() {
+            NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
+            NotificationInformation stackNotificationInfo = createNotificationInfo(STACK_NOTIFICATION_DISMISSIBLE, 100);
+            given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(stackNotificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+            notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
+
+            InOrder inOrder = inOrder(downloadService, notificationManager);
+            inOrder.verify(downloadService).stop(true);
+            inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, stackNotificationInfo.getId(), stackNotificationInfo.getNotification());
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        public void stacksNonDismissibleNotification() {
+            NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            verify(downloadService, never()).stop(true);
+            verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
+        }
+
+        @Test
+        public void stopsService_andStacksNonDismissibleNotification_ifNotificationWasPersistent() {
+            NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
+            NotificationInformation stackNotificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
+            given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(stackNotificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+            notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
+
+            InOrder inOrder = inOrder(downloadService, notificationManager);
+            inOrder.verify(downloadService).stop(true);
+            inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, stackNotificationInfo.getId(), stackNotificationInfo.getNotification());
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        public void addsOngoingEvent_whenStackingNonDismissibleNotification() {
+            NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            assertThat(notificationInfo.getNotification().flags).isEqualTo(Notification.FLAG_ONGOING_EVENT);
+        }
+
+        @Test
+        public void dismissesStackedNotification_whenUpdatingNotification() {
+            NotificationInformation notificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            verify(notificationManager).cancel(NOTIFICATION_TAG, notificationInfo.getId());
+        }
+
+        @Test
+        public void doesNotStopService_whenNotificationIsHidden_andNotificationWasNotPersistent() {
+            NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 0);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
+            NotificationInformation hiddenNotificationInfoWithDifferentId = createNotificationInfo(HIDDEN_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(hiddenNotificationInfoWithDifferentId);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+
+            verify(downloadService, never()).stop(true);
+        }
+
+        @Test
+        public void stopsService_whenNotificationIsHidden_andNotificationWasPersistent() {
+            NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
+            NotificationInformation hiddenNotificationInfo = createNotificationInfo(HIDDEN_NOTIFICATION, 100);
+            given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(hiddenNotificationInfo);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+            notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
+
+            verify(downloadService).stop(true);
+        }
+
+        @Test(timeout = 500)
+        public void waitsForServiceToExist_whenUpdatingNotification() {
+            notificationDispatcher.setService(downloadService);
+
+            notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+        }
     }
 
-    @Test
-    public void stacksDismissibleNotification() {
-        NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_DISMISSIBLE, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
+    public abstract static class BaseTest {
 
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
+        static final String NOTIFICATION_TAG = "download-manager";
 
-        verify(downloadService, never()).stop(true);
-        verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
+        static final DownloadBatchStatus DOWNLOAD_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
+        static final DownloadBatchStatus ANOTHER_DOWNLOAD_BATCH_STATUS = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.QUEUED).build();
+
+        final Object lock = spy(new Object());
+        final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
+        final NotificationManagerCompat notificationManager = mock(NotificationManagerCompat.class);
+        final DownloadManagerService downloadService = mock(DownloadManagerService.class);
+        final Wait.Criteria serviceCriteria = new Wait.Criteria();
+
+        ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
+
+        @Before
+        public void setUp() {
+            given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100));
+
+            notificationDispatcher = new ServiceNotificationDispatcher<>(lock, serviceCriteria, notificationCreator, notificationManager);
+        }
+
+        NotificationInformation createNotificationInfo(NotificationCustomizer.NotificationDisplayState displayState, int id) {
+            return notificationInformation()
+                    .withNotificationDisplayState(displayState)
+                    .withId(id)
+                    .build();
+        }
     }
-
-    @Test
-    public void stopsService_andStacksDismissibleNotification_ifNotificationWasPersistent() {
-        NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
-        NotificationInformation stackNotificationInfo = createNotificationInfo(STACK_NOTIFICATION_DISMISSIBLE, 100);
-        given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(stackNotificationInfo);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-        notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
-
-        InOrder inOrder = inOrder(downloadService, notificationManager);
-        inOrder.verify(downloadService).stop(true);
-        inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, stackNotificationInfo.getId(), stackNotificationInfo.getNotification());
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void stacksNonDismissibleNotification() {
-        NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-
-        verify(downloadService, never()).stop(true);
-        verify(notificationManager).notify(NOTIFICATION_TAG, notificationInfo.getId(), notificationInfo.getNotification());
-    }
-
-    @Test
-    public void stopsService_andStacksNonDismissibleNotification_ifNotificationWasPersistent() {
-        NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
-        NotificationInformation stackNotificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
-        given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(stackNotificationInfo);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-        notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
-
-        InOrder inOrder = inOrder(downloadService, notificationManager);
-        inOrder.verify(downloadService).stop(true);
-        inOrder.verify(notificationManager).notify(NOTIFICATION_TAG, stackNotificationInfo.getId(), stackNotificationInfo.getNotification());
-        inOrder.verifyNoMoreInteractions();
-    }
-
-    @Test
-    public void addsOngoingEvent_whenStackingNonDismissibleNotification() {
-        NotificationInformation notificationInfo = createNotificationInfo(STACK_NOTIFICATION_NOT_DISMISSIBLE, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(notificationInfo);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-
-        assertThat(notificationInfo.getNotification().flags).isEqualTo(Notification.FLAG_ONGOING_EVENT);
-    }
-
-    @Test
-    public void dismissesStackedNotification_whenUpdatingNotification() {
-        NotificationInformation notificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-
-        verify(notificationManager).cancel(NOTIFICATION_TAG, notificationInfo.getId());
-    }
-
-    @Test
-    public void doesNotStopService_whenNotificationIsHidden_andNotificationWasNotPersistent() {
-        NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 0);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
-        NotificationInformation hiddenNotificationInfoWithDifferentId = createNotificationInfo(HIDDEN_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(hiddenNotificationInfoWithDifferentId);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-
-        verify(downloadService, never()).stop(true);
-    }
-
-    @Test
-    public void stopsService_whenNotificationIsHidden_andNotificationWasPersistent() {
-        NotificationInformation persistentNotificationInfo = createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(DOWNLOAD_BATCH_STATUS)).willReturn(persistentNotificationInfo);
-        NotificationInformation hiddenNotificationInfo = createNotificationInfo(HIDDEN_NOTIFICATION, 100);
-        given(notificationCreator.createNotification(ANOTHER_DOWNLOAD_BATCH_STATUS)).willReturn(hiddenNotificationInfo);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-        notificationDispatcher.updateNotification(ANOTHER_DOWNLOAD_BATCH_STATUS);
-
-        verify(downloadService).stop(true);
-    }
-
-    @Test(timeout = 500)
-    public void waitsForServiceToExist_whenUpdatingNotification() {
-        notificationDispatcher.setService(downloadService);
-
-        notificationDispatcher.updateNotification(DOWNLOAD_BATCH_STATUS);
-    }
-
-    private NotificationInformation createNotificationInfo(NotificationCustomizer.NotificationDisplayState displayState, int id) {
-        return notificationInformation()
-                .withNotificationDisplayState(displayState)
-                .withId(id)
-                .build();
-    }
-
 }

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import android.app.Notification;
 import android.support.v4.app.NotificationManagerCompat;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Before;
@@ -37,9 +38,9 @@ public class ServiceNotificationDispatcherTest {
     public static class ServiceDoesNotExist extends BaseTest {
 
         @Rule
-        public Timeout timeout = new Timeout(100) {
+        public Timeout timeout = new Timeout(500, TimeUnit.MILLISECONDS) {
             public Statement apply(Statement base, Description description) {
-                return new FailOnTimeout(base, 100) {
+                return new FailOnTimeout(base, 500) {
                     @Override
                     public void evaluate() throws Throwable {
                         try {

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -33,6 +33,7 @@ public class ServiceNotificationDispatcherTest {
     private final NotificationCreator<DownloadBatchStatus> notificationCreator = mock(NotificationCreator.class);
     private final NotificationManagerCompat notificationManager = mock(NotificationManagerCompat.class);
     private final DownloadManagerService downloadService = mock(DownloadManagerService.class);
+    private final Wait.Criteria serviceCriteria = new Wait.Criteria();
 
     private ServiceNotificationDispatcher<DownloadBatchStatus> notificationDispatcher;
 
@@ -40,7 +41,7 @@ public class ServiceNotificationDispatcherTest {
     public void setUp() {
         given(notificationCreator.createNotification(any(DownloadBatchStatus.class))).willReturn(createNotificationInfo(SINGLE_PERSISTENT_NOTIFICATION, 100));
 
-        notificationDispatcher = new ServiceNotificationDispatcher<>(lock, notificationCreator, notificationManager);
+        notificationDispatcher = new ServiceNotificationDispatcher<>(lock, serviceCriteria, notificationCreator, notificationManager);
         notificationDispatcher.setService(downloadService);
     }
 

--- a/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ServiceNotificationDispatcherTest.java
@@ -46,7 +46,7 @@ public class ServiceNotificationDispatcherTest {
                         try {
                             super.evaluate();
                             throw new TimeoutException();
-                        } catch (Exception e) {
+                        } catch (Exception ignored) {
                         }
                     }
                 };


### PR DESCRIPTION
## Problem
Findbugs has been warning us that our `Wait.Then` does not perform the `wait()` in a loop... This is unlikely to be a problem for the `download-manager` given how and when the service it is waiting on is created. 

The reason this is a problem using an `if` is that the instance we are waiting on can still be `null` on returning to this thread.

```
if(instance == null)
   wait()
```

The `if` is only checked once, on entering, even when another thread notifies. Whereas the `while` will check each time a `notify` is called. 

Using a `while` loop showed that we have another problem.

## Problem 2
When introducing the `while` all of the tests around the `synchronized` blocks then failed. This happens because `Wait.Then` has a `null` reference when being created... this reference is *never* updated and so the `synchronized` block will hang indefinitely. 

## Solution
- Use a `while` loop in place of the `if statement`. 

- Introduce a `Wait.Criteria`, which is essentially a holder and therefore provides a reference to the `Wait.Then` that can be updated when the `service` is initialised. 

- We've added tests to capture both scenarios, when the service is present and absent.