### PR TITLE
Normalise paths when building BatchFile

### DIFF
--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation project(path: ':library')
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testImplementation 'com.google.truth:truth:0.42'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testImplementation 'com.google.truth:truth:0.42'
 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -70,7 +70,7 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
             if (path.isEmpty()) {
                 continue; // ignore empty paths
             }
-            if (!isLastCharFileSeparator(stringBuilder)) {
+            if (isLastCharNotFileSeparator(stringBuilder)) {
                 stringBuilder.append(File.separatorChar);
             }
             stringBuilder.append(removeLeadingTrailingFileSeparator(path));
@@ -93,8 +93,8 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
         return element.substring(beginIndex, endIndex);
     }
 
-    private boolean isLastCharFileSeparator(StringBuilder stringBuilder) {
-        return stringBuilder.length() <= 0 || stringBuilder.charAt(stringBuilder.length() - 1) == File.separatorChar;
+    private boolean isLastCharNotFileSeparator(StringBuilder stringBuilder) {
+        return stringBuilder.length() > 0 && stringBuilder.charAt(stringBuilder.length() - 1) != File.separatorChar;
     }
 
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -61,8 +61,9 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
     private String buildPath(String... paths) {
         StringBuilder stringBuilder = new StringBuilder();
 
-        if (paths[0].startsWith(File.separator)) {
-            stringBuilder.append(File.separator); // if storage path starts with /, we honour it
+        String storagePath = paths[0];
+        if (storagePath.startsWith(File.separator)) {
+            stringBuilder.append(File.separator);
         }
 
         for (String path : paths) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -75,22 +75,22 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
     }
 
     private String sanitise(String path) {
-        String[] pathSegments = path.split(File.separator);
+        String[] pathSegments = path.split(File.separatorChar == '\\' ? "\\\\" : File.separator);
         CharSequence[] filteredPathSegments = filterEmptySegmentsOut(pathSegments);
         return joinWithFileSeparator(filteredPathSegments);
     }
 
-    private CharSequence[] filterEmptySegmentsOut(String[] pathSegments) {
+    private CharSequence[] filterEmptySegmentsOut(String... pathSegments) {
         List<CharSequence> filteredPathSegments = new ArrayList<>();
         for (String pathSegment : pathSegments) {
             if (!pathSegment.isEmpty()) {
                 filteredPathSegments.add(pathSegment);
             }
         }
-        return filteredPathSegments.toArray(new CharSequence[0]);
+        return filteredPathSegments.toArray(new CharSequence[filteredPathSegments.size()]);
     }
 
-    private String joinWithFileSeparator(CharSequence[] elements) {
+    private String joinWithFileSeparator(CharSequence... elements) {
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < elements.length; i++) {
             stringBuilder.append(elements[i]);

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -75,7 +75,7 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
     }
 
     private String sanitise(String path) {
-        String[] pathSegments = path.split("/");
+        String[] pathSegments = path.split(File.separator);
         CharSequence[] filteredPathSegments = filterEmptySegmentsOut(pathSegments);
         return joinWithFileSeparator(filteredPathSegments);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
+    private static final String SEPARATOR_AS_REGEX = File.separatorChar == '\\' ? "\\\\" : File.separator;
+
     private final StorageRoot storageRoot;
     private final DownloadBatchId downloadBatchId;
     private final String networkAddress;
@@ -75,7 +77,7 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
     }
 
     private String sanitise(String path) {
-        String[] pathSegments = path.split(File.separatorChar == '\\' ? "\\\\" : File.separator);
+        String[] pathSegments = path.split(SEPARATOR_AS_REGEX);
         CharSequence[] filteredPathSegments = filterEmptySegmentsOut(pathSegments);
         return joinWithFileSeparator(filteredPathSegments);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -58,21 +58,21 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
         return parentBuilder;
     }
 
-    private String buildPath(String... elements) {
+    private String buildPath(String... paths) {
         StringBuilder stringBuilder = new StringBuilder();
 
-        if (elements[0].startsWith(File.separator)) {
+        if (paths[0].startsWith(File.separator)) {
             stringBuilder.append(File.separator); // if storage path starts with /, we honour it
         }
 
-        for (String element : elements) {
-            if (element.isEmpty()) {
+        for (String path : paths) {
+            if (path.isEmpty()) {
                 continue; // ignore empty paths
             }
             if (!isLastCharFileSeparator(stringBuilder)) {
                 stringBuilder.append(File.separatorChar);
             }
-            stringBuilder.append(removeLeadingTrailingFileSeparator(element));
+            stringBuilder.append(removeLeadingTrailingFileSeparator(path));
         }
 
         return stringBuilder.toString();

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -1,6 +1,8 @@
 package com.novoda.downloadmanager;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
 
@@ -66,35 +68,36 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
             stringBuilder.append(File.separator);
         }
 
-        for (String path : paths) {
-            if (path.isEmpty()) {
-                continue; // ignore empty paths
-            }
-            if (isLastCharNotFileSeparator(stringBuilder)) {
-                stringBuilder.append(File.separatorChar);
-            }
-            stringBuilder.append(removeLeadingTrailingFileSeparator(path));
-        }
+        String joinedPaths = sanitise(joinWithFileSeparator(paths));
+        stringBuilder.append(joinedPaths);
 
         return stringBuilder.toString();
     }
 
-    private String removeLeadingTrailingFileSeparator(String element) {
-        int beginIndex = 0;
-        int endIndex = element.length();
-
-        if (element.charAt(0) == File.separatorChar) {
-            beginIndex = 1;
-        }
-        int lastIndexOfSeparator = element.lastIndexOf(File.separatorChar);
-        if (lastIndexOfSeparator != 0 && lastIndexOfSeparator == element.length() - 1) {
-            endIndex = element.length() - 1;
-        }
-        return element.substring(beginIndex, endIndex);
+    private String sanitise(String path) {
+        String[] pathSegments = path.split("/");
+        CharSequence[] filteredPathSegments = filterEmptySegmentsOut(pathSegments);
+        return joinWithFileSeparator(filteredPathSegments);
     }
 
-    private boolean isLastCharNotFileSeparator(CharSequence charSequence) {
-        return charSequence.length() > 0 && charSequence.charAt(charSequence.length() - 1) != File.separatorChar;
+    private CharSequence[] filterEmptySegmentsOut(String[] pathSegments) {
+        List<CharSequence> filteredPathSegments = new ArrayList<>();
+        for (String pathSegment : pathSegments) {
+            if (!pathSegment.isEmpty()) {
+                filteredPathSegments.add(pathSegment);
+            }
+        }
+        return filteredPathSegments.toArray(new CharSequence[0]);
     }
 
+    private String joinWithFileSeparator(CharSequence[] elements) {
+        StringBuilder stringBuilder = new StringBuilder();
+        for (int i = 0; i < elements.length; i++) {
+            stringBuilder.append(elements[i]);
+            if (i < elements.length - 1) {
+                stringBuilder.append((CharSequence) File.separator);
+            }
+        }
+        return stringBuilder.toString();
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteBatchFileBuilder.java
@@ -93,8 +93,8 @@ final class LiteBatchFileBuilder implements InternalBatchFileBuilder {
         return element.substring(beginIndex, endIndex);
     }
 
-    private boolean isLastCharNotFileSeparator(StringBuilder stringBuilder) {
-        return stringBuilder.length() > 0 && stringBuilder.charAt(stringBuilder.length() - 1) != File.separatorChar;
+    private boolean isLastCharNotFileSeparator(CharSequence charSequence) {
+        return charSequence.length() > 0 && charSequence.charAt(charSequence.length() - 1) != File.separatorChar;
     }
 
 }

--- a/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
@@ -1,0 +1,99 @@
+package com.novoda.downloadmanager;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LiteBatchFileBuilderTest {
+
+    private static final String ANY_NETWORK_ADDRESS = "http://ak.assets.com/some-file";
+
+    private final InternalBatchBuilder batchBuilder = mock(InternalBatchBuilder.class);
+    private final StorageRoot storageRoot = mock(StorageRoot.class);
+    private final DownloadBatchId downloadBatchId = mock(DownloadBatchId.class);
+
+    private LiteBatchFileBuilder liteBatchFileBuilder;
+
+    @Before
+    public void setUp() {
+        when(downloadBatchId.rawId()).thenReturn("my-movie");
+        liteBatchFileBuilder = new LiteBatchFileBuilder(
+                storageRoot,
+                downloadBatchId,
+                ANY_NETWORK_ADDRESS
+        );
+    }
+
+    @Test
+    public void concatenatesAllPaths() {
+        when(storageRoot.path()).thenReturn("root");
+
+        liteBatchFileBuilder
+                .withParentBuilder(batchBuilder)
+                .saveTo("my/path", "my-movie.mp4")
+                .apply();
+
+        verify(batchBuilder).withFile(batchFileWithPath("root/my-movie/my/path/my-movie.mp4"));
+    }
+
+    @Test
+    public void doesNotAddDuplicatePathSeparators() {
+        when(storageRoot.path()).thenReturn("root/");
+        when(downloadBatchId.rawId()).thenReturn("/my-movie/");
+
+        liteBatchFileBuilder
+                .withParentBuilder(batchBuilder)
+                .saveTo("/my/path/", "/my-movie.mp4")
+                .apply();
+
+        verify(batchBuilder).withFile(batchFileWithPath("root/my-movie/my/path/my-movie.mp4"));
+    }
+
+    @Test
+    public void ignoresEmptyPath() {
+        when(storageRoot.path()).thenReturn("root");
+
+        liteBatchFileBuilder
+                .withParentBuilder(batchBuilder)
+                .saveTo("", "my-movie.mp4")
+                .apply();
+
+        verify(batchBuilder).withFile(batchFileWithPath("root/my-movie/my-movie.mp4"));
+    }
+
+    @Test
+    public void ignoreSeparatorAsPath() {
+        when(storageRoot.path()).thenReturn("root/");
+
+        liteBatchFileBuilder
+                .withParentBuilder(batchBuilder)
+                .saveTo("/", "/my-movie.mp4")
+                .apply();
+
+        verify(batchBuilder).withFile(batchFileWithPath("root/my-movie/my-movie.mp4"));
+    }
+
+    @Test
+    public void doesNotIgnoreSeparatorAsRoot() {
+        when(storageRoot.path()).thenReturn("/");
+
+        liteBatchFileBuilder
+                .withParentBuilder(batchBuilder)
+                .saveTo("my/path", "/my-movie.mp4")
+                .apply();
+
+        verify(batchBuilder).withFile(batchFileWithPath("/my-movie/my/path/my-movie.mp4"));
+    }
+
+    private BatchFile batchFileWithPath(String path) {
+        return new BatchFile(
+                ANY_NETWORK_ADDRESS,
+                Optional.absent(),
+                path
+        );
+    }
+
+}

--- a/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
@@ -14,17 +14,15 @@ public class LiteBatchFileBuilderTest {
     private final InternalBatchBuilder batchBuilder = mock(InternalBatchBuilder.class);
     private final StorageRoot storageRoot = mock(StorageRoot.class);
     private final DownloadBatchId downloadBatchId = mock(DownloadBatchId.class);
-
-    private LiteBatchFileBuilder liteBatchFileBuilder;
+    private final LiteBatchFileBuilder liteBatchFileBuilder = new LiteBatchFileBuilder(
+            storageRoot,
+            downloadBatchId,
+            ANY_NETWORK_ADDRESS
+    );
 
     @Before
     public void setUp() {
         when(downloadBatchId.rawId()).thenReturn("my-movie");
-        liteBatchFileBuilder = new LiteBatchFileBuilder(
-                storageRoot,
-                downloadBatchId,
-                ANY_NETWORK_ADDRESS
-        );
     }
 
     @Test

--- a/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
@@ -38,8 +38,8 @@ public class LiteBatchFileBuilderTest {
     }
 
     @Test
-    public void doesNotAddDuplicatePathSeparators() {
-        given(storageRoot.path()).willReturn("root/");
+    public void doesNotAddDuplicateSeparators() {
+        given(storageRoot.path()).willReturn("/root/");
         given(downloadBatchId.rawId()).willReturn("/my-movie/");
 
         liteBatchFileBuilder
@@ -47,7 +47,7 @@ public class LiteBatchFileBuilderTest {
                 .saveTo("/my/path/", "/my-movie.mp4")
                 .apply();
 
-        verify(batchBuilder).withFile(batchFileWithPath("root/my-movie/my/path/my-movie.mp4"));
+        verify(batchBuilder).withFile(batchFileWithPath("/root/my-movie/my/path/my-movie.mp4"));
     }
 
     @Test

--- a/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteBatchFileBuilderTest.java
@@ -3,9 +3,9 @@ package com.novoda.downloadmanager;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class LiteBatchFileBuilderTest {
 
@@ -22,12 +22,12 @@ public class LiteBatchFileBuilderTest {
 
     @Before
     public void setUp() {
-        when(downloadBatchId.rawId()).thenReturn("my-movie");
+        given(downloadBatchId.rawId()).willReturn("my-movie");
     }
 
     @Test
     public void concatenatesAllPaths() {
-        when(storageRoot.path()).thenReturn("root");
+        given(storageRoot.path()).willReturn("root");
 
         liteBatchFileBuilder
                 .withParentBuilder(batchBuilder)
@@ -39,8 +39,8 @@ public class LiteBatchFileBuilderTest {
 
     @Test
     public void doesNotAddDuplicatePathSeparators() {
-        when(storageRoot.path()).thenReturn("root/");
-        when(downloadBatchId.rawId()).thenReturn("/my-movie/");
+        given(storageRoot.path()).willReturn("root/");
+        given(downloadBatchId.rawId()).willReturn("/my-movie/");
 
         liteBatchFileBuilder
                 .withParentBuilder(batchBuilder)
@@ -52,7 +52,7 @@ public class LiteBatchFileBuilderTest {
 
     @Test
     public void ignoresEmptyPath() {
-        when(storageRoot.path()).thenReturn("root");
+        given(storageRoot.path()).willReturn("root");
 
         liteBatchFileBuilder
                 .withParentBuilder(batchBuilder)
@@ -64,7 +64,7 @@ public class LiteBatchFileBuilderTest {
 
     @Test
     public void ignoreSeparatorAsPath() {
-        when(storageRoot.path()).thenReturn("root/");
+        given(storageRoot.path()).willReturn("root/");
 
         liteBatchFileBuilder
                 .withParentBuilder(batchBuilder)
@@ -76,7 +76,7 @@ public class LiteBatchFileBuilderTest {
 
     @Test
     public void doesNotIgnoreSeparatorAsRoot() {
-        when(storageRoot.path()).thenReturn("/");
+        given(storageRoot.path()).willReturn("/");
 
         liteBatchFileBuilder
                 .withParentBuilder(batchBuilder)


### PR DESCRIPTION
## Problem

When building a `BatchFile` with `LiteBatchFileBuilder`, we were simply checking that `path` wasn't the file separator `/`, so we wouldn't add a duplicated separator after that. But that fix (#475) didn't work for cases where the `path` is something like `my/path/to/the/file/` (with a file separator at the end), so we were essentially still adding a double `/`, causing issues like failed downloads.

## Solution

The solution consists in treating each string we need to concatenate as the same kind of path segment:

1. If the first segment (`storageRoot.path()`) starts with a file separator, we add a file separator to the `StringBuilder`
2. Then, for each element
    1. If the element is empty, we ignore it
    1. We add a file separator to the `StringBuilder` if the last char of the `StringBuilder` is not a file separator
    1. We remove any leading or trailing file separators (`/`) from the segment
    1. We add the segment to the `StringBuilder`

## Tests

Tests have been added to prove that all edge and middle cases are covered for.