### PR TITLE
Add support for root base directory

### DIFF
--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -36,8 +36,8 @@ dependencies {
     implementation 'com.facebook.stetho:stetho:1.5.0'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation project(path: ':library')
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation 'com.google.truth:truth:0.42'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -67,9 +67,9 @@ android {
 
 dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
-    implementation 'com.novoda:merlin:1.2.0'
+    implementation 'com.novoda:merlin:1.2.1'
     implementation 'com.facebook.stetho:stetho:1.5.0'
-    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation('android.arch.persistence.room:runtime:1.1.1') {
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'android.arch.core', module: 'runtime'
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.0'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation 'com.google.truth:truth:0.42'
 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -4,13 +4,15 @@ import java.io.File;
 
 final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
+    private static Optional.Predicate<String> rootPath = (it) -> it.equals("/");
+
     private final StorageRoot storageRoot;
     private final DownloadBatchId downloadBatchId;
     private final String networkAddress;
 
     private Optional<DownloadFileId> downloadFileId = Optional.absent();
-    private String path;
-    private String fileName;
+    private Optional<String> path = Optional.absent();
+    private Optional<String> fileName = Optional.absent();
 
     private InternalBatchBuilder parentBuilder;
 
@@ -40,31 +42,19 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
     @Override
     public BatchFileBuilder saveTo(String path, String fileName) {
-        this.path = path;
-        this.fileName = fileName;
+        this.path = Optional.fromNullable(path).filterNot(rootPath);
+        this.fileName = Optional.fromNullable(fileName);
         return this;
     }
 
     @Override
     public BatchBuilder apply() {
-        if (fileName == null) {
-            fileName = FileNameExtractor.extractFrom(networkAddress);
-        }
+        String absolutePath = storageRoot.path() + File.separator
+                + downloadBatchId.rawId() + File.separator
+                + path.map((it) -> it + File.separator).or("")
+                + fileName.getOrElse(() -> FileNameExtractor.extractFrom(networkAddress));
 
-        StringBuilder absolutePath = new StringBuilder(storageRoot.path());
-
-        absolutePath = absolutePath.append(File.separatorChar)
-                .append(downloadBatchId.rawId())
-                .append(File.separatorChar);
-
-        if (path != null) {
-            absolutePath = absolutePath.append(path)
-                    .append(File.separatorChar);
-        }
-
-        absolutePath = absolutePath.append(fileName);
-
-        parentBuilder.withFile(new BatchFile(networkAddress, downloadFileId, absolutePath.toString()));
+        parentBuilder.withFile(new BatchFile(networkAddress, downloadFileId, absolutePath));
         return parentBuilder;
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -4,8 +4,6 @@ import java.io.File;
 
 final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
-    private static Optional.Predicate<String> rootPath = (it) -> it.equals("/");
-
     private final StorageRoot storageRoot;
     private final DownloadBatchId downloadBatchId;
     private final String networkAddress;
@@ -42,7 +40,7 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
     @Override
     public BatchFileBuilder saveTo(String path, String fileName) {
-        this.path = Optional.fromNullable(path).filterNot(rootPath);
+        this.path = Optional.fromNullable(path).filterNot("/"::equals);
         this.fileName = Optional.fromNullable(fileName);
         return this;
     }

--- a/library/src/main/java/com/novoda/downloadmanager/Optional.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Optional.java
@@ -58,11 +58,11 @@ final class Optional<T> {
     }
 
     Optional<T> filter(Predicate<T> condition) {
-        return isPresent() && condition.test(get()) ? this : absent();
+        return isPresent() && condition.isValid(get()) ? this : absent();
     }
 
     Optional<T> filterNot(Predicate<T> condition) {
-        return filter((it) -> !condition.test(it));
+        return filter((it) -> !condition.isValid(it));
     }
 
     <P> Optional<P> map(Func1<T, P> transformation) {
@@ -85,7 +85,7 @@ final class Optional<T> {
 
     interface Predicate<V> {
 
-        boolean test(V value);
+        boolean isValid(V value);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/Optional.java
+++ b/library/src/main/java/com/novoda/downloadmanager/Optional.java
@@ -57,9 +57,35 @@ final class Optional<T> {
         return isPresent() ? this : elseFunc.call();
     }
 
+    Optional<T> filter(Predicate<T> condition) {
+        return isPresent() && condition.test(get()) ? this : absent();
+    }
+
+    Optional<T> filterNot(Predicate<T> condition) {
+        return filter((it) -> !condition.test(it));
+    }
+
+    <P> Optional<P> map(Func1<T, P> transformation) {
+        return isPresent() ? Optional.of(transformation.call(get())) : absent();
+    }
+
+    T getOrElse(Func0<T> elseFunc) {
+        return isPresent() ? get() : elseFunc.call();
+    }
+
     interface Func0<V> {
 
         V call();
+    }
+
+    interface Func1<V, R> {
+
+        R call(V value);
+    }
+
+    interface Predicate<V> {
+
+        boolean test(V value);
     }
 
     @Override

--- a/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/BatchBuilderTest.java
@@ -36,6 +36,18 @@ public class BatchBuilderTest {
         assertThat(batch).isEqualTo(expectedBatch);
     }
 
+    @Test
+    public void acceptsRoot_asBasePath() {
+        Batch batch = Batch.with(TestStorageRootFactory.create(), DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)
+                .downloadFrom("http://example.com/5mb.zip").withIdentifier(DOWNLOAD_FILE_ID).saveTo("/", "5mb.zip").apply()
+                .build();
+
+        BatchFile expectedBatchFile = new BatchFile("http://example.com/5mb.zip", Optional.of(DOWNLOAD_FILE_ID), "root/download_batch_id/5mb.zip");
+        Batch expectedBatch = new Batch(TestStorageRootFactory.create(), DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE, Collections.singletonList(expectedBatchFile));
+
+        assertThat(batch).isEqualTo(expectedBatch);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void throwsException_whenDuplicatedFileIDsAreSupplied() {
         Batch.with(TestStorageRootFactory.create(), DOWNLOAD_BATCH_ID, DOWNLOAD_BATCH_TITLE)


### PR DESCRIPTION
## Problem

When providing `"/"` as the path to use with `saveTo()` we end up with a final location that contains `///` on it.

## Solution

Use `Optional` to make sure we fall back to `absent` when providing a null or root path (using `filterNot`).

Then, when we compile the final path, we map to `path + '/'` or an empty string if absent.

## Rational for other changes

- Removed the use of `StringBuilder` as the compiler replaces `+` with it's own `StringBuilder` and since we are not looping (only case where there is a performance gain) it removes noice. 
- Use `File.separator` instead of `File.separatorChar`because it's shorter and the effective code of `append` for char and String is the same with the diference of calling `length()` on the string. Minimal impact, with easier readability.
- Added a couple of basic `Optional` operators. Why not.
- Also added a test to cover this use case.