### PR TITLE
Java doc storage requirement rule factory 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0'
+        classpath 'com.android.tools.build:gradle:3.1.4'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -34,7 +34,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.facebook.stetho:stetho:1.5.0'
-    implementation 'com.android.support:appcompat-v7:28.0.0-rc02'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation project(path: ':library')
     testImplementation 'org.mockito:mockito-core:2.22.0'

--- a/library/src/main/java/com/novoda/downloadmanager/ByteBasedRemainingStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ByteBasedRemainingStorageRequirementRule.java
@@ -2,12 +2,12 @@ package com.novoda.downloadmanager;
 
 import java.io.File;
 
-class ByteBasedStorageRequirementRule implements StorageRequirementRule {
+class ByteBasedRemainingStorageRequirementRule implements StorageRequirementRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final long bytesRemainingAfterDownload;
 
-    ByteBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
+    ByteBasedRemainingStorageRequirementRule(StorageCapacityReader storageCapacityReader, long bytesRemainingAfterDownload) {
         this.storageCapacityReader = storageCapacityReader;
         this.bytesRemainingAfterDownload = bytesRemainingAfterDownload;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/PercentageBasedRemainingStorageRequirementRule.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PercentageBasedRemainingStorageRequirementRule.java
@@ -4,13 +4,13 @@ import android.support.annotation.FloatRange;
 
 import java.io.File;
 
-class PercentageBasedStorageRequirementRule implements StorageRequirementRule {
+class PercentageBasedRemainingStorageRequirementRule implements StorageRequirementRule {
 
     private final StorageCapacityReader storageCapacityReader;
     private final float percentageOfStorageRemaining;
 
-    PercentageBasedStorageRequirementRule(StorageCapacityReader storageCapacityReader,
-                                          @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
+    PercentageBasedRemainingStorageRequirementRule(StorageCapacityReader storageCapacityReader,
+                                                   @FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
         this.storageCapacityReader = storageCapacityReader;
         this.percentageOfStorageRemaining = percentageOfStorageRemaining;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -8,11 +8,30 @@ public final class StorageRequirementRuleFactory {
         // Uses static factory methods.
     }
 
+    /**
+     * Creates a storage requirement rule, where the storage bytes must be greater than the
+     * given bytes after a download completes. e.g. if specifying 100mb then the rule will
+     * be violated if the system memory remaining after the download is 99mb, preventing the
+     * download from being started.
+     *
+     * @param bytesRemainingAfterDownload the amount of storage in bytes that must be remaining after a download completes.
+     * @return the storage requirement rule to be evaluated when creating a file.
+     */
     public static StorageRequirementRule createByteBasedRule(long bytesRemainingAfterDownload) {
-        return new ByteBasedStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
+        return new ByteBasedRemainingStorageRequirementRule(new StorageCapacityReader(), bytesRemainingAfterDownload);
     }
 
+    /**
+     * Creates a storage requirement rule, where the storage bytes must be greater than the
+     * a given percentage of the storage bytes after a download completes. e.g. if you specify 10% then the rule
+     * will be violated if the remaining system memory is at 9% of the total system memory, preventing the download
+     * from being started.
+     *
+     * @param percentageOfStorageRemaining the amount of storage, as a percentage of the system storage, that must
+     *                                     be remaining after a download completes.
+     * @return the storage requirement rule to be evaluated when creating a file.
+     */
     public static StorageRequirementRule createPercentageBasedRule(@FloatRange(from = 0.0, to = 0.5) float percentageOfStorageRemaining) {
-        return new PercentageBasedStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
+        return new PercentageBasedRemainingStorageRequirementRule(new StorageCapacityReader(), percentageOfStorageRemaining);
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -10,7 +10,7 @@ public final class StorageRequirementRuleFactory {
 
     /**
      * Creates a storage requirement rule, where the storage bytes must be greater than the
-     * given bytes after a download completes. e.g. if specifying 100MB then the rule will
+     * given bytes after a download completes. E.g. if specifying 100MB then the rule will
      * be violated if the system memory remaining after the download is 99MB, preventing the
      * download from being started.
      *
@@ -23,7 +23,7 @@ public final class StorageRequirementRuleFactory {
 
     /**
      * Creates a storage requirement rule, where the storage bytes must be greater than the
-     * a given percentage of the storage bytes after a download completes. e.g. if you specify 10% then the rule
+     * a given percentage of the storage bytes after a download completes. E.g. if you specify 10% then the rule
      * will be violated if the remaining system memory is at 9% of the total system memory, preventing the download
      * from being started.
      *

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -11,7 +11,7 @@ public final class StorageRequirementRuleFactory {
     /**
      * Creates a storage requirement rule, where the storage bytes must be greater than the
      * given bytes after a download completes. E.g. if specifying 100MB then the rule will
-     * be violated if the system memory remaining after the download is 99MB, preventing the
+     * be violated if the system storage remaining after the download is 99MB, preventing the
      * download from being started.
      *
      * @param bytesRemainingAfterDownload the amount of storage in bytes that must be remaining after a download completes.
@@ -24,7 +24,7 @@ public final class StorageRequirementRuleFactory {
     /**
      * Creates a storage requirement rule, where the storage bytes must be greater than the
      * a given percentage of the storage bytes after a download completes. E.g. if you specify 10% then the rule
-     * will be violated if the remaining system memory is at 9% of the total system memory, preventing the download
+     * will be violated if the remaining system storage is at 9% of the total system storage, preventing the download
      * from being started.
      *
      * @param percentageOfStorageRemaining the amount of storage, as a percentage of the system storage, that must

--- a/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/StorageRequirementRuleFactory.java
@@ -10,8 +10,8 @@ public final class StorageRequirementRuleFactory {
 
     /**
      * Creates a storage requirement rule, where the storage bytes must be greater than the
-     * given bytes after a download completes. e.g. if specifying 100mb then the rule will
-     * be violated if the system memory remaining after the download is 99mb, preventing the
+     * given bytes after a download completes. e.g. if specifying 100MB then the rule will
+     * be violated if the system memory remaining after the download is 99MB, preventing the
      * download from being started.
      *
      * @param bytesRemainingAfterDownload the amount of storage in bytes that must be remaining after a download completes.

--- a/library/src/test/java/com/novoda/downloadmanager/ByteBasedRemainingStorageRequirementRuleTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/ByteBasedRemainingStorageRequirementRuleTest.java
@@ -9,18 +9,19 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class PercentageBasedStorageRequirementRuleTest {
+public class ByteBasedRemainingStorageRequirementRuleTest {
 
     private static final long CAPACITY_ONE_GB_IN_BYTES = 1000000000;
-    private static final long USABLE_TWO_HUNDRED_MB_IN_BYTES = 200000000;
+    private static final long USABLE_THREE_HUNDRED_MB_IN_BYTES = 300000000;
     private static final long REMAINING_OVER_ONE_HUNDRED_MB_IN_BYTES = 100000001;
     private static final long REMAINING_ONE_HUNDRED_MB_IN_BYTES = 100000000;
-    private static final float TEN_PERCENT = 0.1f;
+
+    private static final long TWO_HUNDRED_MB_IN_BYTES_REMAINING = 200000000;
 
     private final FileSize fileSize = mock(FileSize.class);
     private final File file = createFile();
     private final StorageCapacityReader storageCapacityReader = createStorageCapacityReader();
-    private final PercentageBasedStorageRequirementRule storageRequirementRule = new PercentageBasedStorageRequirementRule(storageCapacityReader, TEN_PERCENT);
+    private final ByteBasedRemainingStorageRequirementRule storageRequirementRule = new ByteBasedRemainingStorageRequirementRule(storageCapacityReader, TWO_HUNDRED_MB_IN_BYTES_REMAINING);
 
     @Test
     public void doesNotViolateRule_whenRemainingFileSizeIsLessThanRestriction() {
@@ -43,7 +44,7 @@ public class PercentageBasedStorageRequirementRuleTest {
     private static File createFile() {
         File file = mock(File.class);
         given(file.getPath()).willReturn("any_path");
-        given(file.getUsableSpace()).willReturn(USABLE_TWO_HUNDRED_MB_IN_BYTES);
+        given(file.getUsableSpace()).willReturn(USABLE_THREE_HUNDRED_MB_IN_BYTES);
         return file;
     }
 
@@ -52,5 +53,4 @@ public class PercentageBasedStorageRequirementRuleTest {
         given(storageCapacityReader.storageCapacityInBytes(anyString())).willReturn(CAPACITY_ONE_GB_IN_BYTES);
         return storageCapacityReader;
     }
-
 }

--- a/library/src/test/java/com/novoda/downloadmanager/PercentageBasedRemainingStorageRequirementRuleTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/PercentageBasedRemainingStorageRequirementRuleTest.java
@@ -9,19 +9,18 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
-public class ByteBasedStorageRequirementRuleTest {
+public class PercentageBasedRemainingStorageRequirementRuleTest {
 
     private static final long CAPACITY_ONE_GB_IN_BYTES = 1000000000;
-    private static final long USABLE_THREE_HUNDRED_MB_IN_BYTES = 300000000;
+    private static final long USABLE_TWO_HUNDRED_MB_IN_BYTES = 200000000;
     private static final long REMAINING_OVER_ONE_HUNDRED_MB_IN_BYTES = 100000001;
     private static final long REMAINING_ONE_HUNDRED_MB_IN_BYTES = 100000000;
-
-    private static final long TWO_HUNDRED_MB_IN_BYTES_REMAINING = 200000000;
+    private static final float TEN_PERCENT = 0.1f;
 
     private final FileSize fileSize = mock(FileSize.class);
     private final File file = createFile();
     private final StorageCapacityReader storageCapacityReader = createStorageCapacityReader();
-    private final ByteBasedStorageRequirementRule storageRequirementRule = new ByteBasedStorageRequirementRule(storageCapacityReader, TWO_HUNDRED_MB_IN_BYTES_REMAINING);
+    private final PercentageBasedRemainingStorageRequirementRule storageRequirementRule = new PercentageBasedRemainingStorageRequirementRule(storageCapacityReader, TEN_PERCENT);
 
     @Test
     public void doesNotViolateRule_whenRemainingFileSizeIsLessThanRestriction() {
@@ -44,7 +43,7 @@ public class ByteBasedStorageRequirementRuleTest {
     private static File createFile() {
         File file = mock(File.class);
         given(file.getPath()).willReturn("any_path");
-        given(file.getUsableSpace()).willReturn(USABLE_THREE_HUNDRED_MB_IN_BYTES);
+        given(file.getUsableSpace()).willReturn(USABLE_TWO_HUNDRED_MB_IN_BYTES);
         return file;
     }
 
@@ -53,4 +52,5 @@ public class ByteBasedStorageRequirementRuleTest {
         given(storageCapacityReader.storageCapacityInBytes(anyString())).willReturn(CAPACITY_ONE_GB_IN_BYTES);
         return storageCapacityReader;
     }
+
 }


### PR DESCRIPTION
## Problem
It seems that the storage requirement rules factory does not include any java doc, which might make it confusing. 

## Solution
JavaDoc! Rename the class so that it more explicitly mentions that this is the remaining space. This is a small rename and is super easy for clients as they are protected by our interface and factory. 