### PR TITLE
Downloaded notification re-shown

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -21,7 +21,7 @@ class DownloadBatchStatusNotificationDispatcher {
         this.downloadBatchIdNotificationSeen = downloadBatchIdNotificationSeen;
     }
 
-    void updateNotification(DownloadBatchStatus downloadBatchStatus) {
+    void updateNotification(InternalDownloadBatchStatus downloadBatchStatus) {
         if (downloadBatchStatus.notificationSeen()) {
             Logger.v("DownloadBatchStatus:", downloadBatchStatus.getDownloadBatchId(), "notification has already been seen.");
             return;
@@ -38,7 +38,7 @@ class DownloadBatchStatusNotificationDispatcher {
             Logger.v("start updateNotificationSeenAsync " + rawDownloadBatchId
                              + ", seen: " + NOTIFICATION_SEEN
                              + ", status: " + downloadBatchStatus.status());
-            notificationSeenPersistence.updateNotificationSeenAsync(downloadBatchStatus, NOTIFICATION_SEEN);
+            downloadBatchStatus.markAsNotificationSeen(notificationSeenPersistence);
         }
 
         notificationDispatcher.updateNotification(downloadBatchStatus);

--- a/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/InternalDownloadBatchStatus.java
@@ -22,5 +22,7 @@ interface InternalDownloadBatchStatus extends DownloadBatchStatus {
 
     void markAsWaitingForNetwork(DownloadsBatchPersistence persistence);
 
+    void markAsNotificationSeen(DownloadsNotificationSeenPersistence persistence);
+
     InternalDownloadBatchStatus copy();
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadBatchStatus.java
@@ -6,6 +6,7 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
 
     private static final long ZERO_BYTES = 0;
     private static final int TOTAL_PERCENTAGE = 100;
+    private static final boolean NOTIFICATION_SEEN = true;
 
     private final DownloadBatchTitle downloadBatchTitle;
     private final DownloadBatchId downloadBatchId;
@@ -147,6 +148,12 @@ class LiteDownloadBatchStatus implements InternalDownloadBatchStatus {
     public void markAsWaitingForNetwork(DownloadsBatchPersistence persistence) {
         this.status = Status.WAITING_FOR_NETWORK;
         updateStatusAsync(status, persistence);
+    }
+
+    @Override
+    public void markAsNotificationSeen(DownloadsNotificationSeenPersistence persistence) {
+        this.notificationSeen = NOTIFICATION_SEEN;
+        persistence.updateNotificationSeenAsync(this, NOTIFICATION_SEEN);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -129,7 +129,7 @@ class LiteDownloadManagerDownloader {
                     for (DownloadBatchStatusCallback callback : callbacks) {
                         callback.onUpdate(downloadBatchStatus);
                     }
-                    notificationDispatcher.updateNotification(downloadBatchStatus);
+                    notificationDispatcher.updateNotification(((InternalDownloadBatchStatus) downloadBatchStatus));
                 }
             });
         };

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -129,7 +129,11 @@ class LiteDownloadManagerDownloader {
                     for (DownloadBatchStatusCallback callback : callbacks) {
                         callback.onUpdate(downloadBatchStatus);
                     }
-                    notificationDispatcher.updateNotification(((InternalDownloadBatchStatus) downloadBatchStatus));
+
+                    DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
+                    if (downloadBatch != null) {
+                        notificationDispatcher.updateNotification(downloadBatch.status());
+                    }
                 }
             });
         };


### PR DESCRIPTION
## Problem 
The `DOWNLOADED` notification is show again whenever a network recovery mechanism is selected. 

When a network recovery mechanism is selected it requeues downloads against the `download-manager`. If the underlying `Map<DownloadBatchId, DownloadBatch>` already contains the `Batch` to queue then it will not add the new `Batch`. Unfortunately this `Batch` is the original and it was never updated with `notificationSeen=true` 

## Solution 
Add a method to the `DownloadBatchStatus` to update the `notificationSeen` status. This update will be propagated to the `Map<DownloadBatchId, DownloadBatch>` solving the issue.

### Map<DownloadBatchId, DownloadBatch>` 
Someone is bound to ask the question "why not update the map each time"...

If someone were to trigger the network recovery multiple times then we end up queueing multiple downloads against the `ExecutorService`. Which in itself is not a problem, it only is if you allow each `DownloadBatchId` to have a different state, which could potentially happen. Let's say we trigger a download, a network error then occurs and then we decide to delete it. **Well** then the download would finish **and then** the delete would occur. Instead you supply a single consistent instance for multiple threads, that way when the first terminates, even with it queuing a duplicate it will have a consistent state and just go straight to the end state. 

## Future work
- It would be good to avoid the cast. I'd really like to be able to supply an interface to our internal classes where they could receive the `InternalDownloadBatchStatus` but supply the more limited version to other client interfaces that supplies the `DownloadBatchStatus`. 