### PR TITLE
Removing Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,3 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
-
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -72,8 +72,6 @@ dependencies {
     annotationProcessor "androidx.room:room-compiler:$roomVersion"
     api "androidx.work:work-runtime:2.2.0"
 
-    implementation 'com.novoda:merlin:1.2.1'
-    implementation 'com.facebook.stetho:stetho:1.5.1'
     implementation 'com.squareup.okhttp3:okhttp:4.2.2'
     implementation "androidx.room:room-runtime:$roomVersion"
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/library/src/main/java/com/novoda/downloadmanager/ConnectionChecker.java
+++ b/library/src/main/java/com/novoda/downloadmanager/ConnectionChecker.java
@@ -1,23 +1,29 @@
 package com.novoda.downloadmanager;
 
-import com.novoda.merlin.MerlinsBeard;
+import android.annotation.TargetApi;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkInfo;
+import android.os.Build;
 
 class ConnectionChecker {
 
-    private final MerlinsBeard merlinsBeard;
+    private static final boolean IS_NOT_CONNECTED_TO_NETWORK_TYPE = false;
+
+    private final ConnectivityManager connectivityManager;
     private ConnectionType allowedConnectionType;
 
-    ConnectionChecker(MerlinsBeard merlinsBeard, ConnectionType allowedConnectionType) {
-        this.merlinsBeard = merlinsBeard;
+    ConnectionChecker(ConnectivityManager connectivityManager, ConnectionType allowedConnectionType) {
+        this.connectivityManager = connectivityManager;
         this.allowedConnectionType = allowedConnectionType;
     }
 
     boolean isAllowedToDownload() {
         switch (allowedConnectionType) {
             case UNMETERED:
-                return merlinsBeard.isConnectedToWifi();
+                return isConnectedToWifi();
             case METERED:
-                return merlinsBeard.isConnectedToMobileNetwork();
+                return isConnectedToMobileNetwork();
             default:
                 return true;
         }
@@ -25,5 +31,38 @@ class ConnectionChecker {
 
     void updateAllowedConnectionType(ConnectionType allowedConnectionType) {
         this.allowedConnectionType = allowedConnectionType;
+    }
+
+    private boolean isConnectedToMobileNetwork() {
+        return isConnectedTo(ConnectivityManager.TYPE_MOBILE);
+    }
+
+    private boolean isConnectedToWifi() {
+        return isConnectedTo(ConnectivityManager.TYPE_WIFI);
+    }
+
+    private boolean isConnectedTo(int networkType) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            return connectedToNetworkTypeForLollipop(networkType);
+        }
+
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(networkType);
+        return networkInfo != null && networkInfo.isConnected();
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private boolean connectedToNetworkTypeForLollipop(int networkType) {
+        Network[] networks = connectivityManager.getAllNetworks();
+
+        for (Network network : networks) {
+            NetworkInfo networkInfo = connectivityManager.getNetworkInfo(network);
+
+            if (networkInfo != null && networkInfo.getType() == networkType) {
+                return networkInfo.isConnected();
+            }
+
+        }
+
+        return IS_NOT_CONNECTED_TO_NETWORK_TYPE;
     }
 }

--- a/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
+++ b/library/src/main/java/com/novoda/downloadmanager/DownloadManagerBuilder.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.res.Resources;
+import android.net.ConnectivityManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
@@ -21,8 +22,6 @@ import androidx.work.Configuration;
 import androidx.work.DelegatingWorkerFactory;
 import androidx.work.WorkManager;
 import androidx.work.WorkerFactory;
-
-import com.novoda.merlin.MerlinsBeard;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -271,8 +270,8 @@ public final class DownloadManagerBuilder {
         );
 
         DownloadsFilePersistence downloadsFilePersistence = new DownloadsFilePersistence(downloadsPersistence);
-        MerlinsBeard merlinsBeard = MerlinsBeard.from(applicationContext);
-        ConnectionChecker connectionChecker = new ConnectionChecker(merlinsBeard, connectionTypeAllowed);
+        ConnectivityManager connectivityManager = (ConnectivityManager) applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE);
+        ConnectionChecker connectionChecker = new ConnectionChecker(connectivityManager, connectionTypeAllowed);
         Executor executor = Executors.newSingleThreadExecutor();
         DownloadsBatchPersistence downloadsBatchPersistence = new DownloadsBatchPersistence(
                 executor,


### PR DESCRIPTION
Same as https://github.com/novoda/merlin/pull/200 

Removes the `jetifier` config and allows clients of the library to avoid _jetificiation_ 

- Inlines the `MerlinBeard` usage as `merlin` current enforces the jetifier but the library hasn't been updated in a while, happy to revert the change if the above PR is merged and released 😛 

- Removes the stetho dependency within the library, this wasn't being used and probablyyy shouldn't be part of the production classpath