### PR TITLE
Concurrent file downloads

### DIFF
--- a/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
@@ -1,0 +1,42 @@
+package com.novoda.downloadmanager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+class ConcurrentFilesDownloader implements FilesDownloader{
+
+    private static final ExecutorService CONCURRENT_EXECUTOR_SERVICE = Executors.newFixedThreadPool(4);
+
+    private final InternalDownloadBatchStatus downloadBatchStatus;
+    private final ConnectionChecker connectionChecker;
+    private final DownloadsBatchPersistence downloadsBatchPersistence;
+
+    ConcurrentFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker, DownloadsBatchPersistence downloadsBatchPersistence) {
+        this.downloadBatchStatus = downloadBatchStatus;
+        this.connectionChecker = connectionChecker;
+        this.downloadsBatchPersistence = downloadsBatchPersistence;
+    }
+
+    @Override
+    public void download(List<DownloadFile> downloadFiles, DownloadBatchStatusCallback statusCallback, DownloadFile.Callback fileCallback) {
+        List<Callable<Object>> callables = new ArrayList<>(downloadFiles.size());
+
+        for (DownloadFile downloadFile : downloadFiles) {
+            callables.add(Executors.callable(() -> {
+                if (DownloadBatch.batchCannotContinue(downloadBatchStatus, connectionChecker, downloadsBatchPersistence, statusCallback)) {
+                    throw new RuntimeException("Ignored interrupt download exception");
+                }
+                downloadFile.download(fileCallback);
+            }));
+        }
+        try {
+            CONCURRENT_EXECUTOR_SERVICE.invokeAll(callables);
+        } catch (InterruptedException e) {
+            CONCURRENT_EXECUTOR_SERVICE.shutdown();
+        }
+    }
+}
+

--- a/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -27,7 +28,7 @@ class ConcurrentFilesDownloader implements FilesDownloader{
         for (DownloadFile downloadFile : downloadFiles) {
             callables.add(Executors.callable(() -> {
                 if (DownloadBatch.batchCannotContinue(downloadBatchStatus, connectionChecker, downloadsBatchPersistence, statusCallback)) {
-                    throw new RuntimeException("Ignored interrupt download exception");
+                    throw new CancellationException("Ignored interrupt download exception");
                 }
                 downloadFile.download(fileCallback);
             }));

--- a/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ConcurrentFilesDownloader.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-class ConcurrentFilesDownloader implements FilesDownloader{
+class ConcurrentFilesDownloader implements FilesDownloader {
 
     private static final ExecutorService CONCURRENT_EXECUTOR_SERVICE = Executors.newFixedThreadPool(4);
 
@@ -15,7 +15,8 @@ class ConcurrentFilesDownloader implements FilesDownloader{
     private final ConnectionChecker connectionChecker;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
 
-    ConcurrentFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker, DownloadsBatchPersistence downloadsBatchPersistence) {
+    ConcurrentFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker,
+                              DownloadsBatchPersistence downloadsBatchPersistence) {
         this.downloadBatchStatus = downloadBatchStatus;
         this.connectionChecker = connectionChecker;
         this.downloadsBatchPersistence = downloadsBatchPersistence;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatch.java
@@ -37,6 +37,8 @@ class DownloadBatch {
     private long totalBatchSizeBytes;
     private DownloadBatchStatusCallback callback;
 
+    // The download batch is where the majority of the logic sits
+    @SuppressWarnings("checkstyle:parameternumber")
     DownloadBatch(InternalDownloadBatchStatus internalDownloadBatchStatus,
                   List<DownloadFile> downloadFiles,
                   Map<DownloadFileId, Long> fileBytesDownloadedMap,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -15,6 +15,8 @@ final class DownloadBatchFactory {
         // non instantiable factory class
     }
 
+    // The download batch is where the majority of the logic sits
+    @SuppressWarnings("checkstyle:parameternumber")
     static DownloadBatch newInstance(Batch batch,
                                      FileOperations fileOperations,
                                      DownloadsBatchPersistence downloadsBatchPersistence,
@@ -82,7 +84,12 @@ final class DownloadBatchFactory {
                 DOWNLOAD_ERROR
         );
 
-        FilesDownloader filesDownloader = createFilesDownloader(enableConcurrentFileDownloading, downloadsBatchPersistence, connectionChecker, liteDownloadBatchStatus);
+        FilesDownloader filesDownloader = createFilesDownloader(
+                enableConcurrentFileDownloading,
+                downloadsBatchPersistence,
+                connectionChecker,
+                liteDownloadBatchStatus
+        );
 
         return new DownloadBatch(
                 liteDownloadBatchStatus,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -81,6 +81,8 @@ final class DownloadBatchFactory {
                 DOWNLOAD_ERROR
         );
 
+        SequentialFilesDownloader filesDownloader = new SequentialFilesDownloader(liteDownloadBatchStatus, connectionChecker, downloadsBatchPersistence);
+
         return new DownloadBatch(
                 liteDownloadBatchStatus,
                 downloadFiles,
@@ -88,7 +90,8 @@ final class DownloadBatchFactory {
                 downloadsBatchPersistence,
                 fileCallbackThrottle,
                 connectionChecker,
-                downloadBatchRequirementRule
+                downloadBatchRequirementRule,
+                filesDownloader
         );
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadBatchFactory.java
@@ -3,6 +3,7 @@ package com.novoda.downloadmanager;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 
 final class DownloadBatchFactory {
 
@@ -86,7 +87,7 @@ final class DownloadBatchFactory {
         return new DownloadBatch(
                 liteDownloadBatchStatus,
                 downloadFiles,
-                new HashMap<>(),
+                new ConcurrentHashMap<>(),
                 downloadsBatchPersistence,
                 fileCallbackThrottle,
                 connectionChecker,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -60,6 +60,7 @@ public final class DownloadManagerBuilder {
     private TimeUnit timeUnit;
     private long frequency;
     private Optional<LogHandle> logHandle;
+    private boolean enableConcurrentFileDownloading;
 
     public static DownloadManagerBuilder newInstance(Context context, Handler callbackHandler, @DrawableRes final int notificationIcon) {
         Context applicationContext = context.getApplicationContext();
@@ -96,6 +97,7 @@ public final class DownloadManagerBuilder {
         CallbackThrottleCreator.Type callbackThrottleCreatorType = CallbackThrottleCreator.Type.THROTTLE_BY_PROGRESS_INCREASE;
 
         Optional<LogHandle> logHandle = Optional.absent();
+        boolean enableConcurrentFileDownloading = false;
 
         return new DownloadManagerBuilder(
                 applicationContext,
@@ -111,7 +113,8 @@ public final class DownloadManagerBuilder {
                 connectionTypeAllowed,
                 allowNetworkRecovery,
                 callbackThrottleCreatorType,
-                logHandle
+                logHandle,
+                enableConcurrentFileDownloading
         );
     }
 
@@ -130,7 +133,9 @@ public final class DownloadManagerBuilder {
                                    ConnectionType connectionTypeAllowed,
                                    boolean allowNetworkRecovery,
                                    CallbackThrottleCreator.Type callbackThrottleCreatorType,
-                                   Optional<LogHandle> logHandle) {
+                                   Optional<LogHandle> logHandle,
+                                   boolean enableConcurrentFileDownloading
+        ) {
         this.applicationContext = applicationContext;
         this.callbackHandler = callbackHandler;
         this.storageRequirementRules = storageRequirementRules;
@@ -145,6 +150,7 @@ public final class DownloadManagerBuilder {
         this.allowNetworkRecovery = allowNetworkRecovery;
         this.callbackThrottleCreatorType = callbackThrottleCreatorType;
         this.logHandle = logHandle;
+        this.enableConcurrentFileDownloading = enableConcurrentFileDownloading;
     }
 
     public DownloadManagerBuilder withCustomHttpClient(HttpClient httpClient) {
@@ -235,6 +241,11 @@ public final class DownloadManagerBuilder {
         return this;
     }
 
+    public DownloadManagerBuilder withConcurrentFileDownloading() {
+        this.enableConcurrentFileDownloading = true;
+        return this;
+    }
+
     // It creates the whole LiteDownloadManager, it is a long process!
     @SuppressWarnings("PMD.ExcessiveMethodLength")
     public DownloadManager build() {
@@ -300,7 +311,8 @@ public final class DownloadManagerBuilder {
                 callbacks,
                 callbackThrottleCreator,
                 downloadBatchStatusFilter,
-                serviceCriteria
+                serviceCriteria,
+                enableConcurrentFileDownloading
         );
 
         liteDownloadManager = new LiteDownloadManager(

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -143,6 +143,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
 
         FileCallbackThrottle fileCallbackThrottle = callbackThrottleCreator.create();
 
+        SequentialFilesDownloader filesDownloader = new SequentialFilesDownloader(liteDownloadBatchStatus, connectionChecker, DownloadsBatchPersistence.this);
+
         return new DownloadBatch(
                 liteDownloadBatchStatus,
                 downloadFiles,
@@ -150,7 +152,8 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
                 DownloadsBatchPersistence.this,
                 fileCallbackThrottle,
                 connectionChecker,
-                downloadBatchRequirementRule
+                downloadBatchRequirementRule,
+                filesDownloader
         );
     }
 

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -143,7 +143,11 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
 
         FileCallbackThrottle fileCallbackThrottle = callbackThrottleCreator.create();
 
-        SequentialFilesDownloader filesDownloader = new SequentialFilesDownloader(liteDownloadBatchStatus, connectionChecker, DownloadsBatchPersistence.this);
+        SequentialFilesDownloader filesDownloader = new SequentialFilesDownloader(
+                liteDownloadBatchStatus,
+                connectionChecker,
+                DownloadsBatchPersistence.this
+        );
 
         return new DownloadBatch(
                 liteDownloadBatchStatus,

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -5,7 +5,6 @@ import android.support.annotation.WorkerThread;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadsBatchPersistence.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 
 class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, DownloadsNotificationSeenPersistence {
@@ -112,7 +113,7 @@ class DownloadsBatchPersistence implements DownloadsBatchStatusPersistence, Down
 
         downloadFiles = Collections.unmodifiableList(downloadFiles);
 
-        Map<DownloadFileId, Long> downloadedFileSizeMap = new HashMap<>(downloadFiles.size());
+        Map<DownloadFileId, Long> downloadedFileSizeMap = new ConcurrentHashMap<>(downloadFiles.size());
 
         long currentBytesDownloaded = 0;
         long totalBatchSizeBytes = 0;

--- a/library/src/main/java/com/novoda/downloadmanager/FilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/FilesDownloader.java
@@ -1,0 +1,7 @@
+package com.novoda.downloadmanager;
+
+import java.util.List;
+
+interface FilesDownloader {
+    void download(List<DownloadFile> downloadFiles, DownloadBatchStatusCallback statusCallback, DownloadFile.Callback fileCallback);
+}

--- a/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/LiteDownloadManagerDownloader.java
@@ -27,6 +27,7 @@ class LiteDownloadManagerDownloader {
     private final CallbackThrottleCreator callbackThrottleCreator;
     private final DownloadBatchStatusFilter downloadBatchStatusFilter;
     private final Wait.Criteria serviceCriteria;
+    private final boolean enableConcurrentFileDownloading;
 
     private DownloadService downloadService;
 
@@ -45,7 +46,8 @@ class LiteDownloadManagerDownloader {
                                   Set<DownloadBatchStatusCallback> callbacks,
                                   CallbackThrottleCreator callbackThrottleCreator,
                                   DownloadBatchStatusFilter downloadBatchStatusFilter,
-                                  Wait.Criteria serviceCriteria) {
+                                  Wait.Criteria serviceCriteria,
+                                  boolean enableConcurrentFileDownloading) {
         this.waitForDownloadService = waitForDownloadService;
         this.waitForDownloadBatchStatusCallback = waitForDownloadBatchStatusCallback;
         this.executor = executor;
@@ -60,6 +62,7 @@ class LiteDownloadManagerDownloader {
         this.callbackThrottleCreator = callbackThrottleCreator;
         this.downloadBatchStatusFilter = downloadBatchStatusFilter;
         this.serviceCriteria = serviceCriteria;
+        this.enableConcurrentFileDownloading = enableConcurrentFileDownloading;
     }
 
     void download(Batch batch, Map<DownloadBatchId, DownloadBatch> downloadBatchMap) {
@@ -70,7 +73,8 @@ class LiteDownloadManagerDownloader {
                 downloadsFilePersistence,
                 callbackThrottleCreator.create(),
                 connectionChecker,
-                downloadBatchRequirementRule
+                downloadBatchRequirementRule,
+                enableConcurrentFileDownloading
         );
 
         executor.submit(downloadBatch::updateTotalSize);
@@ -153,7 +157,8 @@ class LiteDownloadManagerDownloader {
                 downloadsFilePersistence,
                 callbackThrottleCreator.create(),
                 connectionChecker,
-                downloadBatchRequirementRule
+                downloadBatchRequirementRule,
+                enableConcurrentFileDownloading
         );
         downloadBatchMap.put(downloadBatch.getId(), downloadBatch);
         return downloadsBatchPersistence.persistCompletedBatch(completedDownloadBatch);

--- a/library/src/main/java/com/novoda/downloadmanager/PathBasedFilePersistence.java
+++ b/library/src/main/java/com/novoda/downloadmanager/PathBasedFilePersistence.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 class PathBasedFilePersistence implements FilePersistence {
 
     private static final boolean APPEND = true;
+    private static final Object LOCK = new Object();
 
     private StorageRequirementRule storageRequirementRule;
 
@@ -55,13 +56,15 @@ class PathBasedFilePersistence implements FilePersistence {
     }
 
     private boolean ensureParentDirectoriesExistFor(File outputFile) {
-        boolean parentExists = outputFile.getParentFile().exists();
-        if (parentExists) {
-            return true;
-        }
+        synchronized (LOCK) {
+            boolean parentExists = outputFile.getParentFile().exists();
+            if (parentExists) {
+                return true;
+            }
 
-        Logger.w(String.format("path: %s doesn't exist, creating parent directories...", outputFile.getAbsolutePath()));
-        return outputFile.getParentFile().mkdirs();
+            Logger.w(String.format("path: %s doesn't exist, creating parent directories...", outputFile.getAbsolutePath()));
+            return outputFile.getParentFile().mkdirs();
+        }
     }
 
     @Override

--- a/library/src/main/java/com/novoda/downloadmanager/SequentialFilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/SequentialFilesDownloader.java
@@ -2,13 +2,14 @@ package com.novoda.downloadmanager;
 
 import java.util.List;
 
-class SequentialFilesDownloader implements FilesDownloader{
+class SequentialFilesDownloader implements FilesDownloader {
 
     private final InternalDownloadBatchStatus downloadBatchStatus;
     private final ConnectionChecker connectionChecker;
     private final DownloadsBatchPersistence downloadsBatchPersistence;
 
-    SequentialFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker, DownloadsBatchPersistence downloadsBatchPersistence) {
+    SequentialFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker,
+                              DownloadsBatchPersistence downloadsBatchPersistence) {
         this.downloadBatchStatus = downloadBatchStatus;
         this.connectionChecker = connectionChecker;
         this.downloadsBatchPersistence = downloadsBatchPersistence;

--- a/library/src/main/java/com/novoda/downloadmanager/SequentialFilesDownloader.java
+++ b/library/src/main/java/com/novoda/downloadmanager/SequentialFilesDownloader.java
@@ -1,0 +1,27 @@
+package com.novoda.downloadmanager;
+
+import java.util.List;
+
+class SequentialFilesDownloader implements FilesDownloader{
+
+    private final InternalDownloadBatchStatus downloadBatchStatus;
+    private final ConnectionChecker connectionChecker;
+    private final DownloadsBatchPersistence downloadsBatchPersistence;
+
+    SequentialFilesDownloader(InternalDownloadBatchStatus downloadBatchStatus, ConnectionChecker connectionChecker, DownloadsBatchPersistence downloadsBatchPersistence) {
+        this.downloadBatchStatus = downloadBatchStatus;
+        this.connectionChecker = connectionChecker;
+        this.downloadsBatchPersistence = downloadsBatchPersistence;
+    }
+
+    @Override
+    public void download(List<DownloadFile> downloadFiles, DownloadBatchStatusCallback statusCallback, DownloadFile.Callback fileCallback) {
+        for (DownloadFile downloadFile : downloadFiles) {
+            if (DownloadBatch.batchCannotContinue(downloadBatchStatus, connectionChecker, downloadsBatchPersistence, statusCallback)) {
+                break;
+            }
+            downloadFile.download(fileCallback);
+        }
+    }
+}
+

--- a/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
+++ b/library/src/test/java/com/novoda/downloadmanager/LiteDownloadManagerDownloaderTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.verify;
 
 public class LiteDownloadManagerDownloaderTest {
 
+    private static final boolean DISABLED_CONCURRENT_FILE_DOWNLOADING = false;
+
     private final Object waitForDownloadService = new Object();
     private final Object waitForDownloadBatchStatusCallback = new Object();
     private final ExecutorService executor = mock(ExecutorService.class);
@@ -65,7 +67,8 @@ public class LiteDownloadManagerDownloaderTest {
                 callbacks,
                 callbackThrottleCreator,
                 downloadBatchStatusFilter,
-                serviceCriteria
+                serviceCriteria,
+                DISABLED_CONCURRENT_FILE_DOWNLOADING
         );
 
         downloader.setDownloadService(downloadService);


### PR DESCRIPTION
Adds support for concurrently downloading files within a batch.

When using the library with big batches (2000+ files) the overhead of connecting/handshaking/latency of downloading each file becomes rather large (2000 * 0.5s = 16 minutes), this becomes especially apparent on smaller files which don't have a lot of time to fully saturate the connection.
 
- Adds `DownloadManagerBuilder.withConcurrentFileDownloading` defaults to `disabled`
- Uses the `SequentialFilesDownloader` for adding completed batches (as I haven't been able to test this)
- Adds a `ConcurrentFilesDownloader` which uses a fixed thread pool of 4

This change dropped my big batch download times from 16-20 minutes down to 2-3 minutes 