### PR TITLE
Use correct total file size for resume request

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.novoda:bintray-release:0.8.1'
         classpath 'com.novoda:gradle-static-analysis-plugin:0.6'
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.novoda.downloadmanager.demo.simple"

--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation project(path: ':library')
-    testImplementation 'org.mockito:mockito-core:2.22.0'
-    testImplementation 'com.google.truth:truth:0.41'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'com.google.truth:truth:0.42'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.23.0'
-    testImplementation 'com.google.truth:truth:0.41'
+    testImplementation 'com.google.truth:truth:0.42'
 }
 
 publish {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,7 +33,7 @@ buildProperties {
 
 android {
     compileSdkVersion 28
-    buildToolsVersion "27.0.3"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 14
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.22.0'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'com.google.truth:truth:0.41'
 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadService.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 public class LiteDownloadService extends Service implements DownloadService {
 
     private static final long TEN_MINUTES_IN_MILLIS = TimeUnit.MINUTES.toMillis(10);
-    private static final String WAKELOCK_TAG = "WakelockTag";
+    private static final String WAKELOCK_TAG = "liteDownloadService:wakelocktag";
 
     private ExecutorService executor;
     private IBinder binder;

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkRequestCreator.java
@@ -26,7 +26,7 @@ class NetworkRequestCreator {
 
     NetworkRequest createDownloadRequestWithDownloadedBytesHeader(String url, long currentSize, long totalSize) {
         Map<String, String> headers = new HashMap<>();
-        String headerValue = String.format(DOWNLOADED_BYTES_VALUE_FORMAT, currentSize, totalSize);
+        String headerValue = String.format(DOWNLOADED_BYTES_VALUE_FORMAT, currentSize, totalSize - 1);
         headers.put("Range", headerValue);
 
         return new LiteNetworkRequest(headers, url, NetworkRequest.Method.GET);

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -23,7 +23,7 @@ public class NetworkRequestCreatorTest {
     }
 
     @Test
-    public void givenSimpleRequest_whenCreatingFileSizeBodyRequest_thenReturnsExpectedResumeRequest() {
+    public void createsFileSizeBodyRequest() {
         NetworkRequest networkRequest = networkRequestCreator.createFileSizeBodyRequest("http://www.google.com");
 
         NetworkRequest expectedNetworkRequest = aNetworkRequest()

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -10,7 +10,7 @@ public class NetworkRequestCreatorTest {
     private final NetworkRequestCreator networkRequestCreator = new NetworkRequestCreator();
 
     @Test
-    public void givenSimpleRequest_whenCreatingFileSizeHeadRequest_thenReturnsExpectedResumeRequest() {
+    public void createsFileSizeHeadRequest() {
         NetworkRequest networkRequest = networkRequestCreator.createFileSizeHeadRequest("http://www.google.com");
 
         NetworkRequest expectedNetworkRequest = aNetworkRequest()

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -36,7 +36,7 @@ public class NetworkRequestCreatorTest {
     }
 
     @Test
-    public void givenSimpleRequest_whenCreatingRequest_thenReturnsExpectedResumeRequest() {
+    public void createsDownloadRequest() {
         NetworkRequest networkRequest = networkRequestCreator.createDownloadRequest("http://www.google.com");
 
         NetworkRequest expectedNetworkRequest = aNetworkRequest()

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -48,7 +48,7 @@ public class NetworkRequestCreatorTest {
     }
 
     @Test
-    public void givenPartiallyDownloadedFile_whenCreatingResumeRequest_thenReturnsExpectedResumeRequest() {
+    public void createsResumeRequest() {
         NetworkRequest networkRequest = networkRequestCreator.createDownloadRequestWithDownloadedBytesHeader(
                 "http://www.google.com",
                 100,

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -1,0 +1,71 @@
+package com.novoda.downloadmanager;
+
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.novoda.downloadmanager.NetworkRequestFixtures.aNetworkRequest;
+
+public class NetworkRequestCreatorTest {
+
+    private final NetworkRequestCreator networkRequestCreator = new NetworkRequestCreator();
+
+    @Test
+    public void givenSimpleRequest_whenCreatingFileSizeHeadRequest_thenReturnsExpectedResumeRequest() {
+        NetworkRequest networkRequest = networkRequestCreator.createFileSizeHeadRequest("http://www.google.com");
+
+        NetworkRequest expectedNetworkRequest = aNetworkRequest()
+                .withHeader("Accept-Encoding", "identity")
+                .withUrl("http://www.google.com")
+                .withMethod(NetworkRequest.Method.HEAD)
+                .build();
+
+        assertThatNetworkRequestsAreEqual(networkRequest, expectedNetworkRequest);
+    }
+
+    @Test
+    public void givenSimpleRequest_whenCreatingFileSizeBodyRequest_thenReturnsExpectedResumeRequest() {
+        NetworkRequest networkRequest = networkRequestCreator.createFileSizeBodyRequest("http://www.google.com");
+
+        NetworkRequest expectedNetworkRequest = aNetworkRequest()
+                .withHeader("Accept-Encoding", "identity")
+                .withUrl("http://www.google.com")
+                .withMethod(NetworkRequest.Method.GET)
+                .build();
+
+        assertThatNetworkRequestsAreEqual(networkRequest, expectedNetworkRequest);
+    }
+
+    @Test
+    public void givenSimpleRequest_whenCreatingRequest_thenReturnsExpectedResumeRequest() {
+        NetworkRequest networkRequest = networkRequestCreator.createDownloadRequest("http://www.google.com");
+
+        NetworkRequest expectedNetworkRequest = aNetworkRequest()
+                .withUrl("http://www.google.com")
+                .withMethod(NetworkRequest.Method.GET)
+                .build();
+
+        assertThatNetworkRequestsAreEqual(networkRequest, expectedNetworkRequest);
+    }
+
+    @Test
+    public void givenPartiallyDownloadedFile_whenCreatingResumeRequest_thenReturnsExpectedResumeRequest() {
+        NetworkRequest networkRequest = networkRequestCreator.createDownloadRequestWithDownloadedBytesHeader(
+                "http://www.google.com",
+                100,
+                500);
+
+        NetworkRequest expectedNetworkRequest = aNetworkRequest()
+                .withHeader("Range", "bytes=100-499")
+                .withUrl("http://www.google.com")
+                .withMethod(NetworkRequest.Method.GET)
+                .build();
+
+        assertThatNetworkRequestsAreEqual(networkRequest, expectedNetworkRequest);
+    }
+
+    private void assertThatNetworkRequestsAreEqual(NetworkRequest networkRequest, NetworkRequest expectedNetworkRequest) {
+        assertThat(networkRequest.headers()).isEqualTo(expectedNetworkRequest.headers());
+        assertThat(networkRequest.method()).isEqualTo(expectedNetworkRequest.method());
+        assertThat(networkRequest.url()).isEqualTo(expectedNetworkRequest.url());
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestCreatorTest.java
@@ -52,7 +52,8 @@ public class NetworkRequestCreatorTest {
         NetworkRequest networkRequest = networkRequestCreator.createDownloadRequestWithDownloadedBytesHeader(
                 "http://www.google.com",
                 100,
-                500);
+                500
+        );
 
         NetworkRequest expectedNetworkRequest = aNetworkRequest()
                 .withHeader("Range", "bytes=100-499")

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
@@ -78,5 +78,14 @@ class NetworkRequestFixtures {
             result = 31 * result + method.hashCode();
             return result;
         }
+
+        @Override
+        public String toString() {
+            return "StubNetworkRequest{" +
+                    "headers=" + headers +
+                    ", url='" + url + '\'' +
+                    ", method=" + method +
+                    '}';
+        }
     }
 }

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
@@ -1,0 +1,62 @@
+package com.novoda.downloadmanager;
+
+import java.util.Hashtable;
+import java.util.Map;
+
+class NetworkRequestFixtures {
+
+    private Map<String, String> headers = new Hashtable<>();
+    private String url = "http://www.google.com";
+    private NetworkRequest.Method method = NetworkRequest.Method.GET;
+
+    static NetworkRequestFixtures aNetworkRequest() {
+        return new NetworkRequestFixtures();
+    }
+
+    NetworkRequestFixtures withHeader(String key, String value) {
+        headers.put(key, value);
+        return this;
+    }
+
+    NetworkRequestFixtures withUrl(String url) {
+        this.url = url;
+        return this;
+    }
+
+    NetworkRequestFixtures withMethod(NetworkRequest.Method method) {
+        this.method = method;
+        return this;
+    }
+
+    NetworkRequest build() {
+        return new StubNetworkRequest(headers, url, method);
+    }
+
+    private static class StubNetworkRequest implements NetworkRequest {
+
+        private final Map<String, String> headers;
+        private final String url;
+        private final Method method;
+
+        private StubNetworkRequest(Map<String, String> headers, String url, Method method) {
+            this.headers = headers;
+            this.url = url;
+            this.method = method;
+        }
+
+        @Override
+        public Map<String, String> headers() {
+            return headers;
+        }
+
+        @Override
+        public String url() {
+            return url;
+        }
+
+        @Override
+        public Method method() {
+            return method;
+        }
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkRequestFixtures.java
@@ -58,5 +58,25 @@ class NetworkRequestFixtures {
         public Method method() {
             return method;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof StubNetworkRequest)) return false;
+
+            StubNetworkRequest that = (StubNetworkRequest) o;
+
+            if (!headers.equals(that.headers)) return false;
+            if (!url.equals(that.url)) return false;
+            return method == that.method;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = headers.hashCode();
+            result = 31 * result + url.hashCode();
+            result = 31 * result + method.hashCode();
+            return result;
+        }
     }
 }


### PR DESCRIPTION
## Problem

Following the issue https://github.com/novoda/download-manager/issues/442 and checking the official specs for the resume request format https://datatracker.ietf.org/doc/rfc7233/?include_text=1 it looks like we have to use the `fileSize - 1` in our request. Currently we use`fileSize`

## Solution

Use `fileSize - 1` for the network resume request and add tests on it

## Screenshots

![video mp4](https://user-images.githubusercontent.com/2845931/47289116-25a1de80-d5f1-11e8-80e0-dfece8f86086.gif)
