### PR TITLE
Persistent delete notification

### DIFF
--- a/demo-simple/build.gradle
+++ b/demo-simple/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
     implementation project(path: ':library')
     testImplementation 'org.mockito:mockito-core:2.28.2'
     testImplementation 'com.google.truth:truth:0.44'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     annotationProcessor 'android.arch.persistence.room:compiler:1.1.1'
     implementation 'com.novoda:merlin:1.2.1'
     implementation 'com.facebook.stetho:stetho:1.5.1'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
     implementation('android.arch.persistence.room:runtime:1.1.1') {
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'android.arch.core', module: 'runtime'

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -51,4 +51,9 @@ class DownloadBatchStatusNotificationDispatcher {
     void setDownloadService(DownloadService downloadService) {
         notificationDispatcher.setService(downloadService);
     }
+
+    void removeDeletedBatchNotification(DownloadBatchStatus downloadBatchStatus) {
+        downloadBatchIdNotificationSeen.remove(downloadBatchStatus.getDownloadBatchId().rawId());
+        notificationDispatcher.updateNotification(downloadBatchStatus);
+    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcher.java
@@ -51,9 +51,4 @@ class DownloadBatchStatusNotificationDispatcher {
     void setDownloadService(DownloadService downloadService) {
         notificationDispatcher.setService(downloadService);
     }
-
-    void removeDeletedBatchNotification(DownloadBatchStatus downloadBatchStatus) {
-        downloadBatchIdNotificationSeen.remove(downloadBatchStatus.getDownloadBatchId().rawId());
-        notificationDispatcher.updateNotification(downloadBatchStatus);
-    }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManager.java
@@ -120,7 +120,6 @@ class LiteDownloadManager implements DownloadManager {
         }
 
         downloadBatch.delete();
-        downloadBatchMap.remove(downloadBatchId);
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -133,19 +133,15 @@ class LiteDownloadManagerDownloader {
                     DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
                     if (downloadBatch != null) {
                         notificationDispatcher.updateNotification(downloadBatch.status());
-                    } else {
-                        removeNotificationForDeletedBatch(downloadBatchStatus);
+
+                        if (downloadBatch.status().status() == DELETED) {
+                            Logger.v("batch " + downloadBatchId.rawId() + " is finally deleted, removing it from the map");
+                            downloadBatchMap.remove(downloadBatchId);
+                        }
                     }
                 }
             });
         };
-    }
-
-    private void removeNotificationForDeletedBatch(DownloadBatchStatus downloadBatchStatus) {
-        if (downloadBatchStatus.status() == DELETED) {
-            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " has been deleted, remove notification.");
-            notificationDispatcher.removeDeletedBatchNotification(downloadBatchStatus);
-        }
     }
 
     void setDownloadService(DownloadService downloadService) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -133,10 +133,19 @@ class LiteDownloadManagerDownloader {
                     DownloadBatch downloadBatch = downloadBatchMap.get(downloadBatchId);
                     if (downloadBatch != null) {
                         notificationDispatcher.updateNotification(downloadBatch.status());
+                    } else {
+                        removeNotificationForDeletedBatch(downloadBatchStatus);
                     }
                 }
             });
         };
+    }
+
+    private void removeNotificationForDeletedBatch(DownloadBatchStatus downloadBatchStatus) {
+        if (downloadBatchStatus.status() == DELETED) {
+            Logger.v("batch " + downloadBatchStatus.getDownloadBatchId().rawId() + " has been deleted, remove notification.");
+            notificationDispatcher.removeDeletedBatchNotification(downloadBatchStatus);
+        }
     }
 
     void setDownloadService(DownloadService downloadService) {

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -119,10 +119,6 @@ class LiteDownloadManagerDownloader {
             }
 
             DownloadBatchId downloadBatchId = downloadBatchStatus.getDownloadBatchId();
-            if (downloadBatchStatus.status() == DELETED) {
-                Logger.v("batch " + downloadBatchId.rawId() + " is finally deleted, removing it from the map");
-                downloadBatchMap.remove(downloadBatchId);
-            }
 
             callbackHandler.post(() -> {
                 synchronized (waitForDownloadBatchStatusCallback) {

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
@@ -58,14 +58,4 @@ public class DownloadBatchStatusNotificationDispatcherTest {
 
         verify(notificationDispatcher).setService(downloadService);
     }
-
-    @Test
-    public void updatesNotification_whenRemovingDeletedBatchNotification() {
-        InternalDownloadBatchStatus notificationDeletedBatchStatus = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DELETED).build();
-
-        downloadBatchStatusNotificationDispatcher.removeDeletedBatchNotification(notificationDeletedBatchStatus);
-
-        verify(notificationDispatcher).updateNotification(notificationDeletedBatchStatus);
-    }
-
 }

--- a/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/DownloadBatchStatusNotificationDispatcherTest.java
@@ -59,4 +59,13 @@ public class DownloadBatchStatusNotificationDispatcherTest {
         verify(notificationDispatcher).setService(downloadService);
     }
 
+    @Test
+    public void updatesNotification_whenRemovingDeletedBatchNotification() {
+        InternalDownloadBatchStatus notificationDeletedBatchStatus = anInternalDownloadsBatchStatus().withStatus(DownloadBatchStatus.Status.DELETED).build();
+
+        downloadBatchStatusNotificationDispatcher.removeDeletedBatchNotification(notificationDeletedBatchStatus);
+
+        verify(notificationDispatcher).updateNotification(notificationDeletedBatchStatus);
+    }
+
 }

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerTest.java
@@ -200,11 +200,15 @@ public class LiteDownloadManagerTest {
             verify(downloadBatch).delete();
         }
 
+        /**
+         * The removal from the map occurs in {@link LiteDownloadManagerDownloader} after the notification has been sent
+         * to avoid race conditions between the map removal and the executor attempting to send notifications.
+         */
         @Test
-        public void removesBatchFromMap_whenDeletingBatch() {
+        public void doesNotRemoveBatchFromMap_whenDeletingBatch() {
             liteDownloadManager.delete(DOWNLOAD_BATCH_ID);
 
-            assertThat(downloadingBatches).doesNotContainKey(DOWNLOAD_BATCH_ID);
+            assertThat(downloadingBatches).containsKey(DOWNLOAD_BATCH_ID);
         }
 
         @Test


### PR DESCRIPTION
## Problem 
It seems that when deleting we are immediately removing the batch from the internal map. Which has the unfortunate consequence of nearly always making this code [here](https://github.com/novoda/download-manager/pull/488/files#diff-02a0200e71740d602b2050b608006528R134) null 😂 I say nearly always because it's kind of a race between the executor and the update of the map to see who will remove or send a notification first 😄 

## Solution
Avoid removing from the internal map until we have sent the `notification`. 