### PR TITLE
DLM-472/Create BatchBuilder from Batch

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/BatchBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchBuilder.java
@@ -21,6 +21,12 @@ public interface BatchBuilder {
      */
     Batch build();
 
+    /**
+     * Creates a {@link BatchBuilder} from a {@link Batch}.
+     *
+     * @param batch to create the {@link BatchBuilder} from.
+     * @return {@link BatchBuilder}.
+     */
     static BatchBuilder from(Batch batch) {
         InternalBatchBuilder builder = (InternalBatchBuilder) Batch.with(batch.storageRoot(), batch.downloadBatchId(), batch.title());
         for (BatchFile batchFile : batch.batchFiles()) {

--- a/library/src/main/java/com/novoda/downloadmanager/BatchBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/BatchBuilder.java
@@ -20,4 +20,12 @@ public interface BatchBuilder {
      * @return an instance of {@link Batch}.
      */
     Batch build();
+
+    static BatchBuilder from(Batch batch) {
+        InternalBatchBuilder builder = (InternalBatchBuilder) Batch.with(batch.storageRoot(), batch.downloadBatchId(), batch.title());
+        for (BatchFile batchFile : batch.batchFiles()) {
+            builder.withFile(batchFile);
+        }
+        return builder;
+    }
 }


### PR DESCRIPTION
## Problem
As mentioned in #472, clients may want to be able to add additional files to a download batch builder outside a single flow. At the moment `Batch` is immutable, which is good, but a builder can only be created and used in a single step. 

## Solution 
Create a mechanism where clients can create a `BatchBuilder` from a given `batch`, allowing them to append additional files before posting to the `download-manager`. 