### PR TITLE
DLM-499/Network recovery not initialised

### DIFF
--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -33,11 +33,11 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.facebook.stetho:stetho:1.5.0'
+    implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation project(path: ':library')
-    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation 'com.google.truth:truth:0.44'
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -69,7 +69,7 @@ android {
 dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
     implementation 'com.novoda:merlin:1.2.1'
-    implementation 'com.facebook.stetho:stetho:1.5.0'
+    implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.squareup.okhttp3:okhttp:3.12.1'
     implementation('android.arch.persistence.room:runtime:1.1.1') {
         exclude group: 'com.android.support', module: 'support-v4'
@@ -78,7 +78,7 @@ dependencies {
     implementation 'com.evernote:android-job:1.2.6'
     implementation 'net.sourceforge.findbugs:annotations:1.3.2'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.27.0'
+    testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation 'com.google.truth:truth:0.44'
 }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -250,13 +250,13 @@ public final class DownloadManagerBuilder {
                     LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
                     downloadService = binder.getService();
                     liteDownloadManager.submitAllStoredDownloads(() -> {
-                        liteDownloadManager.initialise(downloadService);
-
                         if (allowNetworkRecovery) {
                             DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, liteDownloadManager, connectionTypeAllowed);
                         } else {
                             DownloadsNetworkRecoveryCreator.createDisabled();
                         }
+
+                        liteDownloadManager.initialise(downloadService);
                     });
                 }
             }


### PR DESCRIPTION
## Problem
As detailed in #499, we're observing exceptions where the `DownloadsNetworkRecovery` is accessed before being initialized.

## Solution
Avoid possible race condition by first initializing the `DownloadsNetworkRecovery` and then the `liteDownloadManager`.

Manually verified through the included sample that this doesn't break the basic download workfows:
- start/pause/resume/stop
- start/airplane mode on/airplane mode off/resume

## Paired with
@zegnus