### PR TITLE
Lint options

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
-    implementation 'com.novoda:merlin:1.1.7'
+    implementation 'com.novoda:merlin:1.2.0'
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation('android.arch.persistence.room:runtime:1.1.1') {

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -29,6 +29,14 @@ staticAnalysis {
         excludeFilter teamPropsFile('static-analysis/findbugs-excludes.xml')
         includeVariants { variant -> excludeTestAndRelease(variant) }
     }
+
+    lintOptions {
+        lintConfig rootProject.file('team-props/lint-rules/lint-config.xml')
+        checkReleaseBuilds false
+        includeVariants { variant ->
+            variant.name in ['release', 'preProductionGoogleQa']
+        }
+    }
 }
 
 static boolean excludeTestAndRelease(variant) {

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -33,9 +33,7 @@ staticAnalysis {
     lintOptions {
         lintConfig rootProject.file('team-props/lint-rules/lint-config.xml')
         checkReleaseBuilds false
-        includeVariants { variant ->
-            variant.name in ['release', 'preProductionGoogleQa']
-        }
+        includeVariants { variant -> excludeTestAndRelease(variant) }
     }
 }
 

--- a/team-props/static-analysis.gradle
+++ b/team-props/static-analysis.gradle
@@ -3,8 +3,7 @@ apply plugin: 'com.novoda.static-analysis'
 staticAnalysis {
     penalty {
         maxErrors = 0
-//      Need to address GH Issue #284 before reducing.
-        maxWarnings = 5
+        maxWarnings = 0
     }
 
     checkstyle {


### PR DESCRIPTION
## Problem 
In our local static analysis configuration we have not setup `lint` 

## Solution
Add the lint config to the `static-analysis` config.