### PR TITLE
Create service connection listener after liteDownloadManager

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -242,33 +242,6 @@ public final class DownloadManagerBuilder {
             Logger.attach(logHandle.get());
         }
 
-        Intent intent = new Intent(applicationContext, LiteDownloadService.class);
-        ServiceConnection serviceConnection = new ServiceConnection() {
-            @Override
-            public void onServiceConnected(ComponentName name, IBinder service) {
-                if (service instanceof LiteDownloadService.DownloadServiceBinder) {
-                    LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
-                    downloadService = binder.getService();
-                    liteDownloadManager.submitAllStoredDownloads(() -> {
-                        if (allowNetworkRecovery) {
-                            DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, liteDownloadManager, connectionTypeAllowed);
-                        } else {
-                            DownloadsNetworkRecoveryCreator.createDisabled();
-                        }
-
-                        liteDownloadManager.initialise(downloadService);
-                    });
-                }
-            }
-
-            @Override
-            public void onServiceDisconnected(ComponentName name) {
-                // no-op
-            }
-        };
-
-        applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
-
         filePersistenceCreator.withStorageRequirementRules(storageRequirementRules);
         FileOperations fileOperations = new FileOperations(filePersistenceCreator, fileSizeRequester, fileDownloaderCreator);
         Set<DownloadBatchStatusCallback> callbacks = new CopyOnWriteArraySet<>();
@@ -344,6 +317,33 @@ public final class DownloadManagerBuilder {
                 serviceCriteria
         );
 
+        Intent intent = new Intent(applicationContext, LiteDownloadService.class);
+        ServiceConnection serviceConnection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName name, IBinder service) {
+                if (service instanceof LiteDownloadService.DownloadServiceBinder) {
+                    LiteDownloadService.DownloadServiceBinder binder = (LiteDownloadService.DownloadServiceBinder) service;
+                    downloadService = binder.getService();
+                    liteDownloadManager.submitAllStoredDownloads(() -> {
+                        if (allowNetworkRecovery) {
+                            DownloadsNetworkRecoveryCreator.createEnabled(applicationContext, liteDownloadManager, connectionTypeAllowed);
+                        } else {
+                            DownloadsNetworkRecoveryCreator.createDisabled();
+                        }
+
+                        liteDownloadManager.initialise(downloadService);
+                    });
+                }
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                // no-op
+            }
+        };
+
+        applicationContext.bindService(intent, serviceConnection, Service.BIND_AUTO_CREATE);
+        
         return liteDownloadManager;
     }
 


### PR DESCRIPTION
In my application `onServiceConnected` seems to sometimes get called immediately after `applicationContext.bindService(...)` is called, which causes a crash, because `liteDownloadManager` is not initialized yet. This PR calls bindService after liteDownloadManager is initialized to eliminate the possibility of this crash.

Fixes #510 