### PR TITLE
DLM-253/Quick Returns

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -22,6 +22,7 @@ class DownloadBatch {
 
     private static final int ZERO_BYTES = 0;
     private static final String STATUS = ", status ";
+    private static final String BATCH = "batch ";
 
     private final Map<DownloadFileId, Long> fileBytesDownloadedMap;
     private final InternalDownloadBatchStatus downloadBatchStatus;
@@ -68,7 +69,7 @@ class DownloadBatch {
 
         updateTotalSize();
 
-        Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+        Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                          + STATUS + downloadBatchStatus.status()
                          + " totalBatchSize " + totalBatchSizeBytes);
 
@@ -79,7 +80,7 @@ class DownloadBatch {
                 downloadBatchRequirementRule,
                 totalBatchSizeBytes
         )) {
-            Logger.v("abort after getting total batch size download " + rawBatchId + STATUS + downloadBatchStatus.status());
+            Logger.v("abort after getting total " + BATCH + "size download " + rawBatchId + STATUS + downloadBatchStatus.status());
             return;
         }
 
@@ -142,7 +143,7 @@ class DownloadBatch {
                                             DownloadsBatchPersistence downloadsBatchPersistence,
                                             DownloadBatchStatusCallback callback) {
         if (downloadBatchStatus.status() == DELETING) {
-            Logger.v("sync delete and mark as deleted batch " + downloadBatchStatus.getDownloadBatchId().rawId());
+            Logger.v("sync delete and mark as deleted " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadBatchStatus.markAsDeleted();
             downloadsBatchPersistence.deleteSync(downloadBatchStatus);
             notifyCallback(callback, downloadBatchStatus);
@@ -163,13 +164,13 @@ class DownloadBatch {
                                             DownloadBatchStatusCallback callback,
                                             DownloadsBatchPersistence downloadsBatchPersistence) {
         if (downloadBatchStatus.status() == DELETING) {
-            Logger.v("abort processNetworkError, the batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " is deleting");
+            Logger.v("abort processNetworkError, the " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId() + " is deleting");
             return;
         }
         downloadBatchStatus.markAsWaitingForNetwork(downloadsBatchPersistence);
         notifyCallback(callback, downloadBatchStatus);
         Logger.v(
-                "scheduleRecovery for batch "
+                "scheduleRecovery for " + BATCH
                         + downloadBatchStatus.getDownloadBatchId().rawId()
                         + STATUS
                         + downloadBatchStatus.status()
@@ -275,7 +276,7 @@ class DownloadBatch {
 
     private static boolean networkError(InternalDownloadBatchStatus downloadBatchStatus) {
         if (downloadBatchStatus.status() == DELETING) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+            Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                              + STATUS + downloadBatchStatus.status()
                              + " abort network error");
             return false;
@@ -291,10 +292,10 @@ class DownloadBatch {
     }
 
     void pause() {
-        Logger.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + STATUS + downloadBatchStatus.status());
+        Logger.v("pause " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId() + STATUS + downloadBatchStatus.status());
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+            Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                              + STATUS + downloadBatchStatus.status()
                              + " abort pause batch");
             return;
@@ -310,7 +311,7 @@ class DownloadBatch {
     void waitForNetwork() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status != DOWNLOADING) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+            Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                              + STATUS + downloadBatchStatus.status()
                              + " abort wait for network");
             return;
@@ -324,7 +325,7 @@ class DownloadBatch {
     void resume() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+            Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                              + STATUS + downloadBatchStatus.status()
                              + " abort resume batch");
             return;
@@ -339,14 +340,14 @@ class DownloadBatch {
     void delete() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == DELETING || status == DELETED) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+            Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                              + STATUS + downloadBatchStatus.status()
                              + " abort delete batch");
             return;
         }
 
         downloadBatchStatus.markAsDeleting();
-        Logger.v("delete request for batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+        Logger.v("delete request for " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
                          + STATUS + downloadBatchStatus.status()
                          + ", should be deleting");
         notifyCallback(callback, downloadBatchStatus);
@@ -356,7 +357,7 @@ class DownloadBatch {
         }
 
         if (status == PAUSED || status == DOWNLOADED || status == WAITING_FOR_NETWORK || status == ERROR) {
-            Logger.v("delete async paused or downloaded batch " + downloadBatchStatus.getDownloadBatchId().rawId());
+            Logger.v("delete async paused or downloaded " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId());
             downloadsBatchPersistence.deleteAsync(downloadBatchStatus, downloadBatchId -> {
                 Logger.v("delete paused or downloaded mark as deleted: " + downloadBatchId.rawId());
                 downloadBatchStatus.markAsDeleted();
@@ -364,7 +365,7 @@ class DownloadBatch {
             });
         }
 
-        Logger.v("delete request for batch end " + downloadBatchStatus.getDownloadBatchId().rawId()
+        Logger.v("delete request for " + BATCH + "end " + downloadBatchStatus.getDownloadBatchId().rawId()
                          + STATUS + downloadBatchStatus.status()
                          + ", should be deleting");
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -8,12 +8,12 @@ import java.util.Map;
 
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DELETING;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADED;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.DOWNLOADING;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.ERROR;
-import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.PAUSED;
 import static com.novoda.downloadmanager.DownloadBatchStatus.Status.QUEUED;
+import static com.novoda.downloadmanager.DownloadBatchStatus.Status.WAITING_FOR_NETWORK;
 import static com.novoda.downloadmanager.DownloadError.Type.REQUIREMENT_RULE_VIOLATED;
 
 // This model knows how to interact with low level components.
@@ -246,6 +246,7 @@ class DownloadBatch {
                 DownloadError downloadError = DownloadErrorFactory.createSizeMismatchError(downloadFileStatus);
                 downloadBatchStatus.markAsError(Optional.of(downloadError), downloadsBatchPersistence);
                 fileCallbackThrottle.update(downloadBatchStatus);
+                Logger.e("Abort fileDownloadCallback: " + downloadError.message());
                 return;
             }
 
@@ -292,6 +293,7 @@ class DownloadBatch {
         Logger.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", " + STATUS + " " + downloadBatchStatus.status());
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
+            Logger.v("abort pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -305,6 +307,7 @@ class DownloadBatch {
     void waitForNetwork() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status != DOWNLOADING) {
+            Logger.v("abort `wait for network` on batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
             return;
         }
 
@@ -316,6 +319,7 @@ class DownloadBatch {
     void resume() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
+            Logger.v("abort resume batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -275,13 +275,13 @@ class DownloadBatch {
     }
 
     private static boolean networkError(InternalDownloadBatchStatus downloadBatchStatus) {
+        DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (downloadBatchStatus.status() == DELETING) {
             Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                             + STATUS + downloadBatchStatus.status()
+                             + STATUS + status
                              + " abort network error");
             return false;
         }
-        DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == WAITING_FOR_NETWORK) {
             return true;
         } else if (status == ERROR) {
@@ -296,7 +296,7 @@ class DownloadBatch {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
             Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                             + STATUS + downloadBatchStatus.status()
+                             + STATUS + status
                              + " abort pause batch");
             return;
         }
@@ -312,7 +312,7 @@ class DownloadBatch {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status != DOWNLOADING) {
             Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                             + STATUS + downloadBatchStatus.status()
+                             + STATUS + status
                              + " abort wait for network");
             return;
         }
@@ -326,7 +326,7 @@ class DownloadBatch {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
             Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                             + STATUS + downloadBatchStatus.status()
+                             + STATUS + status
                              + " abort resume batch");
             return;
         }
@@ -341,14 +341,14 @@ class DownloadBatch {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == DELETING || status == DELETED) {
             Logger.v(BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                             + STATUS + downloadBatchStatus.status()
+                             + STATUS + status
                              + " abort delete batch");
             return;
         }
 
         downloadBatchStatus.markAsDeleting();
         Logger.v("delete request for " + BATCH + downloadBatchStatus.getDownloadBatchId().rawId()
-                         + STATUS + downloadBatchStatus.status()
+                         + STATUS + status
                          + ", should be deleting");
         notifyCallback(callback, downloadBatchStatus);
 
@@ -366,7 +366,7 @@ class DownloadBatch {
         }
 
         Logger.v("delete request for " + BATCH + "end " + downloadBatchStatus.getDownloadBatchId().rawId()
-                         + STATUS + downloadBatchStatus.status()
+                         + STATUS + status
                          + ", should be deleting");
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -275,7 +275,9 @@ class DownloadBatch {
 
     private static boolean networkError(InternalDownloadBatchStatus downloadBatchStatus) {
         if (downloadBatchStatus.status() == DELETING) {
-            Logger.v("abort networkError check because the batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " is deleting");
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                             + STATUS + downloadBatchStatus.status()
+                             + " abort network error");
             return false;
         }
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
@@ -292,7 +294,9 @@ class DownloadBatch {
         Logger.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + STATUS + downloadBatchStatus.status());
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
-            Logger.v("abort pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                             + STATUS + downloadBatchStatus.status()
+                             + " abort pause batch");
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -306,7 +310,9 @@ class DownloadBatch {
     void waitForNetwork() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status != DOWNLOADING) {
-            Logger.v("abort `wait for network` on batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                             + STATUS + downloadBatchStatus.status()
+                             + " abort wait for network");
             return;
         }
 
@@ -318,7 +324,9 @@ class DownloadBatch {
     void resume() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
-            Logger.v("abort resume batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                             + STATUS + downloadBatchStatus.status()
+                             + " abort resume batch");
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
@@ -331,7 +339,9 @@ class DownloadBatch {
     void delete() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == DELETING || status == DELETED) {
-            Logger.v("abort delete batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
+                             + STATUS + downloadBatchStatus.status()
+                             + " abort delete batch");
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -21,7 +21,7 @@ import static com.novoda.downloadmanager.DownloadError.Type.REQUIREMENT_RULE_VIO
 class DownloadBatch {
 
     private static final int ZERO_BYTES = 0;
-    private static final String STATUS = "status";
+    private static final String STATUS = ", status ";
 
     private final Map<DownloadFileId, Long> fileBytesDownloadedMap;
     private final InternalDownloadBatchStatus downloadBatchStatus;
@@ -57,10 +57,10 @@ class DownloadBatch {
 
     void download() {
         String rawBatchId = downloadBatchStatus.getDownloadBatchId().rawId();
-        Logger.v("start sync download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
+        Logger.v("start sync download " + rawBatchId + STATUS + downloadBatchStatus.status());
 
         if (shouldAbortStartingBatch(connectionChecker, callback, downloadBatchStatus, downloadsBatchPersistence)) {
-            Logger.v("abort starting download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
+            Logger.v("abort starting download " + rawBatchId + STATUS + downloadBatchStatus.status());
             return;
         }
 
@@ -69,7 +69,7 @@ class DownloadBatch {
         updateTotalSize();
 
         Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                         + " " + STATUS + " " + downloadBatchStatus.status()
+                         + STATUS + downloadBatchStatus.status()
                          + " totalBatchSize " + totalBatchSizeBytes);
 
         if (shouldAbortAfterGettingTotalBatchSize(
@@ -79,7 +79,7 @@ class DownloadBatch {
                 downloadBatchRequirementRule,
                 totalBatchSizeBytes
         )) {
-            Logger.v("abort after getting total batch size download " + rawBatchId + ", " + STATUS + " " + downloadBatchStatus.status());
+            Logger.v("abort after getting total batch size download " + rawBatchId + STATUS + downloadBatchStatus.status());
             return;
         }
 
@@ -171,9 +171,8 @@ class DownloadBatch {
         Logger.v(
                 "scheduleRecovery for batch "
                         + downloadBatchStatus.getDownloadBatchId().rawId()
-                        + ", "
                         + STATUS
-                        + " " + downloadBatchStatus.status()
+                        + downloadBatchStatus.status()
         );
         DownloadsNetworkRecoveryCreator.getInstance().scheduleRecovery();
     }
@@ -290,10 +289,10 @@ class DownloadBatch {
     }
 
     void pause() {
-        Logger.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + ", " + STATUS + " " + downloadBatchStatus.status());
+        Logger.v("pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + STATUS + downloadBatchStatus.status());
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == PAUSED || status == DOWNLOADED) {
-            Logger.v("abort pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
+            Logger.v("abort pause batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
             return;
         }
         downloadBatchStatus.markAsPaused(downloadsBatchPersistence);
@@ -307,7 +306,7 @@ class DownloadBatch {
     void waitForNetwork() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status != DOWNLOADING) {
-            Logger.v("abort `wait for network` on batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
+            Logger.v("abort `wait for network` on batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
             return;
         }
 
@@ -319,7 +318,7 @@ class DownloadBatch {
     void resume() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == QUEUED || status == DOWNLOADING || status == DOWNLOADED) {
-            Logger.v("abort resume batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
+            Logger.v("abort resume batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
             return;
         }
         downloadBatchStatus.markAsQueued(downloadsBatchPersistence);
@@ -332,13 +331,13 @@ class DownloadBatch {
     void delete() {
         DownloadBatchStatus.Status status = downloadBatchStatus.status();
         if (status == DELETING || status == DELETED) {
-            Logger.v("abort delete batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the " + STATUS + " is " + status);
+            Logger.v("abort delete batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " because the status is " + status);
             return;
         }
 
         downloadBatchStatus.markAsDeleting();
         Logger.v("delete request for batch " + downloadBatchStatus.getDownloadBatchId().rawId()
-                         + ", " + STATUS + " " + downloadBatchStatus.status()
+                         + STATUS + downloadBatchStatus.status()
                          + ", should be deleting");
         notifyCallback(callback, downloadBatchStatus);
 
@@ -356,7 +355,7 @@ class DownloadBatch {
         }
 
         Logger.v("delete request for batch end " + downloadBatchStatus.getDownloadBatchId().rawId()
-                         + ", " + STATUS + ": " + downloadBatchStatus.status()
+                         + STATUS + downloadBatchStatus.status()
                          + ", should be deleting");
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -54,12 +54,14 @@ class DownloadFile {
         if (fileSize.isTotalSizeUnknown()) {
             DownloadError downloadError = DownloadErrorFactory.createTotalSizeRequestFailedError(downloadFileId, url);
             updateAndFeedbackWithStatus(downloadError, callback);
+            Logger.w("abort download file " + downloadFileId + " because size is unknown: " + downloadError.message());
             return;
         }
 
         fileSize.setCurrentSize(filePersistence.getCurrentSize(filePath));
 
         if (downloadFileStatus.isMarkedAsDeleted()) {
+            Logger.v("abort download file " + downloadFileId + " marked as deleted");
             return;
         }
 
@@ -72,6 +74,7 @@ class DownloadFile {
         if (fileSize.currentSize() == fileSize.totalSize()) {
             downloadFileStatus.update(fileSize, filePath);
             callback.onUpdate(downloadFileStatus);
+            Logger.w("abort download file " + downloadFileId + " because already downloaded");
             return;
         }
 
@@ -79,6 +82,7 @@ class DownloadFile {
         if (result != FilePersistenceResult.SUCCESS) {
             DownloadError downloadError = convertError(result);
             updateAndFeedbackWithStatus(downloadError, callback);
+            Logger.w("failed to persist file " + downloadFileId + " because " + downloadError.message());
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
@@ -14,7 +14,8 @@ class FileCallbackThrottleByProgressIncrease implements FileCallbackThrottle {
     @Override
     public void update(DownloadBatchStatus currentDownloadBatchStatus) {
         if (callback == null) {
-            throw new IllegalStateException("A DownloadBatchStatusCallback must be set before an update is called.");
+            Logger.w("A DownloadBatchStatusCallback must be set before an update is called.");
+            return;
         }
 
         if (progressHasChanged(currentDownloadBatchStatus)) {

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncrease.java
@@ -14,7 +14,7 @@ class FileCallbackThrottleByProgressIncrease implements FileCallbackThrottle {
     @Override
     public void update(DownloadBatchStatus currentDownloadBatchStatus) {
         if (callback == null) {
-            return;
+            throw new IllegalStateException("A DownloadBatchStatusCallback must be set before an update is called.");
         }
 
         if (progressHasChanged(currentDownloadBatchStatus)) {

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
@@ -19,7 +19,8 @@ class FileCallbackThrottleByTime implements FileCallbackThrottle {
     @Override
     public void update(DownloadBatchStatus downloadBatchStatus) {
         if (callback == null) {
-            throw new IllegalStateException("A DownloadBatchStatusCallback must be set before an update is called.");
+            Logger.w("A DownloadBatchStatusCallback must be set before an update is called.");
+            return;
         }
 
         this.downloadBatchStatus = downloadBatchStatus;

--- a/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileCallbackThrottleByTime.java
@@ -19,7 +19,7 @@ class FileCallbackThrottleByTime implements FileCallbackThrottle {
     @Override
     public void update(DownloadBatchStatus downloadBatchStatus) {
         if (callback == null) {
-            return;
+            throw new IllegalStateException("A DownloadBatchStatusCallback must be set before an update is called.");
         }
 
         this.downloadBatchStatus = downloadBatchStatus;

--- a/library/src/main/java/com/novoda/downloadmanager/FixedRateTimerActionScheduler.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FixedRateTimerActionScheduler.java
@@ -21,6 +21,7 @@ class FixedRateTimerActionScheduler implements ActionScheduler {
     @Override
     public void schedule(final Action action) {
         if (actionTimerTasks.containsKey(action)) {
+            Logger.v("Already contains action, aborting schedule");
             return;
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -114,6 +114,7 @@ class LiteDownloadManagerDownloader {
     private DownloadBatchStatusCallback downloadBatchCallback(Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
         return downloadBatchStatus -> {
             if (downloadBatchStatus == null || downloadBatchStatusFilter.shouldFilterOut(downloadBatchStatus)) {
+                Logger.v("Abort download batch callback download batch status is filtered.");
                 return;
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/PathBasedFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PathBasedFilePersistence.java
@@ -89,6 +89,7 @@ class PathBasedFilePersistence implements FilePersistence {
 
         File fileToDelete = new File(absoluteFilePath.path());
         if (!fileToDelete.exists()) {
+            Logger.w("Abort delete, file does not exist: " + absoluteFilePath.path());
             return;
         }
 
@@ -107,6 +108,7 @@ class PathBasedFilePersistence implements FilePersistence {
     @Override
     public void close() {
         if (fileOutputStream == null) {
+            Logger.w("Abort closing stream, does not exist.");
             return;
         }
 

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
@@ -21,7 +21,7 @@ public class FileCallbackThrottleByProgressIncreaseTest {
     private final FileCallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new FileCallbackThrottleByProgressIncrease();
 
     @Test(expected = IllegalStateException.class)
-    public void doesNothing_whenCallbackUnset() {
+    public void throws_whenCallbackUnset() {
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
     }
 
@@ -42,6 +42,16 @@ public class FileCallbackThrottleByProgressIncreaseTest {
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
 
         then(downloadBatchCallback).should(never()).onUpdate(any(DownloadBatchStatus.class));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void removesCallback_whenStoppingUpdates() {
+        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
+        callbackThrottleByProgressIncrease.stopUpdates();
+
+        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+
+        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
     }
 
     private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
@@ -20,9 +20,11 @@ public class FileCallbackThrottleByProgressIncreaseTest {
 
     private final FileCallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new FileCallbackThrottleByProgressIncrease();
 
-    @Test(expected = IllegalStateException.class)
-    public void throws_whenCallbackUnset() {
+    @Test
+    public void doesNothing_whenCallbackUnset() {
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
+
+        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
     }
 
     @Test
@@ -44,8 +46,8 @@ public class FileCallbackThrottleByProgressIncreaseTest {
         then(downloadBatchCallback).should(never()).onUpdate(any(DownloadBatchStatus.class));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void removesCallback_whenStoppingUpdates() {
+    @Test
+    public void doesNothing_whenStoppingUpdates() {
         callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
         callbackThrottleByProgressIncrease.stopUpdates();
 

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByProgressIncreaseTest.java
@@ -4,7 +4,10 @@ import org.junit.Test;
 
 import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anInternalDownloadsBatchStatus;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 
 public class FileCallbackThrottleByProgressIncreaseTest {
 
@@ -17,15 +20,14 @@ public class FileCallbackThrottleByProgressIncreaseTest {
 
     private final FileCallbackThrottleByProgressIncrease callbackThrottleByProgressIncrease = new FileCallbackThrottleByProgressIncrease();
 
-    @Test
+    @Test(expected = IllegalStateException.class)
     public void doesNothing_whenCallbackUnset() {
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
-
-        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
     }
 
     @Test
     public void doesNothing_whenDownloadBatchStatusIsUnchanged() {
+        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
         givenPreviousUpdate(percentageIncreasedStatus);
 
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
@@ -40,16 +42,6 @@ public class FileCallbackThrottleByProgressIncreaseTest {
         callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
 
         then(downloadBatchCallback).should(never()).onUpdate(any(DownloadBatchStatus.class));
-    }
-
-    @Test
-    public void doesNotEmitsStatus_whenStoppingUpdates() {
-        callbackThrottleByProgressIncrease.setCallback(downloadBatchCallback);
-        callbackThrottleByProgressIncrease.stopUpdates();
-
-        callbackThrottleByProgressIncrease.update(percentageIncreasedStatus);
-
-        then(downloadBatchCallback).should(never()).onUpdate(percentageIncreasedStatus);
     }
 
     private void givenPreviousUpdate(DownloadBatchStatus downloadBatchStatus) {

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
@@ -3,40 +3,35 @@ package com.novoda.downloadmanager;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class FileCallbackThrottleByTimeTest {
 
     private final ActionScheduler actionScheduler = mock(ActionScheduler.class);
     private final DownloadBatchStatusCallback callback = mock(DownloadBatchStatusCallback.class);
     private final DownloadBatchStatus downloadBatchStatus = mock(DownloadBatchStatus.class);
-
-    private FileCallbackThrottleByTime callbackThrottleByTime;
+    private final FileCallbackThrottleByTime callbackThrottleByTime = new FileCallbackThrottleByTime(actionScheduler);
 
     @Before
     public void setUp() {
-        callbackThrottleByTime = new FileCallbackThrottleByTime(actionScheduler);
-
         final ArgumentCaptor<ActionScheduler.Action> argumentCaptor = ArgumentCaptor.forClass(ActionScheduler.Action.class);
-        willAnswer(new Answer<Void>() {
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                argumentCaptor.getValue().perform();
-                return null;
-            }
+        willAnswer((Answer<Void>) invocation -> {
+            argumentCaptor.getValue().perform();
+            return null;
         }).given(actionScheduler).schedule(argumentCaptor.capture());
     }
 
-    @Test
-    public void doesNothing_whenCallbackIsAbsent() {
+    @Test(expected = IllegalStateException.class)
+    public void throws_whenCallbackIsAbsent() {
         callbackThrottleByTime.update(downloadBatchStatus);
-
-        verifyZeroInteractions(actionScheduler, callback, downloadBatchStatus);
     }
 
     @Test

--- a/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/FileCallbackThrottleByTimeTest.java
@@ -29,9 +29,11 @@ public class FileCallbackThrottleByTimeTest {
         }).given(actionScheduler).schedule(argumentCaptor.capture());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throws_whenCallbackIsAbsent() {
+    @Test
+    public void doesNothing_whenCallbackIsAbsent() {
         callbackThrottleByTime.update(downloadBatchStatus);
+
+        verifyZeroInteractions(actionScheduler, callback, downloadBatchStatus);
     }
 
     @Test


### PR DESCRIPTION
## Problem 
As stated in #253, we have a number of `quick return` statements in the library that have little to no feedback when they are triggered. This means we could have errors in the flow but they are undiscoverable because we receive no notifications. 

## Solution
For the `CallbackThrottle` we now throw `IllegalStateException` when a callback is not present but we try to emit a `DownloadBatchStatus`. 

For the remainder of the `quick return`s, we now log messages to make debugging easier for maintainers and client applications. These are hidden behind the `Logger` so they need to be enabled through the `builder` to be shown in the `logcat`. 