### PR TITLE
Add a single dismissible notification

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NotificationCustomizer.java
@@ -32,9 +32,16 @@ public interface NotificationCustomizer<T> {
 
     /**
      * Represents the different ways in which a notification can be displayed to a user.
+     * <p>
+     * SINGLE_PERSISTENT_NOTIFICATION - normally used for DOWNLOADING, bound to a foreground service
+     * SINGLE_DISMISSIBLE_NOTIFICATION - single dismissible notification IN ADDITION to the SINGLE_PERSISTENT_NOTIFICATION for DOWNLOADING
+     * STACK_NOTIFICATION_NOT_DISMISSIBLE - stack notifications but do not allow user to dismiss
+     * STACK_NOTIFICATION_DISMISSIBLE - stack notifications allowing user to dismiss
+     * HIDDEN_NOTIFICATION - do not display a notification
      */
     enum NotificationDisplayState {
         SINGLE_PERSISTENT_NOTIFICATION,
+        SINGLE_DISMISSIBLE_NOTIFICATION,
         STACK_NOTIFICATION_NOT_DISMISSIBLE,
         STACK_NOTIFICATION_DISMISSIBLE,
         HIDDEN_NOTIFICATION

--- a/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ServiceNotificationDispatcher.java
@@ -42,6 +42,10 @@ class ServiceNotificationDispatcher<T> {
                 case SINGLE_PERSISTENT_NOTIFICATION:
                     updatePersistentNotification(notificationInformation);
                     break;
+                case SINGLE_DISMISSIBLE_NOTIFICATION:
+                    notificationManager.cancelAll();
+                    stackNotification(notificationInformation);
+                    break;
                 case STACK_NOTIFICATION_NOT_DISMISSIBLE:
                     stackNotificationNotDismissible(notificationInformation);
                     break;


### PR DESCRIPTION
## Problem 
As per issue #474, clients of the application cannot specify that they want a single dismissible notification. See #474 for discussion and usecase.

## Solution
Add an additional `NotificationDisplayState` called `SINGLE_DISMISSIBLE_NOTIFICATION`, which will cancel all current notifications sent through the notification manager, not the service. This notification should not replace `SINGLE_PERSISTENT_NOTIFICATION` which is designed to operate on a foreground service and keep downloads working, this is additional functionality for the other states i.e. DELETED, DOWNLOADED etc.

## Example
![notifications mp4](https://user-images.githubusercontent.com/3380092/53325784-fd4a2980-38db-11e9-8c61-db927e983f9a.gif)

