### PR TITLE
DLM-454/Swallowing Events

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
@@ -120,6 +120,7 @@ class LiteDownloadManager implements DownloadManager {
         }
 
         downloadBatch.delete();
+        downloadBatchMap.remove(downloadBatchId);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
@@ -66,7 +66,6 @@ class LiteDownloadManager implements DownloadManager {
     private DownloadsBatchPersistence.LoadBatchesCallback loadBatchesCallback(AllStoredDownloadsSubmittedCallback callback) {
         return downloadBatches -> {
             for (DownloadBatch downloadBatch : downloadBatches) {
-                downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
                 downloader.download(downloadBatch, downloadBatchMap);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -69,7 +69,6 @@ class LiteDownloadManagerDownloader {
                 connectionChecker
         );
 
-        downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         executor.submit(downloadBatch::updateTotalSize);
         download(downloadBatch, downloadBatchMap);
     }
@@ -80,11 +79,13 @@ class LiteDownloadManagerDownloader {
             downloadBatchMap.put(downloadBatchId, downloadBatch);
         }
 
+        DownloadBatch batchToDownload = downloadBatchMap.get(downloadBatchId);
+
         executor.submit(new Runnable() {
             @Override
             public void run() {
                 Wait.<Void>waitFor(serviceCriteria, waitForDownloadService)
-                        .thenPerform(executeDownload(downloadBatch, downloadBatchMap));
+                        .thenPerform(executeDownload(batchToDownload, downloadBatchMap));
             }
         });
     }

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
@@ -2,21 +2,21 @@ package com.novoda.downloadmanager;
 
 import android.os.Handler;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -77,12 +77,12 @@ public class LiteDownloadManagerDownloaderTest {
     }
 
     private void setUpBatches() {
-        willReturn(downloadBatchId).given(downloadBatch).getId();
-        willReturn(downloadBatchId).given(anotherDownloadBatchWithTheSameId).getId();
+        given(downloadBatch.getId()).willReturn(downloadBatchId);
+        given(anotherDownloadBatchWithTheSameId.getId()).willReturn(downloadBatchId);
     }
 
     @Test
-    public void addDownloadBatchIntoQueue_whenDownloadingBatchWithNewId() {
+    public void addsDownloadBatchToQueue() {
         downloadingBatches.clear();
 
         downloader.download(downloadBatch, downloadingBatches);
@@ -91,16 +91,7 @@ public class LiteDownloadManagerDownloaderTest {
     }
 
     @Test
-    public void downloadBatchByNewRef_whenDownloadingBatchWithNewId() {
-        downloadingBatches.clear();
-
-        downloader.download(downloadBatch, downloadingBatches);
-
-        verify(downloadService).download(eq(downloadBatch), any());
-    }
-
-    @Test
-    public void doesNotAddDownloadBatchIntoQueue_whenDownloadingBatchWithExistingId() {
+    public void doesNotAddDownloadBatchToQueue_whenIdAlreadyExists() {
         downloadingBatches.put(downloadBatchId, anotherDownloadBatchWithTheSameId);
 
         downloader.download(downloadBatch, downloadingBatches);
@@ -109,7 +100,16 @@ public class LiteDownloadManagerDownloaderTest {
     }
 
     @Test
-    public void downloadBatchByOldRef_whenDownloadingBatchWithExistingId() {
+    public void downloadsBatch() {
+        downloadingBatches.clear();
+
+        downloader.download(downloadBatch, downloadingBatches);
+
+        verify(downloadService).download(eq(downloadBatch), any());
+    }
+
+    @Test
+    public void downloadsBatchByOriginalReference_whenIdAlreadyExists() {
         downloadingBatches.put(downloadBatchId, anotherDownloadBatchWithTheSameId);
 
         downloader.download(downloadBatch, downloadingBatches);

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
@@ -1,0 +1,119 @@
+package com.novoda.downloadmanager;
+
+import android.os.Handler;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class LiteDownloadManagerDownloaderTest {
+
+    private final Object waitForDownloadService = new Object();
+    private final Object waitForDownloadBatchStatusCallback = new Object();
+    private final ExecutorService executor = mock(ExecutorService.class);
+    private final Handler callbackHandler = mock(Handler.class);
+    private final FileOperations fileOperations = mock(FileOperations.class);
+    private final DownloadsBatchPersistence downloadsBatchPersistence = mock(DownloadsBatchPersistence.class);
+    private final DownloadsFilePersistence downloadsFilePersistence = mock(DownloadsFilePersistence.class);
+    private final DownloadBatchStatusNotificationDispatcher notificationDispatcher = mock(DownloadBatchStatusNotificationDispatcher.class);
+    private final ConnectionChecker connectionChecker = mock(ConnectionChecker.class);
+    private final Set<DownloadBatchStatusCallback> callbacks = new HashSet<>();
+    private final CallbackThrottleCreator callbackThrottleCreator = mock(CallbackThrottleCreator.class);
+    private final DownloadBatchStatusFilter downloadBatchStatusFilter = mock(DownloadBatchStatusFilter.class);
+    private final Wait.Criteria serviceCriteria = mock(Wait.Criteria.class);
+    private final DownloadService downloadService = mock(DownloadService.class);
+
+    private final DownloadBatch downloadBatch = mock(DownloadBatch.class, Mockito.RETURNS_DEEP_STUBS);
+    private final DownloadBatch anotherDownloadBatchWithTheSameId = mock(DownloadBatch.class, Mockito.RETURNS_DEEP_STUBS);
+    private final DownloadBatchId downloadBatchId = mock(DownloadBatchId.class);
+
+    private final Map<DownloadBatchId, DownloadBatch> downloadingBatches = new HashMap<>();
+
+    private LiteDownloadManagerDownloader downloader;
+
+    @Before
+    public void setUp() {
+        setUpExecutorService();
+        setUpBatches();
+
+        downloader = new LiteDownloadManagerDownloader(
+                waitForDownloadService,
+                waitForDownloadBatchStatusCallback,
+                executor,
+                callbackHandler,
+                fileOperations,
+                downloadsBatchPersistence,
+                downloadsFilePersistence,
+                notificationDispatcher,
+                connectionChecker,
+                callbacks,
+                callbackThrottleCreator,
+                downloadBatchStatusFilter,
+                serviceCriteria
+        );
+
+        downloader.setDownloadService(downloadService);
+    }
+
+    private void setUpExecutorService() {
+        willAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return null;
+        }).given(executor).submit(any(Runnable.class));
+    }
+
+    private void setUpBatches() {
+        willReturn(downloadBatchId).given(downloadBatch).getId();
+        willReturn(downloadBatchId).given(anotherDownloadBatchWithTheSameId).getId();
+    }
+
+    @Test
+    public void addDownloadBatchIntoQueue_whenDownloadingBatchWithNewId() {
+        downloadingBatches.clear();
+
+        downloader.download(downloadBatch, downloadingBatches);
+
+        assertThat(downloadingBatches).containsEntry(downloadBatchId, downloadBatch);
+    }
+
+    @Test
+    public void downloadBatchByNewRef_whenDownloadingBatchWithNewId() {
+        downloadingBatches.clear();
+
+        downloader.download(downloadBatch, downloadingBatches);
+
+        verify(downloadService).download(eq(downloadBatch), any());
+    }
+
+    @Test
+    public void doesNotAddDownloadBatchIntoQueue_whenDownloadingBatchWithExistingId() {
+        downloadingBatches.put(downloadBatchId, anotherDownloadBatchWithTheSameId);
+
+        downloader.download(downloadBatch, downloadingBatches);
+
+        assertThat(downloadingBatches).doesNotContainEntry(downloadBatchId, downloadBatch);
+    }
+
+    @Test
+    public void downloadBatchByOldRef_whenDownloadingBatchWithExistingId() {
+        downloadingBatches.put(downloadBatchId, anotherDownloadBatchWithTheSameId);
+
+        downloader.download(downloadBatch, downloadingBatches);
+
+        verify(downloadService).download(eq(anotherDownloadBatchWithTheSameId), any());
+    }
+}

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -192,6 +192,13 @@ public class LiteDownloadManagerTest {
         }
 
         @Test
+        public void removesBatchFromMap_whenDeletingBatch() {
+            liteDownloadManager.delete(DOWNLOAD_BATCH_ID);
+
+            assertThat(downloadingBatches).doesNotContainKey(DOWNLOAD_BATCH_ID);
+        }
+
+        @Test
         public void addsCallbackToInternalList() {
             DownloadBatchStatusCallback additionalDownloadBatchCallback = mock(DownloadBatchStatusCallback.class);
 

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -105,6 +105,15 @@ public class LiteDownloadManagerTest {
         }
 
         @Test
+        public void doesNotPutBatchesIntoDownloadsMap_whenSubmittingAllStoredDownloads() {
+            downloadingBatches.clear();
+
+            liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
+
+            assertThat(downloadingBatches).isEmpty();
+        }
+
+        @Test
         public void notifies_whenSubmittingAllStoredDownloads() {
             liteDownloadManager.submitAllStoredDownloads(allStoredDownloadsSubmittedCallback);
 


### PR DESCRIPTION
## Problem 
As per #454 there are inconsistencies when emitting events when queuing multiple times against the executor. After some investigation by @Lingviston and myself we have discovered that it is because of the references we are storing in the `map` and passing to the executor. Let's break it down with a table 

#### Before fix
Batch & Reference | Map | Executor 
--- | --- | ---
Batch 1 - ref 1 | Added (ref 1) | Batch 1 - ref 1
Batch 1 - ref 2 | Replaced (ref 2) | Batch 1 - ref 2

#### After fix
Batch & Reference | Map | Executor 
--- | --- | ---
Batch 1 - ref 1 | Added (ref 1) | Batch 1 - ref 1
Batch 1 - ref 2 | Not replaced (ref 1) | Batch 1 - ref 1

When we perform an action (pause), we are mutating the original ref (ref1) which will pause the download and eventually remove from the executor. If we then force a re-queue, using `submitAll` we queue a new ref (ref2), which replaces the original in the map and queues again on the executor. Essentially wiping the `pause` and saying we want to download again.

## Solution 
When the `map` contains a `DownloadBatch` we should use that to queue against the executor, it represents our mutated `DownloadBatch`, rather than using the new `DownloadBatch` as it is considered `fresh` and doesn't represent the state changes that have occurred in the `download-manager`. This means that we only perform a `put` in two locations, on `download` and on `addCompletedBatch`. 

## Additional
We should also remove a `DownloadBatch` from the internal map when it has been deleted. 

## Drawbacks?
The only thing I can think of is if a client adds the same download batch id for different batches, but that isn't supported anyway 

### Big thanks
Big thank you to @Lingviston, for taking the time to investigate this issue with me, you were a great help! 
