### PR TITLE
DLM-483/FileDownloader Error Strong Typing

### DIFF
--- a/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFileDownloader.java
+++ b/demo-simple/src/main/java/com/novoda/downloadmanager/demo/CustomFileDownloader.java
@@ -17,7 +17,7 @@ class CustomFileDownloader implements FileDownloader {
     private boolean canDownload;
 
     @Override
-    public void startDownloading(String url, FileSize fileSize, Callback callback) {
+    public void startDownloading(String requestUrl, FileSize fileSize, Callback callback) {
         Log.v(TAG, "Start downloading");
 
         canDownload = true;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -41,7 +41,7 @@ final class DownloadErrorFactory {
         return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_WRITTEN, cannotWriteToFileMessage);
     }
 
-    static DownloadError createNetworkError(FileDownloader.FileDownloadError error) {
+    static DownloadError createNetworkError(FileDownloader.Error error) {
         String networkErrorMessage = "Network error, cannot download file. Cause: " + error.message();
         return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -41,8 +41,8 @@ final class DownloadErrorFactory {
         return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_WRITTEN, cannotWriteToFileMessage);
     }
 
-    static DownloadError createNetworkError(String networkErrorCause) {
-        String networkErrorMessage = "Network error, cannot download file. Cause: " + networkErrorCause;
+    static DownloadError createNetworkError(FileDownloader.FileDownloadError networkErrorCause) {
+        String networkErrorMessage = "Network error, cannot download file. Cause: " + networkErrorCause.message();
         return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadErrorFactory.java
@@ -41,8 +41,8 @@ final class DownloadErrorFactory {
         return new DownloadError(DownloadError.Type.FILE_CANNOT_BE_WRITTEN, cannotWriteToFileMessage);
     }
 
-    static DownloadError createNetworkError(FileDownloader.FileDownloadError networkErrorCause) {
-        String networkErrorMessage = "Network error, cannot download file. Cause: " + networkErrorCause.message();
+    static DownloadError createNetworkError(FileDownloader.FileDownloadError error) {
+        String networkErrorMessage = "Network error, cannot download file. Cause: " + error.message();
         return new DownloadError(DownloadError.Type.NETWORK_ERROR_CANNOT_DOWNLOAD_FILE, networkErrorMessage);
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -103,8 +103,8 @@ class DownloadFile {
             }
 
             @Override
-            public void onError(FileDownloader.FileDownloadError cause) {
-                DownloadError downloadError = DownloadErrorFactory.createNetworkError(cause);
+            public void onError(FileDownloader.FileDownloadError error) {
+                DownloadError downloadError = DownloadErrorFactory.createNetworkError(error);
                 updateAndFeedbackWithStatus(downloadError, callback);
             }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -103,7 +103,7 @@ class DownloadFile {
             }
 
             @Override
-            public void onError(String cause) {
+            public void onError(FileDownloader.FileDownloadError cause) {
                 DownloadError downloadError = DownloadErrorFactory.createNetworkError(cause);
                 updateAndFeedbackWithStatus(downloadError, callback);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadFile.java
@@ -103,7 +103,7 @@ class DownloadFile {
             }
 
             @Override
-            public void onError(FileDownloader.FileDownloadError error) {
+            public void onError(FileDownloader.Error error) {
                 DownloadError downloadError = DownloadErrorFactory.createNetworkError(error);
                 updateAndFeedbackWithStatus(downloadError, callback);
             }

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -29,7 +29,7 @@ public interface FileDownloader {
     }
 
     /**
-     * Represents the information of a {@link LiteFileDownloadError} that is accessible to clients.
+     * Represents error information that is accessible to clients.
      */
     interface Error {
 

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -33,6 +33,8 @@ public interface FileDownloader {
      */
     interface Error {
 
+        int UNEXPECTED_ERROR_CODE = -1;
+
         /**
          * Use to create instances of {@link LiteFileDownloadError}.
          *

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -27,4 +27,14 @@ public interface FileDownloader {
 
         void onDownloadFinished();
     }
+
+    interface FileDownloadError {
+
+        String rawRequest();
+
+        String message();
+
+        int errorCode();
+
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -28,13 +28,36 @@ public interface FileDownloader {
         void onDownloadFinished();
     }
 
+    /**
+     * Represents the information of a {@link LiteFileDownloadError} that is accessible to clients.
+     */
     interface FileDownloadError {
 
+        /**
+         * Use to create instances of {@link LiteFileDownloadError}.
+         *
+         * @param rawRequest the raw request from which the error occurs.
+         * @param message    any message associated with the error.
+         * @param errorCode  the code associated with the error.
+         * @return an instance of {@link FileDownloadError}.
+         */
+        static FileDownloader.FileDownloadError createFrom(String rawRequest, String message, int errorCode) {
+            return new LiteFileDownloadError(rawRequest, message, errorCode);
+        }
+
+        /**
+         * @return the raw request performed when the error occurred.
+         */
         String rawRequest();
 
+        /**
+         * @return a message representing the error that occurred.
+         */
         String message();
 
+        /**
+         * @return a short code representing the error that occurred.
+         */
         int errorCode();
-
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -8,11 +8,11 @@ public interface FileDownloader {
     /**
      * Called internally to start downloading a file.
      *
-     * @param url      of the asset to download.
-     * @param fileSize the byte ranges, represented as file sizes, used to download an asset.
-     * @param callback that is notified of download progress.
+     * @param requestUrl of the asset to download.
+     * @param fileSize   the byte ranges, represented as file sizes, used to download an asset.
+     * @param callback   that is notified of download progress.
      */
-    void startDownloading(String url, FileSize fileSize, Callback callback);
+    void startDownloading(String requestUrl, FileSize fileSize, Callback callback);
 
     /**
      * Called internally to stop downloading a file.
@@ -48,7 +48,7 @@ public interface FileDownloader {
         /**
          * @return the raw request performed when the error occurred.
          */
-        String rawRequest();
+        String requestUrl();
 
         /**
          * @return a message representing the error that occurred.

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -23,7 +23,7 @@ public interface FileDownloader {
 
         void onBytesRead(byte[] buffer, int bytesRead);
 
-        void onError(FileDownloadError cause);
+        void onError(FileDownloadError error);
 
         void onDownloadFinished();
     }

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -23,7 +23,7 @@ public interface FileDownloader {
 
         void onBytesRead(byte[] buffer, int bytesRead);
 
-        void onError(String cause);
+        void onError(FileDownloadError cause);
 
         void onDownloadFinished();
     }

--- a/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FileDownloader.java
@@ -23,7 +23,7 @@ public interface FileDownloader {
 
         void onBytesRead(byte[] buffer, int bytesRead);
 
-        void onError(FileDownloadError error);
+        void onError(Error error);
 
         void onDownloadFinished();
     }
@@ -31,7 +31,7 @@ public interface FileDownloader {
     /**
      * Represents the information of a {@link LiteFileDownloadError} that is accessible to clients.
      */
-    interface FileDownloadError {
+    interface Error {
 
         /**
          * Use to create instances of {@link LiteFileDownloadError}.
@@ -39,9 +39,9 @@ public interface FileDownloader {
          * @param rawRequest the raw request from which the error occurs.
          * @param message    any message associated with the error.
          * @param errorCode  the code associated with the error.
-         * @return an instance of {@link FileDownloadError}.
+         * @return an instance of {@link Error}.
          */
-        static FileDownloader.FileDownloadError createFrom(String rawRequest, String message, int errorCode) {
+        static Error createFrom(String rawRequest, String message, int errorCode) {
             return new LiteFileDownloadError(rawRequest, message, errorCode);
         }
 

--- a/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
@@ -1,0 +1,66 @@
+package com.novoda.downloadmanager;
+
+class LiteFileDownloadError implements FileDownloader.FileDownloadError {
+
+    private final String rawRequest;
+    private final String message;
+    private final int errorCode;
+
+    LiteFileDownloadError(String rawRequest, String message, int errorCode) {
+        this.rawRequest = rawRequest;
+        this.message = message;
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public String rawRequest() {
+        return rawRequest;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public int errorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LiteFileDownloadError that = (LiteFileDownloadError) o;
+
+        if (errorCode != that.errorCode) {
+            return false;
+        }
+        if (rawRequest != null ? !rawRequest.equals(that.rawRequest) : that.rawRequest != null) {
+            return false;
+        }
+        return message != null ? message.equals(that.message) : that.message == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = rawRequest != null ? rawRequest.hashCode() : 0;
+        result = 31 * result + (message != null ? message.hashCode() : 0);
+        result = 31 * result + errorCode;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "LiteFileDownloadError{"
+                + "rawRequest='" + rawRequest + '\''
+                + ", message='" + message + '\''
+                + ", errorCode=" + errorCode
+                + '}';
+    }
+}

--- a/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
@@ -2,19 +2,19 @@ package com.novoda.downloadmanager;
 
 class LiteFileDownloadError implements FileDownloader.FileDownloadError {
 
-    private final String rawRequest;
+    private final String requestUrl;
     private final String message;
     private final int errorCode;
 
-    LiteFileDownloadError(String rawRequest, String message, int errorCode) {
-        this.rawRequest = rawRequest;
+    LiteFileDownloadError(String requestUrl, String message, int errorCode) {
+        this.requestUrl = requestUrl;
         this.message = message;
         this.errorCode = errorCode;
     }
 
     @Override
-    public String rawRequest() {
-        return rawRequest;
+    public String requestUrl() {
+        return requestUrl;
     }
 
     @Override
@@ -41,7 +41,7 @@ class LiteFileDownloadError implements FileDownloader.FileDownloadError {
         if (errorCode != that.errorCode) {
             return false;
         }
-        if (rawRequest != null ? !rawRequest.equals(that.rawRequest) : that.rawRequest != null) {
+        if (requestUrl != null ? !requestUrl.equals(that.requestUrl) : that.requestUrl != null) {
             return false;
         }
         return message != null ? message.equals(that.message) : that.message == null;
@@ -49,7 +49,7 @@ class LiteFileDownloadError implements FileDownloader.FileDownloadError {
 
     @Override
     public int hashCode() {
-        int result = rawRequest != null ? rawRequest.hashCode() : 0;
+        int result = requestUrl != null ? requestUrl.hashCode() : 0;
         result = 31 * result + (message != null ? message.hashCode() : 0);
         result = 31 * result + errorCode;
         return result;
@@ -58,7 +58,7 @@ class LiteFileDownloadError implements FileDownloader.FileDownloadError {
     @Override
     public String toString() {
         return "LiteFileDownloadError{"
-                + "rawRequest='" + rawRequest + '\''
+                + "requestUrl='" + requestUrl + '\''
                 + ", message='" + message + '\''
                 + ", errorCode=" + errorCode
                 + '}';

--- a/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteFileDownloadError.java
@@ -1,6 +1,6 @@
 package com.novoda.downloadmanager;
 
-class LiteFileDownloadError implements FileDownloader.FileDownloadError {
+class LiteFileDownloadError implements FileDownloader.Error {
 
     private final String requestUrl;
     private final String message;

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -30,7 +30,7 @@ class NetworkFileDownloader implements FileDownloader {
             processResponse(callback, response, responseCode, requestUrl);
         } catch (IOException e) {
             Logger.e(e, "Exception with http request");
-            callback.onError(FileDownloadError.createFrom(requestUrl, e.getMessage(), -1));
+            callback.onError(Error.createFrom(requestUrl, e.getMessage(), -1));
         } finally {
             try {
                 if (response != null) {
@@ -64,7 +64,7 @@ class NetworkFileDownloader implements FileDownloader {
                     url,
                     responseCode
             );
-            callback.onError(FileDownloadError.createFrom(url, networkErrorMessage, responseCode));
+            callback.onError(Error.createFrom(url, networkErrorMessage, responseCode));
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -30,7 +30,7 @@ class NetworkFileDownloader implements FileDownloader {
             processResponse(callback, response, responseCode, url);
         } catch (IOException e) {
             Logger.e(e, "Exception with http request");
-            callback.onError(e.getMessage());
+            callback.onError(FileDownloadError.createFrom(url, e.getMessage(), -1));
         } finally {
             try {
                 if (response != null) {
@@ -64,7 +64,7 @@ class NetworkFileDownloader implements FileDownloader {
                     url,
                     responseCode
             );
-            callback.onError(networkErrorMessage);
+            callback.onError(FileDownloadError.createFrom(url, networkErrorMessage, responseCode));
         }
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -19,18 +19,18 @@ class NetworkFileDownloader implements FileDownloader {
     }
 
     @Override
-    public void startDownloading(String url, FileSize fileSize, Callback callback) {
+    public void startDownloading(String requestUrl, FileSize fileSize, Callback callback) {
         canDownload = true;
 
-        NetworkRequest request = createRequestFrom(url, fileSize);
+        NetworkRequest request = createRequestFrom(requestUrl, fileSize);
         NetworkResponse response = null;
         try {
             response = httpClient.execute(request);
             int responseCode = response.code();
-            processResponse(callback, response, responseCode, url);
+            processResponse(callback, response, responseCode, requestUrl);
         } catch (IOException e) {
             Logger.e(e, "Exception with http request");
-            callback.onError(FileDownloadError.createFrom(url, e.getMessage(), -1));
+            callback.onError(FileDownloadError.createFrom(requestUrl, e.getMessage(), -1));
         } finally {
             try {
                 if (response != null) {

--- a/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/NetworkFileDownloader.java
@@ -30,7 +30,7 @@ class NetworkFileDownloader implements FileDownloader {
             processResponse(callback, response, responseCode, requestUrl);
         } catch (IOException e) {
             Logger.e(e, "Exception with http request");
-            callback.onError(Error.createFrom(requestUrl, e.getMessage(), -1));
+            callback.onError(Error.createFrom(requestUrl, e.getMessage(), Error.UNEXPECTED_ERROR_CODE));
         } finally {
             try {
                 if (response != null) {

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
@@ -7,13 +7,13 @@ import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anI
 
 public class DownloadBatchStatusFilterTest {
 
-    private final FileDownloader.FileDownloadError firstError = FileDownloader.FileDownloadError.createFrom(
+    private final FileDownloader.Error firstError = FileDownloader.Error.createFrom(
             "www.example.com",
             "first",
             -1
     );
 
-    private final FileDownloader.FileDownloadError secondError = FileDownloader.FileDownloadError.createFrom(
+    private final FileDownloader.Error secondError = FileDownloader.Error.createFrom(
             "www.example.com",
             "second",
             -1

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusFilterTest.java
@@ -7,6 +7,17 @@ import static com.novoda.downloadmanager.InternalDownloadBatchStatusFixtures.anI
 
 public class DownloadBatchStatusFilterTest {
 
+    private final FileDownloader.FileDownloadError firstError = FileDownloader.FileDownloadError.createFrom(
+            "www.example.com",
+            "first",
+            -1
+    );
+
+    private final FileDownloader.FileDownloadError secondError = FileDownloader.FileDownloadError.createFrom(
+            "www.example.com",
+            "second",
+            -1
+    );
     private final InternalDownloadBatchStatus firstPercentageStatus = anInternalDownloadsBatchStatus()
             .withPercentageDownloaded(75)
             .build();
@@ -14,10 +25,10 @@ public class DownloadBatchStatusFilterTest {
             .withPercentageDownloaded(80)
             .build();
     private final InternalDownloadBatchStatus firstErrorStatus = anInternalDownloadsBatchStatus()
-            .withDownloadError(DownloadErrorFactory.createNetworkError("first"))
+            .withDownloadError(DownloadErrorFactory.createNetworkError(firstError))
             .build();
     private final InternalDownloadBatchStatus secondErrorStatus = anInternalDownloadsBatchStatus()
-            .withDownloadError(DownloadErrorFactory.createNetworkError("second"))
+            .withDownloadError(DownloadErrorFactory.createNetworkError(secondError))
             .build();
     private final InternalDownloadBatchStatus firstStatus = anInternalDownloadsBatchStatus()
             .build();

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
@@ -67,12 +67,12 @@ public class NetworkFileDownloaderTest {
 
         networkFileDownloader.startDownloading(ANY_RAW_URL, UNKNOWN_FILE_SIZE, callback);
 
-        FileDownloader.FileDownloadError expectedFileDownloadError = FileDownloader.FileDownloadError.createFrom(
+        FileDownloader.Error expectedError = FileDownloader.Error.createFrom(
                 ANY_RAW_URL,
                 "Request: http://example.com with response code: 418 failed.",
                 418
         );
-        verify(callback).onError(expectedFileDownloadError);
+        verify(callback).onError(expectedError);
     }
 
     @Test
@@ -92,12 +92,12 @@ public class NetworkFileDownloaderTest {
 
         networkFileDownloader.startDownloading(ANY_RAW_URL, UNKNOWN_FILE_SIZE, callback);
 
-        FileDownloader.FileDownloadError expectedFileDownloadError = FileDownloader.FileDownloadError.createFrom(
+        FileDownloader.Error expectedError = FileDownloader.Error.createFrom(
                 ANY_RAW_URL,
                 MESSAGE,
                 -1
         );
-        verify(callback).onError(expectedFileDownloadError);
+        verify(callback).onError(expectedError);
     }
 
     @Test

--- a/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/NetworkFileDownloaderTest.java
@@ -67,8 +67,12 @@ public class NetworkFileDownloaderTest {
 
         networkFileDownloader.startDownloading(ANY_RAW_URL, UNKNOWN_FILE_SIZE, callback);
 
-        String expectedCause = "Request: http://example.com with response code: 418 failed.";
-        verify(callback).onError(expectedCause);
+        FileDownloader.FileDownloadError expectedFileDownloadError = FileDownloader.FileDownloadError.createFrom(
+                ANY_RAW_URL,
+                "Request: http://example.com with response code: 418 failed.",
+                418
+        );
+        verify(callback).onError(expectedFileDownloadError);
     }
 
     @Test
@@ -88,7 +92,12 @@ public class NetworkFileDownloaderTest {
 
         networkFileDownloader.startDownloading(ANY_RAW_URL, UNKNOWN_FILE_SIZE, callback);
 
-        verify(callback).onError(MESSAGE);
+        FileDownloader.FileDownloadError expectedFileDownloadError = FileDownloader.FileDownloadError.createFrom(
+                ANY_RAW_URL,
+                MESSAGE,
+                -1
+        );
+        verify(callback).onError(expectedFileDownloadError);
     }
 
     @Test


### PR DESCRIPTION
⚠️ Against a feature branch to ensure we have addressed all of the issues outlined in #483 ⚠️ 

## Problem 
We need to introduce a better retry and failure mechanism when attempting to download a file. At the moment we only return a `message` associated with the failure from the `FileDownloader` which is not enough information to allow us or clients to perform any meaningful retrial / error flow. 

## Solution 
Introduce a `FileDownloader.FileDownloadError` interface and an associated model that represents some additional data that is required in order to be able to perform meaningful error handling. 

Not currently hooked up to any error handling, just passes the new model back to the `DownloadBatch` who then transforms it back to the old error. This will be used when we introduce the new error handling interface. See #483 for more information. 