### PR TITLE
Local build thresholds

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
-    implementation 'com.novoda:merlin:1.1.7'
+    implementation 'com.novoda:merlin:1.2.0'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation('android.arch.persistence.room:runtime:1.1.1') {

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -3,8 +3,7 @@ apply plugin: 'com.novoda.static-analysis'
 staticAnalysis {
     penalty {
         maxErrors = 0
-//      Need to address GH Issue #284 before reducing.
-        maxWarnings = 5
+        maxWarnings = 0
     }
 
     checkstyle {


### PR DESCRIPTION
## Problem
Local builds are passing when PRs opened are being failed by the CI, this is because we set a local threshold for local builds but not for PRs. When reducing the number of warnings / errors in the project we should change this threshold accordingly. 

## Solution
Change the threshold for local builds now that there aren't any errors in the build. Use the latest version of `Merlin` to prevent a failure. https://github.com/novoda/merlin/releases/tag/v1.2.0

